### PR TITLE
remove clustertasks to work on kcp

### DIFF
--- a/hack/test-all-tasks/pipeline.yaml
+++ b/hack/test-all-tasks/pipeline.yaml
@@ -16,8 +16,7 @@ spec:
       params:
         - name: url
           value:  https://github.com/devfile-samples/devfile-sample-python-basic
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: git-clone
       workspaces:
         - name: output

--- a/pipelines/devfile-build.yaml
+++ b/pipelines/devfile-build.yaml
@@ -48,8 +48,7 @@ spec:
           value: $(params.git-url)
         - name: revision
           value: "$(params.revision)"
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: git-clone
       workspaces:
         - name: output
@@ -102,8 +101,7 @@ spec:
           value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
       runAfter:
         - appstudio-configure-build
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: buildah
       workspaces:
         - name: source

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -52,8 +52,7 @@ spec:
           value: $(params.git-url)
         - name: revision
           value: "$(params.revision)"
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: git-clone
       workspaces:
         - name: output
@@ -98,8 +97,7 @@ spec:
           value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
       runAfter:
         - appstudio-configure-build 
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: buildah
       workspaces:
         - name: source

--- a/pipelines/java-builder.yaml
+++ b/pipelines/java-builder.yaml
@@ -73,8 +73,7 @@ spec:
             registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:da1aedf0b17f2b9dd2a46edc93ff1c0582989414b902a28cd79bad8a035c9ea4
         - name: userHome
           value: /tekton/home
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: git-clone
       workspaces:
         - name: output
@@ -108,8 +107,7 @@ spec:
         - name: BUILDER_IMAGE
           value: >-
             registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: s2i-java
       workspaces:
         - name: source

--- a/pipelines/nodejs-builder.yaml
+++ b/pipelines/nodejs-builder.yaml
@@ -96,8 +96,7 @@ spec:
             registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
       runAfter:
         - appstudio-configure-build 
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: s2i-nodejs
       workspaces:
         - name: source
@@ -129,8 +128,7 @@ spec:
             registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:da1aedf0b17f2b9dd2a46edc93ff1c0582989414b902a28cd79bad8a035c9ea4
         - name: userHome
           value: /tekton/home
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: git-clone
       workspaces:
         - name: output

--- a/pipelines/noop.yaml
+++ b/pipelines/noop.yaml
@@ -29,8 +29,8 @@ spec:
   tasks:
     - name: start 
       taskRef:
-        kind: ClusterTask
-        name: openshift-client
+        bundle: ${CONTAINER_REPO}/appstudio-tasks:utils-task-${TAG}
+        name: utils-task
       params:
         - name: SCRIPT 
           value: |
@@ -39,12 +39,12 @@ spec:
             echo "GIT URL: $(params.git-url)" 
             echo "Image URL: $(params.output-image)" 
       workspaces:
-        - name: manifest-dir 
+        - name: source 
           workspace: workspace
     - name: task1 
       taskRef:
-        kind: ClusterTask
-        name: openshift-client
+        bundle: ${CONTAINER_REPO}/appstudio-tasks:utils-task-${TAG}
+        name: utils-task
       params:
         - name: SCRIPT 
           value: |
@@ -53,12 +53,12 @@ spec:
       runAfter:
         - start 
       workspaces:
-        - name: manifest-dir 
+        - name: source 
           workspace: workspace
     - name: task2 
       taskRef:
-        kind: ClusterTask
-        name: openshift-client
+        bundle: ${CONTAINER_REPO}/appstudio-tasks:utils-task-${TAG}
+        name: utils-task
       params:
         - name: SCRIPT 
           value: |
@@ -67,12 +67,12 @@ spec:
       runAfter:
         - start 
       workspaces:
-        - name: manifest-dir 
+        - name: source 
           workspace: workspace
     - name: task3 
       taskRef:
-        kind: ClusterTask
-        name: openshift-client
+        bundle: ${CONTAINER_REPO}/appstudio-tasks:utils-task-${TAG}
+        name: utils-task
       params:
         - name: SCRIPT 
           value: | 
