### PR TITLE
Pipelines and Tasks moved to this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,8 @@
 
 This repository contains components that are installed or managed by the build service team.
 
-This includes ClusterTasks or utility containers.
+This includes default Pipelines and Tasks.
+
+The pipelines can be found in the `pipelines` directories. 
+The tasks can be found in the `tasks` directories. 
+

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,0 +1,10 @@
+# build-definitions
+
+This directory the OCI bundle with default pipelines installed for build-definitions.
+
+In `package-bundle` set this to the correct destination 
+`BUNDLE=quay.io/$REPO_USER/build-templates-bundle:v0.1`
+
+This have to be updated on the infra-deployment cluster when the version is updated.
+
+TODO - add CI automate this version bumps. 

--- a/pipelines/build-templates-bundle/devfile-build.yaml
+++ b/pipelines/build-templates-bundle/devfile-build.yaml
@@ -1,0 +1,118 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: devfile-build 
+  namespace: build-templates
+  labels:
+    "pipelines.openshift.io/used-by" : "build-cloud"
+    "pipelines.openshift.io/runtime" : "generic"
+    "pipelines.openshift.io/strategy" : "docker" 
+spec:
+  params:
+    - description: 'Source Repository URL'
+      name: git-url
+      type: string
+    - description: 'Fully Qualified Output Image'
+      name: output-image
+      type: string
+    - default: .
+      description: The path to your source code
+      name: PATH_CONTEXT
+      type: string
+  tasks:
+    - name: clone-repository
+      params:
+        - name: url
+          value: $(params.git-url)
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: workspace
+    - name: analyze-devfile
+      runAfter:
+        - clone-repository
+      taskRef:
+        kind: ClusterTask
+        name: analyze-devfile
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: build-container 
+      params:
+        - name: IMAGE
+          value: >-
+            $(params.output-image)
+        - name: BUILDER_IMAGE
+          value: >-
+            registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+        - name: STORAGE_DRIVER
+          value: vfs
+        - name: DOCKERFILE
+          value: $(tasks.analyze-devfile.results.dockerfile)
+        - name: CONTEXT
+          value: /workspace/source
+        - name: TLSVERIFY
+          value: 'true'
+        - name: FORMAT
+          value: oci
+      runAfter:
+        - analyze-devfile
+      taskRef:
+        kind: ClusterTask
+        name: buildah
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: show-summary
+      runAfter:
+        - build-container 
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash
+            echo  
+            echo "Build Summary:"
+            echo  
+            echo "Build repository: $(params.git-url)" 
+            echo "Generated Image is in : $(params.output-image)"  
+            echo  
+            echo from Devfile 
+            echo "Dockerfile: $(tasks.analyze-devfile.results.dockerfile)" 
+            echo "Build repository: $(tasks.analyze-devfile.results.path)" 
+            echo 
+
+            echo "encoding deploy yaml"
+            DEPLOYFILE="$(tasks.analyze-devfile.results.deploy)"
+            echo "Deploy Yaml: $(DEPLOYFILE)"
+            cat "$DEPLOYFILE"
+            echo "-----"
+            DEPLOY=$(cat $DEPLOYFILE | base64)
+            echo "$DEPLOY"
+
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/repo=$(params.git-url)
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/image=$(params.output-image)
+            #this should be put into a gitops repo but will be passed thru to enable deploy 
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/deploy="$DEPLOY"
+
+            echo "Output is in the following annotations:"
+            
+            echo "Build Repo is in 'build.appstudio.openshift.io/repo' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/repo}"' 
+            
+            echo "Build Image is in 'build.appstudio.openshift.io/image' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/image}"' 
+ 
+            echo "Deploy Yaml Image is in 'build.appstudio.openshift.io/deploy' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/deploy}"' 
+
+            echo End Summary  
+      workspaces:
+        - name: manifest-dir 
+          workspace: workspace
+  workspaces:
+    - name: workspace

