### PR TITLE
Remove logging of dockerconfigjson auth file

### DIFF
--- a/tasks/configure-build.yaml
+++ b/tasks/configure-build.yaml
@@ -32,8 +32,6 @@ spec:
         if [ -f "$AUTH" ]; then
           echo "$AUTH found" 
           echo
-          cat $AUTH
-          echo
 
           cp $AUTH $DEST
 


### PR DESCRIPTION
Pipeline task appstudio-configure-build is logging credentials in plain
form. Removing printing of the credentials.