@@ -81,12 +81,12 @@ spec:
       runAfter:
         - task2 
       workspaces:
-        - name: manifest-dir 
+        - name: source 
           workspace: workspace
     - name: merge 
       taskRef:
-        kind: ClusterTask
-        name: openshift-client
+        bundle: ${CONTAINER_REPO}/appstudio-tasks:utils-task-${TAG}
+        name: utils-task
       params:
         - name: SCRIPT 
           value: |
@@ -108,7 +108,7 @@ spec:
         - task1 
         - task3
       workspaces:
-        - name: manifest-dir 
+        - name: source 
           workspace: workspace
   workspaces:
     - name: workspace

--- a/pipelines/noop.yaml
+++ b/pipelines/noop.yaml
@@ -28,8 +28,7 @@ spec:
       default: Dockerfile
   tasks:
     - name: start 
-      taskRef:
-        bundle: ${CONTAINER_REPO}/appstudio-tasks:utils-task-${TAG}
+      taskRef: 
         name: utils-task
       params:
         - name: SCRIPT 
@@ -42,8 +41,7 @@ spec:
         - name: source 
           workspace: workspace
     - name: task1 
-      taskRef:
-        bundle: ${CONTAINER_REPO}/appstudio-tasks:utils-task-${TAG}
+      taskRef: 
         name: utils-task
       params:
         - name: SCRIPT 
@@ -56,8 +54,7 @@ spec:
         - name: source 
           workspace: workspace
     - name: task2 
-      taskRef:
-        bundle: ${CONTAINER_REPO}/appstudio-tasks:utils-task-${TAG}
+      taskRef: 
         name: utils-task
       params:
         - name: SCRIPT 
@@ -70,8 +67,7 @@ spec:
         - name: source 
           workspace: workspace
     - name: task3 
-      taskRef:
-        bundle: ${CONTAINER_REPO}/appstudio-tasks:utils-task-${TAG}
+      taskRef: 
         name: utils-task
       params:
         - name: SCRIPT 
@@ -84,8 +80,7 @@ spec:
         - name: source 
           workspace: workspace
     - name: merge 
-      taskRef:
-        bundle: ${CONTAINER_REPO}/appstudio-tasks:utils-task-${TAG}
+      taskRef: 
         name: utils-task
       params:
         - name: SCRIPT 

--- a/pipelines/prototype-build-compliance.yaml
+++ b/pipelines/prototype-build-compliance.yaml
@@ -52,8 +52,7 @@ spec:
           value: $(params.git-url)
         - name: revision
           value: "$(params.revision)"
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: git-clone
       workspaces:
         - name: output
@@ -244,8 +243,7 @@ spec:
           value: "$(tasks.build-appstudio-configure-build.results.buildah-auth-param)"
       runAfter:
         - build-placeholder-build-step
-      taskRef:
-        kind: ClusterTask
+      taskRef: 
         name: buildah
       workspaces:
         - name: source

--- a/tasks/buildah.yaml
+++ b/tasks/buildah.yaml
@@ -1,0 +1,84 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build   
+  name: buildah 
+spec:
+  description: |-
+    Buildah task builds source into a container image and then pushes it to a container registry.
+    Buildah Task builds source into a container image using Project Atomic's Buildah build tool.It uses Buildah's support for building from Dockerfiles, using its buildah bud command.This command executes the directives in the Dockerfile to assemble a container image, then pushes that image to a container registry.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: registry.redhat.io/rhel8/buildah@sha256:e19cf23d5f1e0608f5a897f0a50448beb9f8387031cca49c7487ec71bd91c4d3
+    description: The location of the buildah builder image.
+    name: BUILDER_IMAGE
+    type: string
+  - default: vfs
+    description: Set buildah storage driver
+    name: STORAGE_DRIVER
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    name: TLSVERIFY
+    type: string
+  - default: oci
+    description: The format of the built container, oci or docker
+    name: FORMAT
+    type: string
+  - default: ""
+    description: Extra parameters passed for the build command when building images.
+    name: BUILD_EXTRA_ARGS
+    type: string
+  - default: ""
+    description: Extra parameters passed for the push command when pushing images.
+    name: PUSH_EXTRA_ARGS
+    type: string
+  results:
+  - description: Digest of the image just built.
+    name: IMAGE_DIGEST
+  steps:
+  - image: $(params.BUILDER_IMAGE)
+    name: build
+    resources: {}
+    script: |
+      buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
+        $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
+        --tls-verify=$(params.TLSVERIFY) --no-cache \
+        -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - image: $(params.BUILDER_IMAGE)
+    name: push
+    resources: {}
+    script: |
+      buildah --storage-driver=$(params.STORAGE_DRIVER) push \
+        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+        docker://$(params.IMAGE)
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - image: $(params.BUILDER_IMAGE)
+    name: digest-to-results
+    resources: {}
+    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  workspaces:
+  - name: source