--- a/pipelines/build-templates-bundle/docker-build.yaml
+++ b/pipelines/build-templates-bundle/docker-build.yaml
@@ -1,0 +1,91 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: docker-build
+  namespace: build-templates
+  labels:
+    "pipelines.openshift.io/used-by" : "build-cloud"
+    "pipelines.openshift.io/runtime" : "generic"
+    "pipelines.openshift.io/strategy" : "docker" 
+spec:
+  params:
+    - description: 'Source Repository URL'
+      name: git-url
+      type: string
+    - description: 'Fully Qualified Output Image'
+      name: output-image
+      type: string
+    - default: .
+      description: The path to your source code
+      name: PATH_CONTEXT
+      type: string
+  tasks:
+    - name: clone-repository
+      params:
+        - name: url
+          value: $(params.git-url)
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: workspace
+    - name: build-container 
+      params:
+        - name: IMAGE
+          value: >-
+            $(params.output-image)
+        - name: BUILDER_IMAGE
+          value: >-
+            registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+        - name: STORAGE_DRIVER
+          value: vfs
+        - name: DOCKERFILE
+          value: ./Dockerfile
+        - name: CONTEXT
+          value: /workspace/source
+        - name: TLSVERIFY
+          value: 'true'
+        - name: FORMAT
+          value: oci
+      runAfter:
+        - clone-repository
+      taskRef:
+        kind: ClusterTask
+        name: buildah
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: show-summary
+      runAfter:
+        - build-container 
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash
+            echo  
+            echo "Build Summary:"
+            echo
+            echo "Build repository: $(params.git-url)" 
+            echo "Generated Image is in : $(params.output-image)"  
+            echo  
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/repo=$(params.git-url)
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/image=$(params.output-image)
+
+            echo "Output is in the following annotations:"
+            
+            echo "Build Repo is in 'build.appstudio.openshift.io/repo' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/repo}"' 
+            
+            echo "Build Image is in 'build.appstudio.openshift.io/image' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/image}"' 
+
+            echo End Summary  
+      workspaces:
+        - name: manifest-dir 
+          workspace: workspace
+  workspaces:
+    - name: workspace

--- a/pipelines/build-templates-bundle/java-builder.yaml
+++ b/pipelines/build-templates-bundle/java-builder.yaml
@@ -1,0 +1,109 @@
+## Sample Pipeline for a Java s2i build provided ootb.
+#
+## If changed by a user, the App Studio HAS service should push the modified 
+## Pipeline definition into the user's repository.
+
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    "pipelines.openshift.io/used-by" : "build-cloud"
+    "pipelines.openshift.io/runtime" : "java"
+    "pipelines.openshift.io/strategy" : "s2i"
+  name: java-builder
+  namespace: build-templates
+spec:
+  params:
+    - description: 'Source Repository URL'
+      name: git-url
+      type: string
+    - description: 'Fully Qualified Output Image'
+      name: output-image
+      type: string
+    - default: .
+      description: The path to your source code
+      name: path-context 
+      type: string
+  tasks:
+    - name: git-clone
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: submodules
+          value: 'true'
+        - name: depth
+          value: '1'
+        - name: sslVerify
+          value: 'true'
+        - name: deleteExisting
+          value: 'true'
+        - name: verbose
+          value: 'true'
+        - name: gitInitImage
+          value: >-
+            registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:da1aedf0b17f2b9dd2a46edc93ff1c0582989414b902a28cd79bad8a035c9ea4
+        - name: userHome
+          value: /tekton/home
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: workspace
+    - name: s2i-java
+      params:
+        - name: VERSION
+          value: openjdk-11-ubi8
+        - name: PATH_CONTEXT
+          value: $(params.path-context)
+        - name: TLSVERIFY
+          value: 'true'
+        - name: MAVEN_CLEAR_REPO
+          value: 'false'
+        - name: IMAGE
+          value: "$(params.output-image)"
+        - name: BUILDER_IMAGE
+          value: >-
+            registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+      runAfter:
+        - git-clone
+      taskRef:
+        kind: ClusterTask
+        name: s2i-java
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: show-summary
+      runAfter:
+        - s2i-java 
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash
+            echo  
+            echo "Build Summary:"
+            echo
+            echo "Build repository: $(params.git-url)" 
+            echo "Generated Image is in : $(params.output-image)"  
+            echo 
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/repo=$(params.git-url)
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/image=$(params.output-image)
+
+            echo "Output is in the following annotations:"
+            
+            echo "Build Repo is in 'build.appstudio.openshift.io/repo' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/repo}"' 
+            
+            echo "Build Image is in 'build.appstudio.openshift.io/image' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/image}"' 
+
+            echo End Summary  
+      workspaces:
+        - name: manifest-dir 
+          workspace: workspace
+  workspaces:
+    - name: workspace

