### PR TITLE
Parameterize the revision

### DIFF
--- a/pipelines/build-templates-bundle/docker-build.yaml
+++ b/pipelines/build-templates-bundle/docker-build.yaml
@@ -14,6 +14,7 @@ spec:
     - description: 'Revision of the Source Repository'
       name: revision
       type: string
+      default: main
     - description: 'Fully Qualified Output Image'
       name: output-image
       type: string

--- a/pipelines/build-templates-bundle/docker-build.yaml
+++ b/pipelines/build-templates-bundle/docker-build.yaml
@@ -11,6 +11,9 @@ spec:
     - description: 'Source Repository URL'
       name: git-url
       type: string
+    - description: 'Revision of the Source Repository'
+      name: revision
+      type: string
     - description: 'Fully Qualified Output Image'
       name: output-image
       type: string
@@ -39,6 +42,8 @@ spec:
       params:
         - name: url
           value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
       taskRef:
         kind: ClusterTask
         name: git-clone


### PR DESCRIPTION
Without this, we wouldn't be able to have these pipeline definitions consumed for webhooks.