--- a/tasks/git-clone.yaml
+++ b/tasks/git-clone.yaml
@@ -1,0 +1,207 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/categories: Git
+    tekton.dev/displayName: git clone
+    tekton.dev/pipelines.minVersion: 0.21.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: git 
+  name: git-clone 
+spec:
+  description: |-
+    These Tasks are Git tasks to work with repositories used by other tasks in your Pipeline.
+    The git-clone Task will clone a repo from the provided url into the output Workspace. By default the repo will be cloned into the root of your Workspace. You can clone into a subdirectory by setting this Task's subdirectory param. This Task also supports sparse checkouts. To perform a sparse checkout, pass a list of comma separated directory patterns to this Task's sparseCheckoutDirectories param.
+  params:
+  - description: Repository URL to clone from.
+    name: url
+    type: string
+  - default: ""
+    description: Revision to checkout. (branch, tag, sha, ref, etc...)
+    name: revision
+    type: string
+  - default: ""
+    description: Refspec to fetch before checking out revision.
+    name: refspec
+    type: string
+  - default: "true"
+    description: Initialize and fetch git submodules.
+    name: submodules
+    type: string
+  - default: "1"
+    description: Perform a shallow clone, fetching only the most recent N commits.
+    name: depth
+    type: string
+  - default: "true"
+    description: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.
+    name: sslVerify
+    type: string
+  - default: ""
+    description: Subdirectory inside the `output` Workspace to clone the repo into.
+    name: subdirectory
+    type: string
+  - default: ""
+    description: Define the directory patterns to match or exclude when performing a sparse checkout.
+    name: sparseCheckoutDirectories
+    type: string
+  - default: "true"
+    description: Clean out the contents of the destination directory if it already exists before cloning.
+    name: deleteExisting
+    type: string
+  - default: ""
+    description: HTTP proxy server for non-SSL requests.
+    name: httpProxy
+    type: string
+  - default: ""
+    description: HTTPS proxy server for SSL requests.
+    name: httpsProxy
+    type: string
+  - default: ""
+    description: Opt out of proxying HTTP/HTTPS requests.
+    name: noProxy
+    type: string
+  - default: "true"
+    description: Log the commands that are executed during `git-clone`'s operation.
+    name: verbose
+    type: string
+  - default: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b1598a980f17d5f5d3d8a4b11ab4f5184677f7f17ad302baa36bd3c1
+    description: The image providing the git-init binary that this Task runs.
+    name: gitInitImage
+    type: string
+  - default: /tekton/home
+    description: |
+      Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
+      the gitInitImage param with an image containing custom user configuration.
+    name: userHome
+    type: string
+  results:
+  - description: The precise commit SHA that was fetched by this Task.
+    name: commit
+  - description: The precise URL that was fetched by this Task.
+    name: url
+  steps:
+  - env:
+    - name: HOME
+      value: $(params.userHome)
+    - name: PARAM_URL
+      value: $(params.url)
+    - name: PARAM_REVISION
+      value: $(params.revision)
+    - name: PARAM_REFSPEC
+      value: $(params.refspec)
+    - name: PARAM_SUBMODULES
+      value: $(params.submodules)
+    - name: PARAM_DEPTH
+      value: $(params.depth)
+    - name: PARAM_SSL_VERIFY
+      value: $(params.sslVerify)
+    - name: PARAM_SUBDIRECTORY
+      value: $(params.subdirectory)
+    - name: PARAM_DELETE_EXISTING
+      value: $(params.deleteExisting)
+    - name: PARAM_HTTP_PROXY
+      value: $(params.httpProxy)
+    - name: PARAM_HTTPS_PROXY
+      value: $(params.httpsProxy)
+    - name: PARAM_NO_PROXY
+      value: $(params.noProxy)
+    - name: PARAM_VERBOSE
+      value: $(params.verbose)
+    - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+      value: $(params.sparseCheckoutDirectories)
+    - name: PARAM_USER_HOME
+      value: $(params.userHome)
+    - name: WORKSPACE_OUTPUT_PATH
+      value: $(workspaces.output.path)
+    - name: WORKSPACE_SSH_DIRECTORY_BOUND
+      value: $(workspaces.ssh-directory.bound)
+    - name: WORKSPACE_SSH_DIRECTORY_PATH
+      value: $(workspaces.ssh-directory.path)
+    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+      value: $(workspaces.basic-auth.bound)
+    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+      value: $(workspaces.basic-auth.path)
+    image: $(params.gitInitImage)
+    name: clone
+    resources: {}
+    script: |
+      #!/usr/bin/env sh
+      set -eu
+
+      if [ "${PARAM_VERBOSE}" = "true" ] ; then
+        set -x
+      fi
+
+      if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+        cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+        cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+        chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+        chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+      fi
+
+      if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
+        cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+        chmod 700 "${PARAM_USER_HOME}"/.ssh
+        chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+      fi
+
+      CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+
+      cleandir() {
+        # Delete any existing contents of the repo directory if it exists.
+        #
+        # We don't just "rm -rf ${CHECKOUT_DIR}" because ${CHECKOUT_DIR} might be "/"
+        # or the root of a mounted volume.
+        if [ -d "${CHECKOUT_DIR}" ] ; then
+          # Delete non-hidden files and directories
+          rm -rf "${CHECKOUT_DIR:?}"/*
+          # Delete files and directories starting with . but excluding ..
+          rm -rf "${CHECKOUT_DIR}"/.[!.]*
+          # Delete files and directories starting with .. plus any other character
+          rm -rf "${CHECKOUT_DIR}"/..?*
+        fi
+      }
+
+      if [ "${PARAM_DELETE_EXISTING}" = "true" ] ; then
+        cleandir
+      fi
+
+      test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+      test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+      test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+      /ko-app/git-init \
+        -url="${PARAM_URL}" \
+        -revision="${PARAM_REVISION}" \
+        -refspec="${PARAM_REFSPEC}" \
+        -path="${CHECKOUT_DIR}" \
+        -sslVerify="${PARAM_SSL_VERIFY}" \
+        -submodules="${PARAM_SUBMODULES}" \
+        -depth="${PARAM_DEPTH}" \
+        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
+      cd "${CHECKOUT_DIR}"
+      RESULT_SHA="$(git rev-parse HEAD)"
+      EXIT_CODE="$?"
+      if [ "${EXIT_CODE}" != 0 ] ; then
+        exit "${EXIT_CODE}"
+      fi
+      printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+      printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+  workspaces:
+  - description: The git repo will be cloned onto the volume backing this Workspace.
+    name: output
+  - description: |
+      A .ssh directory with private key, known_hosts, config, etc. Copied to
+      the user's home before git commands are executed. Used to authenticate
+      with the git remote when performing the clone. Binding a Secret to this
+      Workspace is strongly recommended over other volume types.
+    name: ssh-directory
+    optional: true
+  - description: |
+      A Workspace containing a .gitconfig and .git-credentials file. These
+      will be copied to the user's home before any git commands are run. Any
+      other files in this Workspace are ignored. It is strongly recommended
+      to use ssh-directory over basic-auth whenever possible and to bind a
+      Secret to this Workspace over other volume types.
+    name: basic-auth
+    optional: true

--- a/tasks/kustomization.yaml
+++ b/tasks/kustomization.yaml
@@ -8,3 +8,7 @@ resources:
 - init.yaml
 - summary.yaml
 - utils-task.yaml
+- buildah.yaml
+- git-clone.yaml
+- s2i-nodejs.yaml
+- s2i-java.yaml

--- a/tasks/s2i-java.yaml
+++ b/tasks/s2i-java.yaml
@@ -1,0 +1,145 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/displayName: s2i java
+    tekton.dev/pipelines.minVersion: "0.19"
+    tekton.dev/tags: s2i, java, workspace 
+  name: s2i-java 
+spec:
+  description: s2i-java task clones a Git repository and builds and pushes a container image using S2I and a Java builder image.
+  params:
+  - default: openjdk-11-ubi8
+    description: The tag of java imagestream for java version
+    name: VERSION
+    type: string
+  - default: .
+    description: The location of the path to run s2i from
+    name: PATH_CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    name: TLSVERIFY
+    type: string
+  - default: ""
+    description: Additional Maven arguments
+    name: MAVEN_ARGS_APPEND
+    type: string
+  - default: "false"
+    description: Remove the Maven repository after the artifact is built
+    name: MAVEN_CLEAR_REPO
+    type: string
+  - default: ""
+    description: The base URL of a mirror used for retrieving artifacts
+    name: MAVEN_MIRROR_URL
+    type: string
+  - description: Location of the repo where image has to be pushed
+    name: IMAGE
+    type: string
+  - default: registry.redhat.io/rhel8/buildah@sha256:e19cf23d5f1e0608f5a897f0a50448beb9f8387031cca49c7487ec71bd91c4d3
+    description: The location of the buildah builder image.
+    name: BUILDER_IMAGE
+    type: string
+  results:
+  - description: Digest of the image just built.
+    name: IMAGE_DIGEST
+  steps:
+  - args:
+    - |-
+      echo "MAVEN_CLEAR_REPO=$(params.MAVEN_CLEAR_REPO)" > env-file
+
+      [[ '$(params.MAVEN_ARGS_APPEND)' != "" ]] &&
+        echo "MAVEN_ARGS_APPEND=$(params.MAVEN_ARGS_APPEND)" >> env-file
+
+      [[ '$(params.MAVEN_MIRROR_URL)' != "" ]] &&
+        echo "MAVEN_MIRROR_URL=$(params.MAVEN_MIRROR_URL)" >> env-file
+
+      echo "Generated Env file"
+      echo "------------------------------"
+      cat env-file
+      echo "------------------------------"
+    command:
+    - /bin/sh
+    - -c
+    env:
+    - name: HOME
+      value: /tekton/home
+    image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:637c15600359cb45bc01445b5e811b6240ca239f0ebfe406b50146e34f68f631
+    name: gen-env-file
+    resources: {}
+    volumeMounts:
+    - mountPath: /env-params
+      name: envparams
+    workingDir: /env-params
+  - command:
+    - s2i
+    - build
+    - $(params.PATH_CONTEXT)
+    - image-registry.openshift-image-registry.svc:5000/openshift/java:$(params.VERSION)
+    - --image-scripts-url
+    - image:///usr/local/s2i
+    - --as-dockerfile
+    - /gen-source/Dockerfile.gen
+    - --environment-file
+    - /env-params/env-file
+    env:
+    - name: HOME
+      value: /tekton/home
+    image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:e518e05a730ae066e371a4bd36a5af9cedc8686fd04bd59648d20ea0a486d7e5
+    name: generate
+    resources: {}
+    volumeMounts:
+    - mountPath: /gen-source
+      name: gen-source
+    - mountPath: /env-params
+      name: envparams
+    workingDir: $(workspaces.source.path)
+  - command:
+    - buildah
+    - bud
+    - --storage-driver=vfs
+    - --tls-verify=$(params.TLSVERIFY)
+    - --layers
+    - -f
+    - /gen-source/Dockerfile.gen
+    - -t
+    - $(params.IMAGE)
+    - .
+    image: $(params.BUILDER_IMAGE)
+    name: build
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /gen-source
+      name: gen-source
+    workingDir: /gen-source
+  - command:
+    - buildah
+    - push
+    - --storage-driver=vfs
+    - --tls-verify=$(params.TLSVERIFY)
+    - --digestfile=$(workspaces.source.path)/image-digest
+    - $(params.IMAGE)
+    - docker://$(params.IMAGE)
+    image: $(params.BUILDER_IMAGE)
+    name: push
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - image: $(params.BUILDER_IMAGE)
+    name: digest-to-results
+    resources: {}
+    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: gen-source
+  - emptyDir: {}
+    name: envparams
+  workspaces:
+  - mountPath: /workspace/source
+    name: source

--- a/tasks/s2i-nodejs.yaml
+++ b/tasks/s2i-nodejs.yaml
@@ -1,0 +1,98 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/displayName: s2i nodejs
+    tekton.dev/pipelines.minVersion: "0.19"
+    tekton.dev/tags: s2i, nodejs, workspace  
+  name: s2i-nodejs
+spec:
+  description: s2i-nodejs task clones a Git repository and builds and pushes a container image using S2I and a nodejs builder image.
+  params:
+  - default: 14-ubi8
+    description: The tag of nodejs imagestream for nodejs version
+    name: VERSION
+    type: string
+  - default: .
+    description: The location of the path to run s2i from.
+    name: PATH_CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    name: TLSVERIFY
+    type: string
+  - description: Location of the repo where image has to be pushed
+    name: IMAGE
+    type: string
+  - default: registry.redhat.io/rhel8/buildah@sha256:e19cf23d5f1e0608f5a897f0a50448beb9f8387031cca49c7487ec71bd91c4d3
+    description: The location of the buildah builder image.
+    name: BUILDER_IMAGE
+    type: string
+  results:
+  - description: Digest of the image just built.
+    name: IMAGE_DIGEST
+  steps:
+  - command:
+    - s2i
+    - build
+    - $(params.PATH_CONTEXT)
+    - image-registry.openshift-image-registry.svc:5000/openshift/nodejs:$(params.VERSION)
+    - --as-dockerfile
+    - /gen-source/Dockerfile.gen
+    env:
+    - name: HOME
+      value: /tekton/home
+    image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:e518e05a730ae066e371a4bd36a5af9cedc8686fd04bd59648d20ea0a486d7e5
+    name: generate
+    resources: {}
+    volumeMounts:
+    - mountPath: /gen-source
+      name: gen-source
+    workingDir: $(workspaces.source.path)
+  - command:
+    - buildah
+    - bud
+    - --storage-driver=vfs
+    - --tls-verify=$(params.TLSVERIFY)
+    - --layers
+    - -f
+    - /gen-source/Dockerfile.gen
+    - -t
+    - $(params.IMAGE)
+    - .
+    image: $(params.BUILDER_IMAGE)
+    name: build
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /gen-source
+      name: gen-source
+    workingDir: /gen-source
+  - command:
+    - buildah
+    - push
+    - --storage-driver=vfs
+    - --tls-verify=$(params.TLSVERIFY)
+    - --digestfile=$(workspaces.source.path)/image-digest
+    - $(params.IMAGE)
+    - docker://$(params.IMAGE)
+    image: $(params.BUILDER_IMAGE)
+    name: push
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - image: $(params.BUILDER_IMAGE)
+    name: digest-to-results
+    resources: {}
+    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: gen-source
+  workspaces:
+  - mountPath: /workspace/source
+    name: source


### PR DESCRIPTION
This PR contains the changes which remove references to clustertasks and replace with local task definitions. This is intended to enable pipelines on KCP

- added buildah, gitclone, s2i-java and s2i-nodejs tasks 
- changed references to all cluster tasks to local tasks