--- a/pipelines/build-templates-bundle/nodejs-builder.yaml
+++ b/pipelines/build-templates-bundle/nodejs-builder.yaml
@@ -1,0 +1,130 @@
+## Sample Pipeline for a NodeJs s2i build provided ootb.
+#
+## If changed by a user, the App Studio HAS service should push the modified 
+## Pipeline definition into the user's repository.
+
+## Sample usage by client
+##
+# apiVersion: tekton.dev/v1beta1
+# kind: PipelineRun
+# metadata:
+#   name: new-pipeline-7vae74
+#   namespace: default
+# spec:
+#   params:
+#     - name: url
+#       value: 'https://github.com/openshift/console'
+#     - name: IMAGE
+#       value: 'docker.io/sbose78/sample-nodejs:fooo'
+#     - name: PATH_CONTEXT
+#       value: frontend
+#   pipelineRef:
+#     name: new-pipeline
+#   serviceAccountName: pipeline
+#   timeout: 1h0m0s
+#   workspaces:
+#     - name: workspace
+#       persistentVolumeClaim:
+#         claimName: app-studio-default-workspace
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: nodejs-builder
+  namespace: build-templates
+  labels:
+    "pipelines.openshift.io/used-by" : "build-cloud"
+    "pipelines.openshift.io/runtime" : "nodejs"
+    "pipelines.openshift.io/strategy" : "s2i"
+spec:
+  params: 
+    - description: 'Source Repository URL'
+      name: git-url
+      type: string
+    - description: 'Fully Qualified Output Image'
+      name: output-image
+      type: string
+    - default: .
+      description: The path to your source code
+      name: path-context 
+      type: string
+  tasks:
+    - name: s2i-nodejs
+      params:
+        - name: VERSION
+          value: 14-ubi8
+        - name: PATH_CONTEXT
+          value: "$(params.path-context)"
+        - name: TLSVERIFY
+          value: 'true'
+        - name: IMAGE
+          value: "$(params.output-image)"
+        - name: BUILDER_IMAGE
+          value: >-
+            registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+      runAfter:
+        - git-clone
+      taskRef:
+        kind: ClusterTask
+        name: s2i-nodejs
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: git-clone
+      params:
+        - name: url
+          value: "$(params.git-url)"
+        - name: submodules
+          value: 'true'
+        - name: depth
+          value: '1'
+        - name: sslVerify
+          value: 'true'
+        - name: deleteExisting
+          value: 'true'
+        - name: verbose
+          value: 'true'
+        - name: gitInitImage
+          value: >-
+            registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:da1aedf0b17f2b9dd2a46edc93ff1c0582989414b902a28cd79bad8a035c9ea4
+        - name: userHome
+          value: /tekton/home
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: workspace
+    - name: show-summary
+      runAfter:
+        - s2i-nodejs
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash
+            echo  
+            echo "Build Summary:"
+            echo
+            echo "Build repository: $(params.git-url)" 
+            echo "Generated Image is in : $(params.output-image)"  
+            echo 
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/repo=$(params.git-url)
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/image=$(params.output-image)
+
+            echo "Output is in the following annotations:"
+            
+            echo "Build Repo is in 'build.appstudio.openshift.io/repo' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/repo}"' 
+            
+            echo "Build Image is in 'build.appstudio.openshift.io/image' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/image}"' 
+
+            echo End Summary  
+      workspaces:
+        - name: manifest-dir 
+          workspace: workspace
+  workspaces:
+    - name: workspace

