### PR TITLE
Make s2i-java and s2i-nodejs chains friendly too

### DIFF
--- a/tasks/buildah.yaml
+++ b/tasks/buildah.yaml
@@ -46,10 +46,10 @@ spec:
     name: PUSH_EXTRA_ARGS
     type: string
   results:
-  - description: Digest of the image just built.
+  - description: Digest of the image just built
     name: IMAGE_DIGEST
-  - name: IMAGE_URL
-    description: Image repository where the built image would be pushed to
+  - description: Image repository where the built image was pushed
+    name: IMAGE_URL
   steps:
   - image: $(params.BUILDER_IMAGE)
     name: build

--- a/tasks/s2i-java.yaml
+++ b/tasks/s2i-java.yaml
@@ -41,8 +41,10 @@ spec:
     name: BUILDER_IMAGE
     type: string
   results:
-  - description: Digest of the image just built.
+  - description: Digest of the image just built
     name: IMAGE_DIGEST
+  - description: Image repository where the built image was pushed
+    name: IMAGE_URL
   steps:
   - args:
     - |-
@@ -132,7 +134,9 @@ spec:
   - image: $(params.BUILDER_IMAGE)
     name: digest-to-results
     resources: {}
-    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+    script: |
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
   volumes:
   - emptyDir: {}
     name: varlibcontainers

--- a/tasks/s2i-nodejs.yaml
+++ b/tasks/s2i-nodejs.yaml
@@ -29,8 +29,10 @@ spec:
     name: BUILDER_IMAGE
     type: string
   results:
-  - description: Digest of the image just built.
+  - description: Digest of the image just built
     name: IMAGE_DIGEST
+  - description: Image repository where the built image was pushed
+    name: IMAGE_URL
   steps:
   - command:
     - s2i
@@ -87,7 +89,9 @@ spec:
   - image: $(params.BUILDER_IMAGE)
     name: digest-to-results
     resources: {}
-    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+    script: |
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
   volumes:
   - emptyDir: {}
     name: varlibcontainers


### PR DESCRIPTION
Tekton Chains expects to see an IMAGE_URL taskrun result containing
the image repo url so let's provide it.

Avoids a "Did not find anything to attest" error from the chains
controller.

Similar to #24 which was merged recently.

Also:
- Make the result descriptions and task step scripts consistent
  across each of the three tasks definitions
- Reword the IMAGE_URL description slightly