--- a/pipelines/build-templates-bundle/noop.yaml
+++ b/pipelines/build-templates-bundle/noop.yaml
@@ -1,0 +1,103 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: noop
+  namespace: build-templates
+  labels:
+    "pipelines.openshift.io/used-by" : "build-cloud"
+    "pipelines.openshift.io/runtime" : "generic"
+    "pipelines.openshift.io/strategy" : "docker" 
+spec:
+  params:
+    - description: 'Source Repository URL'
+      name: git-url
+      type: string
+    - description: 'Fully Qualified Output Image'
+      name: output-image
+      type: string
+  tasks:
+    - name: start 
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash 
+            echo "Simple Pipeline "  
+            echo "GIT URL: $(params.git-url)" 
+            echo "Image URL: $(params.output-image)" 
+      workspaces:
+        - name: manifest-dir 
+          workspace: workspace
+    - name: task1 
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash 
+            echo "task1"  
+      runAfter:
+        - start 
+      workspaces:
+        - name: manifest-dir 
+          workspace: workspace
+    - name: task2 
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash 
+            echo "task2"     
+      runAfter:
+        - start 
+      workspaces:
+        - name: manifest-dir 
+          workspace: workspace
+    - name: task3 
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+      params:
+        - name: SCRIPT 
+          value: | 
+            #!/usr/bin/env bash 
+            echo "task3"       
+      runAfter:
+        - task2 
+      workspaces:
+        - name: manifest-dir 
+          workspace: workspace
+    - name: merge 
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash  
+            echo "Noop Test, this step will wait for parallel tasks to be"    
+
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/repo=none
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.openshift.io/image=none
+
+            echo "Output is in the following annotations:"
+            
+            echo "Build Repo is in 'build.appstudio.openshift.io/repo' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/repo}"' 
+            
+            echo "Build Image is in 'build.appstudio.openshift.io/image' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.openshift\.io/image}"' 
+
+      runAfter:
+        - task1 
+        - task3
+      workspaces:
+        - name: manifest-dir 
+          workspace: workspace
+  workspaces:
+    - name: workspace

--- a/pipelines/package-bundle.sh
+++ b/pipelines/package-bundle.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+TEMPLATES=$SCRIPTDIR/build-templates-bundle
+
+REPO_USER=$MY_QUAY_USER
+if [  -z "$REPO_USER" ]; then
+    REPO_USER=$(git config --get remote.origin.url | cut -d '/' -f 4)  
+fi 
+if [ "$REPO_USER" = "redhat-appstudio" ]; then
+    echo "Warning: You are updating the default bundle in redhat-appstudio" 
+    echo "This is disabled unless you pass -confirm on the cmdline"
+    if ["$1" = "-confirm"]; then 
+        echo "Using $REPO_USER to create OCI Bundle "
+    else 
+        echo "Cannot push to redhat-appstudio without a -confirm on command line."
+        exit 1
+    fi 
+fi 
+BUNDLE=quay.io/$REPO_USER/build-templates-bundle:v0.1
+
+echo 
+echo "Package Templates from: $SCRIPTDIR/build-templates-bundle"
+echo "Using $REPO_USER to create OCI Bundle (set MY_QUAY_USER to override) " 
+echo "Building $BUNDLE" 
+echo 
+ 
+PARAMS="" 
+for i in $TEMPLATES/*.yaml ; do   
+    PARAMS="$PARAMS -f $i " 
+done 
+tkn bundle push $BUNDLE $PARAMS  
+echo  
+ 
+
+
+  

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,0 +1,5 @@
+
+This directory contains all the task definitions provided by App Studio. The tasks need to be installed as part of the Build deployment component via  ClusterTask as AppStudio initial releases will not allow user defined tasks. 
+See 
+`https://github.com/redhat-appstudio/infra-deployments/tree/main/components/build`
+

--- a/tasks/analyze-devfile/Dockerfile.ubuntu
+++ b/tasks/analyze-devfile/Dockerfile.ubuntu
@@ -1,6 +1,0 @@
-FROM ubuntu:latest
-RUN apt-get -y update
-RUN apt-get -y install wget 
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_amd64 -O /usr/bin/yq 
-RUN chmod +x /usr/bin/yq
-   

--- a/tasks/analyze-devfile/README.md
+++ b/tasks/analyze-devfile/README.md
@@ -2,3 +2,5 @@
 
 Analyze Devfile is a component in the build service that extracts information from a devfile to run a build.
 The task needs to be installed as part of the Build deployment via  ClusterTask as AppStudio initial releases will not allow user defined tasks. 
+Note - this task will be merged into the default appstudio-utils image.
+There is no need to have multiple containers for simple utilities. 

--- a/tasks/analyze-devfile/README.md
+++ b/tasks/analyze-devfile/README.md
@@ -1,3 +1,4 @@
 # Source for quay.io/redhat-appstudio/analyze-devfile:v0.1
 
-Analyze Devfile is a component in the build service that extracts information from a devfile to run a build
+Analyze Devfile is a component in the build service that extracts information from a devfile to run a build.
+The task needs to be installed as part of the Build deployment via  ClusterTask as AppStudio initial releases will not allow user defined tasks. 

--- a/tasks/analyze-devfile/analyze-devfile.yaml
+++ b/tasks/analyze-devfile/analyze-devfile.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  name: analyze-devfile
+spec:
+  description: >-
+    Analyze a devfile and output container and path in results
+  results:
+    - name: dockerfile
+      description: Digest of the image just built.
+    - name: path
+      description: Path of the image to be built.
+    - name: deploy
+      description: Contents of deployment yaml.
+  workspaces:
+    - name: source
+  steps:
+    - name: analyze-devfile
+      image: quay.io/redhat-appstudio/analyze-devfile:v0.1
+      script: |
+        #!/usr/bin/env bash  
+        cd ./workspace/source 
+        yq e '.components | with_entries(select(.[].name=="outerloop-build"))' devfile.yaml |  yq e '.[]' - > tmp.outerloop-build.yaml
+        echo
+        echo "outerloop-build section of devfile."
+        cat tmp.outerloop-build.yaml 
+        yq e '.components | with_entries(select(.[].name=="outerloop-deploy"))' devfile.yaml| yq e '.[]' - > tmp.outerloop-deploy.yaml
+        echo
+        echo "outerloop-deploy section of devfile."
+        cat tmp.outerloop-deploy.yaml 
+        echo 
+
+        DOCKERFILE="$(yq e '.image.dockerfile.uri' tmp.outerloop-build.yaml)"
+        BC="$(yq e '.image.dockerfile.buildContext' tmp.outerloop-build.yaml)"
+        DEPLOYFILE="$(yq e '.kubernetes.uri' tmp.outerloop-deploy.yaml)"
+
+        echo "Devfile Analysis:"
+        echo "Dockerfile: $DOCKERFILE"  
+        echo "BuildContext: $BC"   
+        echo "Deploy: $DEPLOYFILE"
+        echo   
+        echo "Deploy contents:"
+        cat "$DEPLOYFILE"
+        echo   
+  
+        echo -n "$DOCKERFILE" >  /tekton/results/dockerfile  
+        echo -n "$BC" > /tekton/results/path
+        echo -n "$DEPLOYFILE" > /tekton/results/deploy
+  

--- a/tasks/appstudio-utils/Dockerfile
+++ b/tasks/appstudio-utils/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal  
+RUN microdnf install  wget 
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_amd64 -O /usr/bin/yq 
+RUN chmod +x /usr/bin/yq
+RUN microdnf install  jq 
+RUN microdnf install  skopeo 
+RUN mkdir /appstudio-utils
+COPY util-scripts   /appstudio-utils/util-scripts 
+RUN chmod +x /appstudio-utils/util-scripts/*.sh

--- a/tasks/appstudio-utils/README.md
+++ b/tasks/appstudio-utils/README.md
@@ -1,0 +1,15 @@
+# Source for quay.io/redhat-appstudioappstudio-utils:v0.1
+
+This component provides an image which contains a suite of app-studio specific utilies.
+
+The utilities are all bundled into a single container which contains the implementations for the specific Task. A single container allows a faster bootstrap for multiple tasks but in future, if a Task needs its own container, it can be move out.
+All the binary requirements for a script must be installed as part of the container build see `Dockerfile`.  
+
+Tasks are simply scripts which are called via the same name as the task specifically `/appstudio-utils/util-scripts/$(context.task.name).sh`  and the script needs to be passed task specific parameters. 
+
+The scripts should be written in a way that you can test them inside and outside of tekton.
+These scripts should be put into the `appstudio-utils/util-scripts` directory for packaging by the default container build.
+
+The tasks in this utility containers are found in the `util-tasks` directory. 
+
+To install tasked define here into an app studio, they need to be changed to clustertaks and added to the infra-deployment/components/

--- a/tasks/appstudio-utils/build
+++ b/tasks/appstudio-utils/build
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # local build script
 
 # to prevent forks from accidentally pushing to redhat-appstudio
@@ -7,16 +5,16 @@
 REPO_USER=$(git config --get remote.origin.url | cut -d '/' -f 4) 
 if [ "$REPO_USER" = "redhat-appstudio" ]; then
     echo "Using redhat-appstudio quay.io user to push results "
-    docker build -t quay.io/redhat-appstudio/analyze-devfile:v0.1 .
-    docker push quay.io/redhat-appstudio/analyze-devfile:v0.1 
+    docker build -t quay.io/redhat-appstudio/appstudio-utils:v0.1 .
+    docker push quay.io/redhat-appstudio/appstudio-utils:v0.1 
     exit 0 
 fi 
-if [  -z "$MY_QUAY_USER"]; then
+if [  -z "$MY_QUAY_USER" ]; then
     echo "MY_QUAY_USER is not set, skip this build."
 else 
     echo "Using $MY_QUAY_USER to push results "
-    docker build -t quay.io/$MY_QUAY_USER/analyze-devfile:v0.1 .
-    docker push quay.io/$MY_QUAY_USER/analyze-devfile:v0.1 
+    docker.exe build -t quay.io/$MY_QUAY_USER/appstudio-utils:v0.1 .
+    docker.exe push quay.io/$MY_QUAY_USER/appstudio-utils:v0.1 
     exit 0 
 fi 
  

--- a/tasks/appstudio-utils/test-all-tasks.sh
+++ b/tasks/appstudio-utils/test-all-tasks.sh
@@ -1,0 +1,120 @@
+
+read -r -d '' PIPELINE <<'PIPELINE_DEF'
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-all-tasks
+  namespace: jdemo 
+spec: 
+  params:
+  - description: 'Fully Qualified Image URL'
+    name: test-image
+    type: string
+  tasks:
+    - name: clone-repository
+      params:
+        - name: url
+          value:  https://github.com/devfile-samples/devfile-sample-python-basic
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: workspace
+    - name: analyze-devfile
+      runAfter:
+        - clone-repository
+      taskRef:
+        kind: Task
+        name: analyze-devfile
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: post-devfile
+      taskRef:
+        kind: Task
+        name: appstudio-utils 
+      runAfter:
+        - analyze-devfile
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash 
+            echo "Devfile dockerfile : $(tasks.analyze-devfile.results.dockerfile)" 
+            echo "Devfile path: $(tasks.analyze-devfile.results.path)" 
+            echo "Devfile deploy: $(tasks.analyze-devfile.results.deploy)" 
+      workspaces:
+        - name: source 
+          workspace: workspace
+    - name: image-exists
+      taskRef:
+        kind: Task
+        name: image-exists
+      params:
+        - name: image-url 
+          value: "$(params.test-image)"
+      workspaces:
+        - name: source
+          workspace: workspace 
+    - name: post
+      taskRef:
+        kind: Task
+        name: appstudio-utils 
+      runAfter:
+        - image-exists
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash 
+            echo "The image: $(params.test-image) exists: $(tasks.image-exists.results.exists)" 
+      workspaces:
+        - name: source 
+          workspace: workspace 
+    - name: utils-with-script
+      taskRef:
+        kind: Task
+        name: appstudio-utils 
+      runAfter:
+        - post
+      params:
+        - name: SCRIPT 
+          value: |
+            #!/usr/bin/env bash 
+            echo "The image: $(params.test-image) exists: $(tasks.image-exists.results.exists)" 
+    - name: utils-no-script
+      taskRef:
+        kind: Task
+        name: appstudio-utils 
+      runAfter:
+        - post       
+  workspaces:
+    - name: workspace
+PIPELINE_DEF
+
+read -r -d '' PRUN <<'PRUN'
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata: 
+  name: test-all-tasks
+spec:
+  params:
+    - name: test-image
+      value: "image-registry.openshift-image-registry.svc:5000/jdemo/devfile-sample-python-basic:0c840c9"  
+  pipelineRef:
+    name: check-image-exists   
+  workspaces:
+    - name: workspace
+      persistentVolumeClaim:
+        claimName: app-studio-default-workspace
+      subPath: . 
+PRUN
+oc apply -f util-tasks/ 
+echo "$PIPELINE" | oc apply -f -
+oc delete pr test-all-tasks  
+echo "$PRUN" | oc apply -f -
+tkn pr logs test-all-tasks -f 
+
+# cleanup manually, this is so you can inspect the results 
+# if you delete immediately, the results are gone
+#oc delete -f util-tasks/
+#oc delete pipeline test-all-tasks

--- a/tasks/appstudio-utils/util-scripts/analyze-devfile.sh
+++ b/tasks/appstudio-utils/util-scripts/analyze-devfile.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# you can test this script inside or outside tekton
+# you need to pass a destination directory if running on shell
+# or /tekton/results if running in tekton
+
+cd ./workspace/source 
+yq e '.components | with_entries(select(.[].name=="outerloop-build"))' devfile.yaml |  yq e '.[]' - > tmp.outerloop-build.yaml
+echo
+echo "outerloop-build section of devfile."
+echo "-----------------------------------"
+cat tmp.outerloop-build.yaml 
+yq e '.components | with_entries(select(.[].name=="outerloop-deploy"))' devfile.yaml| yq e '.[]' - > tmp.outerloop-deploy.yaml
+echo "---"
+echo
+echo "outerloop-deploy section of devfile."
+echo "------------------------------------"
+cat tmp.outerloop-deploy.yaml 
+echo "---"
+echo 
+
+DOCKERFILE="$(yq e '.image.dockerfile.uri' tmp.outerloop-build.yaml)"
+BC="$(yq e '.image.dockerfile.buildContext' tmp.outerloop-build.yaml)"
+DEPLOYFILE="$(yq e '.kubernetes.uri' tmp.outerloop-deploy.yaml)"
+
+echo "Devfile Analysis:"
+echo "Dockerfile: $DOCKERFILE"  
+echo "BuildContext: $BC"   
+echo "Deploy: $DEPLOYFILE"
+echo   
+echo "Deploy contents:"
+cat "$DEPLOYFILE"
+echo   
+  
+echo -n "$DOCKERFILE" >  $1/dockerfile  
+echo -n "$BC" > $1/path
+echo -n "$DEPLOYFILE" > $1/deploy
+
+  
+  

--- a/tasks/appstudio-utils/util-scripts/image-exists.sh
+++ b/tasks/appstudio-utils/util-scripts/image-exists.sh
@@ -1,0 +1,15 @@
+
+#!/usr/bin/env bash   
+# you can test this script inside or outside tekton
+# you need to pass a url (param1) and destination directory (param2) if running on shell
+# or /tekton/results if running in tekton
+echo "Test image name is $1"  
+echo "Results to $2"  
+DIGEST=$(skopeo inspect "docker://$1" 2> err | jq '.Digest')
+if [ -z "$DIGEST" ]
+then
+  echo -n "false" >  $2/exists 
+else 
+  echo -n "true" >  $2/exists
+fi     
+ 

--- a/tasks/appstudio-utils/util-tasks/analyze-devfile.yaml
+++ b/tasks/appstudio-utils/util-tasks/analyze-devfile.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: analyze-devfile
+spec:
+  description: >-
+    Analyze a devfile and output container and path in results
+  results:
+    - name: dockerfile
+      description: Digest of the image just built.
+    - name: path
+      description: Path of the image to be built.
+    - name: deploy
+      description: Contents of deployment yaml.
+  workspaces:
+    - name: source
+  steps:
+    - name: analyze-devfile
+      image: quay.io/jduimovich0/appstudio-utils:v0.1
+      script: |
+        #!/usr/bin/env bash   
+        { set +x ;} 2> /dev/null 
+        echo "App Studio Utility Task $(context.task.name)"     
+        /appstudio-utils/util-scripts/$(context.task.name).sh /tekton/results
+  

--- a/tasks/appstudio-utils/util-tasks/analyze-devfile.yaml
+++ b/tasks/appstudio-utils/util-tasks/analyze-devfile.yaml
@@ -16,7 +16,7 @@ spec:
     - name: source
   steps:
     - name: analyze-devfile
-      image: quay.io/jduimovich0/appstudio-utils:v0.1
+      image: quay.io/redhat-appstudio/appstudio-utils:v0.1
       script: |
         #!/usr/bin/env bash   
         { set +x ;} 2> /dev/null 

--- a/tasks/appstudio-utils/util-tasks/appstudio-utils.yaml
+++ b/tasks/appstudio-utils/util-tasks/appstudio-utils.yaml
@@ -14,7 +14,7 @@ spec:
       optional: true
   steps:
     - name: script 
-      image: quay.io/jduimovich0/appstudio-utils:v0.1
+      image: quay.io/redhat-appstudio/appstudio-utils:v0.1
       script: |
         { set +x ;} 2> /dev/null 
         echo "App Studio Utility Task $(context.task.name)"     

--- a/tasks/appstudio-utils/util-tasks/appstudio-utils.yaml
+++ b/tasks/appstudio-utils/util-tasks/appstudio-utils.yaml
@@ -1,0 +1,24 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: appstudio-utils 
+spec:
+  description: >-
+    Utilities 
+  params:
+    - name: SCRIPT
+      description: Run a Script 
+      default: "echo no-script-passed" 
+  workspaces:
+    - name: source
+      optional: true
+  steps:
+    - name: script 
+      image: quay.io/jduimovich0/appstudio-utils:v0.1
+      script: |
+        { set +x ;} 2> /dev/null 
+        echo "App Studio Utility Task $(context.task.name)"     
+        { set +x ;} 2> /dev/null   
+        echo "$(params.SCRIPT)" | bash
+        
+         

--- a/tasks/appstudio-utils/util-tasks/image-exists.yaml
+++ b/tasks/appstudio-utils/util-tasks/image-exists.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: image-exists 
+spec:
+  description: >-
+    Determine if an image already exists and output results. If the image does exist, then set results to true, else results to false
+  params:
+    - name: image-url
+      description: Image URL for testing 
+  results:
+    - name: exists
+      description: True if exists false otherwise
+  workspaces:
+    - name: source
+      optional: true
+  steps:
+    - name: test-image-exists 
+      image: quay.io/jduimovich0/appstudio-utils:v0.1
+      script: |
+        #!/usr/bin/env bash   
+        { set +x ;} 2> /dev/null 
+        echo "App Studio Utility Task $(context.task.name)"     
+        /appstudio-utils/util-scripts/$(context.task.name).sh \
+          "$(params.image-url)" /tekton/results
+  

--- a/tasks/appstudio-utils/util-tasks/image-exists.yaml
+++ b/tasks/appstudio-utils/util-tasks/image-exists.yaml
@@ -16,7 +16,7 @@ spec:
       optional: true
   steps:
     - name: test-image-exists 
-      image: quay.io/jduimovich0/appstudio-utils:v0.1
+      image: quay.io/redhat-appstudio/appstudio-utils:v0.1
       script: |
         #!/usr/bin/env bash   
         { set +x ;} 2> /dev/null 


### PR DESCRIPTION
This pull request contains the following changes

- pipelines previously define in the infra-deployment repo are now in this repo. This repository will be used to create the OCI bundle for App Studio build definitions pipelines
- new tasks to handle analyze-devfiles, testing for images (exists) to prevent rebuilds
- single container for utility tasks and an easy model to local and tekton way to test these tasks
