### PR TITLE
utility scripts and binaries to test tekton-chains

### DIFF
--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -4,6 +4,7 @@ RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_a
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.9/openshift-client-linux.tar.gz | tar -xz -C /usr/bin/
 RUN curl -L https://github.com/sigstore/cosign/releases/download/v1.5.1/cosign-linux-amd64 -o /usr/bin/cosign && chmod +x /usr/bin/cosign
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.21.0/tkn-linux-amd64-0.21.0.tar.gz | tar -xz --no-same-owner -C /usr/bin/
+RUN curl -L https://github.com/sigstore/rekor/releases/download/v0.5.0/rekor-cli-linux-amd64 -o /usr/bin/rekor-cli && chmod +x /usr/bin/rekor-cli
 RUN dnf -y --setopt=tsflags=nodocs install \
     jq \
     skopeo \

--- a/appstudio-utils/util-scripts/tekton-chains/_helpers.sh
+++ b/appstudio-utils/util-scripts/tekton-chains/_helpers.sh
@@ -1,0 +1,195 @@
+#
+#
+# Misc utilties for bash scripted demos
+#
+# Typical usage:
+#   source $(dirname $0)/_helpers.sh
+
+#------------------------------------------------
+
+#
+# Cosign knows how to fetch the key from the secret in the cluster.
+# Requires that you're authenticated with an account that can access
+# the signing-secret, i.e. kubeadmin but not developer.
+#
+K8S_SIG_KEY=k8s://tekton-chains/signing-secrets
+
+# Presumably real public keys can be published somewhere in future
+#PUB_SIG_KEY=?
+
+# For now use this by default
+[[ -z $SIG_KEY ]] && SIG_KEY=$K8S_SIG_KEY
+
+
+#------------------------------------------------
+
+#
+# Support running demos quietly or without pauses
+#
+QUIET=
+FAST=
+for arg in "$@"; do
+  #
+  #
+  if [[ $arg == "--quiet" ]]; then
+    QUIET=1
+    FAST=1
+  fi
+
+  if [[ $arg == "--fast" ]]; then
+    FAST=1
+  fi
+done
+
+#
+# Create a pretty heading
+#
+title() {
+  [[ -n $QUIET ]] && return
+
+  echo
+  echo "🔗 ---- $* ----"
+}
+
+#
+# Quiet aware echo
+#
+say() {
+  [[ -n $QUIET ]] && return
+
+  echo $*
+}
+
+#
+# Pause and wait for user to hit enter
+#
+pause() {
+  [[ -n $QUIET ]] || [[ -n $FAST ]] && return
+
+  echo
+  local MSG="$*"
+  [[ -z "$MSG" ]] && MSG="Hit enter to continue..."
+  read -p "$MSG"
+}
+
+#
+# Show a command then run it after user hits enter
+# (Could use set -x instead I guess.)
+#
+show-then-run() {
+  if [[ -z "${KUBERNETES_SERVICE_HOST}" ]]; then
+    [[ -z $QUIET ]] && [[ -z $FAST ]] && read -p "\$ $*"
+    $*
+  else
+   $1
+  fi
+}
+
+
+#------------------------------------------------
+
+#
+# Pretty print json as yaml
+#
+yq-pretty() {
+  yq -P -C e ${1:-} -
+}
+
+#
+# Fetch json with curl
+#
+curl-json() {
+  curl -s -H "Accept: application/json" $@
+}
+
+#
+# Trim the type prefix from a k8s name
+#
+trim-name() {
+  echo "$1" | sed 's#.*/##'
+}
+
+# Helper for jsonpath
+get-jsonpath() {
+  kubectl get $TASKRUN_NAME -o jsonpath={.$1}
+}
+
+# Helper for reading chains values
+get-chainsval() {
+  get-jsonpath metadata.annotations.chains\\.tekton\\.dev/$1
+}
+
+# Helper for reading a task result
+get-taskresult() {
+  kubectl get $TASKRUN_NAME \
+    -o jsonpath="{.status.taskResults[?(@.name == \"$1\")].value}"
+}
+
+# Helper for reading a resources result
+get-resourcesresult() {
+  kubectl get $TASKRUN_NAME \
+    -o jsonpath="{.status.resourcesResult[?(@.key == \"$1\")].value}"
+}
+
+# helper to check if running in kubernetes.
+# If running in kubernetes, we don't want to pause
+check-pause() {
+  ARG=${1:-""}
+  if [[ -z "${KUBERNETES_SERVICE_HOST}" ]]; then
+    pause $ARG
+  else
+    $ARG
+  fi
+}
+
+cosign-verify() {
+  IMAGE_URL=$1
+  SIG_KEY=$2
+  VERBOSE=${3:-""}
+  set -x
+  COSIGN_EXPERIMENTAL=1 cosign verify $VERBOSE --key $SIG_KEY $IMAGE_URL -o json | jq .
+}
+
+cosign-verify-attestation() {
+  IMAGE_URL=$1
+  SIG_KEY=$2
+
+  cosign verify-attestation --key $SIG_KEY $IMAGE_URL --output-file /tmp/verify-att.out
+  # There can be multiple attestations for some reason and hence multiple lines in
+  # this file, which makes it invalid json. For the sake of the demo we'll ignore
+  # all but the last line.
+  tail -1 /tmp/verify-att.out | yq e . -P -
+}
+
+kaniko-cosign-verify() {
+  TASKRUN_NAME=$1
+  IMAGE_URL=$2
+  SIG_KEY=$3
+
+  title "Inspect $TASKRUN_NAME annotations"
+  # Just want to show the chains related fields
+  oc get $TASKRUN_NAME -o yaml | yq-pretty .metadata.annotations
+  check-pause
+
+  title "Image url from task result"
+  kubectl get $TASKRUN_NAME -o jsonpath="{.status.taskResults[?(@.name == \"IMAGE_URL\")].value}"
+
+  title "Image digest from task result"
+  kubectl get $TASKRUN_NAME -o jsonpath="{.status.taskResults[?(@.name == \"IMAGE_DIGEST\")].value}"
+  echo
+
+  title "Cosign verify the image"
+  # Save the output data to a file so we can look at it later
+  # (Actually we could just pipe it to jq because the text goes to stderr I think..?)
+  show-then-run "cosign-verify $IMAGE_URL $SIG_KEY"
+
+  check-pause
+
+  title "Cosign verify the image's attestation"
+  show-then-run "cosign-verify-attestation $IMAGE_URL $SIG_KEY"
+  check-pause
+
+  title "Inspect the payload from that attestation output"
+  tail -1 /tmp/verify-att.out | yq e .payload - | base64 -d | yq e . -P -
+
+}

--- a/appstudio-utils/util-scripts/tekton-chains/check-pipelinerun.sh
+++ b/appstudio-utils/util-scripts/tekton-chains/check-pipelinerun.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+source $(dirname $0)/_helpers.sh
+set -u
+
+# Use a specific pipelinerun if provided, otherwise use the latest
+PIPELINERUN_NAME=${1:-$( tkn pipelinerun describe --last -o name )}
+PIPELINERUN_NAME=pipelinerun/$( trim-name $PIPELINERUN_NAME )
+
+TASKRUN_NAMES=$(
+  kubectl get $PIPELINERUN_NAME -o yaml | yq e '.status.taskRuns | keys | .[]' - )
+
+for name in $TASKRUN_NAMES; do
+  echo -n "$name 🔗 "
+  $SCRIPTDIR/check-taskrun.sh $name --quiet
+done

--- a/appstudio-utils/util-scripts/tekton-chains/check-taskrun.sh
+++ b/appstudio-utils/util-scripts/tekton-chains/check-taskrun.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# This script is only for use with chains configured with
+# 'tekton' taskrun storage, which means the chains data is
+# stored in the taskrun annotations.
+#
+# It's probably not useful for 'oci' taskrun storage.
+#
+
+source $(dirname $0)/_helpers.sh
+set -ue
+
+# Use a specific taskrun if provided, otherwise use the latest
+TASKRUN_NAME=${1:-$( tkn taskrun describe --last -o name )}
+TASKRUN_NAME=taskrun/$( trim-name $TASKRUN_NAME )
+
+title Taskrun name
+say $TASKRUN_NAME
+
+# Fetch task run signature and payload
+TASKRUN_UID=$( get-jsonpath metadata.uid )
+SIGNATURE=$( get-chainsval signature-taskrun-$TASKRUN_UID )
+PAYLOAD=$( get-chainsval payload-taskrun-$TASKRUN_UID | base64 --decode )
+
+# For a task that builds an image, image digest should be available
+# in the task results
+IMAGE_DIGEST=$( get-taskresult IMAGE_DIGEST )
+
+# Another place we might find it..?
+# (The taskrun created by simple-demo.sh produces a digest here.)
+[[ -z $IMAGE_DIGEST ]] && IMAGE_DIGEST=$( get-resourcesresult digest )
+
+if [[ -n $IMAGE_DIGEST ]]; then
+  SHORT_IMAGE_DIGEST=$( echo "$IMAGE_DIGEST" | cut -d: -f2 | head -c 12 )
+
+  # For tekton storage, we should then be able to grab these
+  IMAGE_SIGNATURE=$( get-chainsval signature-$SHORT_IMAGE_DIGEST )
+  IMAGE_PAYLOAD=$( get-chainsval payload-$SHORT_IMAGE_DIGEST | base64 --decode)
+
+  title "Image digest found in taskrun"
+  say "Image digest: $IMAGE_DIGEST"
+
+  if [[ -n $IMAGE_SIGNATURE ]] || [[ -n $IMAGE_PAYLOAD ]]; then
+    say "Image signature: $IMAGE_SIGNATURE"
+    say "Image signed payload:"
+    [[ -z $QUIET ]] && echo "$IMAGE_PAYLOAD" | yq-pretty
+  fi
+
+  # Todo: How to verify these also?
+fi
+
+# Try to detect and then handle different formats
+# (It seems like it would be better if the format was available
+# explicitly but afaict it is not.)
+# In the longer term, we won't care about tekton format, so let's
+# not worry too much.
+
+# If the signature is 96 chars then we might be using tekton format
+if [[ ${#SIGNATURE} == 96 ]]; then
+  title "Assuming tekton format"
+  # The signature is just the signature, continue
+
+else
+  title "Assuming in-toto format for taskrun"
+
+  # The signature value is actually encoded json with a payload and
+  # signature list inside it
+  SIG_DATA=$( echo $SIGNATURE | base64 --decode )
+  SIGNATURE=$( echo $SIG_DATA | jq -r '.signatures[0].sig' )
+
+  # Looks like the same payload can be found in both places...
+  # Not sure if feature or bug
+  OTHER_PAYLOAD=$( echo $SIG_DATA | jq -r .payload | base64 --decode )
+
+  if [[ "$PAYLOAD" != "$OTHER_PAYLOAD" ]]; then
+    # Seems like we'll never get here
+    echo "The two payloads are unexpectedly different!"
+    exit 1
+  fi
+
+fi
+
+# Cosign needs files on disk to do a verify-blob afaict
+SIG_FILE=$( mktemp )
+PAYLOAD_FILE=$( mktemp )
+echo -n "$PAYLOAD" > $PAYLOAD_FILE
+echo -n "$SIGNATURE" > $SIG_FILE
+
+title Taskrun signature
+say $SIGNATURE
+
+check-pause
+
+title Taskrun payload
+[[ -z $QUIET ]] && echo "$PAYLOAD" | yq-pretty
+
+check-pause
+
+# Keep going if the verify fails
+set +e
+
+##
+## Fixme: This only works with artifacts.taskrun.format set to 'tekton'.
+## I've never been able to use cosign verify-blob to verify a task's
+## payload and signature using the 'in-toto' format and I don't know why.
+##
+# Now use cosign to verify the signed payload
+title Taskrun verification
+show-then-run cosign verify-blob --key $SIG_KEY --signature $SIG_FILE $PAYLOAD_FILE
+COSIGN_EXIT_CODE=$?
+
+# For debugging...
+title "To view taskrun"
+say " env EDITOR=view kubectl edit $TASKRUN_NAME"
+
+# Clean up
+rm $SIG_FILE $PAYLOAD_FILE
+
+# Use the exit code from cosign
+exit $COSIGN_EXIT_CODE

--- a/appstudio-utils/util-scripts/tekton-chains/cosign-verify-image-local.sh
+++ b/appstudio-utils/util-scripts/tekton-chains/cosign-verify-image-local.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# A wrapper for cosign to help verify a signed image
+#
+
+# Required
+IMAGE_URL=$1
+
+# Set this to use a different sig key. See below for the defaults.
+SIG_KEY=$COSIGN_SIG_KEY
+
+# Set this to --verbose for lots of cosign debug output
+VERBOSE=$COSIGN_VERBOSE
+
+set -eu
+
+if [[ -z $IMAGE_URL ]]; then
+  echo "Image url is required."
+  exit 1
+fi
+
+if [[ -z $SIG_KEY ]]; then
+  # Requires that you're authenticated with an account that can access
+  # the signing-secret in the cluster, i.e. kubeadmin but not developer
+  SIG_KEY=k8s://tekton-chains/signing-secrets
+
+  # If you have the public key locally because you created it
+  # (Presumably real public keys will published somewhere in future)
+  #SIG_KEY=$(git rev-parse --show-toplevel)/cosign.pub
+fi
+
+source $(dirname $0)/_helpers.sh
+
+cosign-verify $IMAGE_URL $SIG_KEY $VERBOSE

--- a/appstudio-utils/util-scripts/tekton-chains/cosign-verify-image-task.sh
+++ b/appstudio-utils/util-scripts/tekton-chains/cosign-verify-image-task.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# A wrapper for cosign to help verify a signed image
+#
+
+# Required
+IMAGE_URL=$1
+SIG_KEY=$2
+VERBOSE=$3
+
+source $(dirname $0)/_helpers.sh
+
+cosign-verify $IMAGE_URL $SIG_KEY $VERBOSE

--- a/appstudio-utils/util-scripts/tekton-chains/kaniko-cosign-verify-local.sh
+++ b/appstudio-utils/util-scripts/tekton-chains/kaniko-cosign-verify-local.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source $(dirname $0)/_helpers.sh
+set -ue
+
+# Use a specific taskrun if provided, otherwise use the latest
+TASKRUN_NAME=${1:-$( tkn taskrun describe --last -o name )}
+TASKRUN_NAME=taskrun/$( echo $TASKRUN_NAME | sed 's#.*/##' )
+
+# Let's not hard code the image url or the registry
+IMAGE_URL=$( oc get $TASKRUN_NAME -o json | jq -r '.status.taskResults[1].value' )
+IMAGE_REGISTRY=$( echo $IMAGE_URL | cut -d/ -f1 )
+#IMAGE_REGISTRY=$( oc registry info )
+
+SIG_KEY="k8s://tekton-chains/signing-secrets"
+
+title "Make sure we're logged in to the registry"
+# Make sure we have a docker credential since cosign will need it
+# (Todo: Probably shouldn't assume kubeadmin user here)
+oc whoami -t | docker login -u kubeadmin --password-stdin $IMAGE_REGISTRY
+
+kaniko-cosign-verify $TASKRUN_NAME $IMAGE_URL $SIG_KEY

--- a/appstudio-utils/util-scripts/tekton-chains/kaniko-cosign-verify-task.sh
+++ b/appstudio-utils/util-scripts/tekton-chains/kaniko-cosign-verify-task.sh
@@ -1,0 +1,30 @@
+#!/bin/bin/env bash
+
+source $(dirname $0)/_helpers.sh
+set -ue
+
+TASK_LABEL=$1
+
+counter=0
+timeout=30
+TASKRUN_NAME=`tkn tr list --label tekton.dev/task="${TASK_LABEL}" |awk '{print $1}' |tail -1`
+while [ `tkn tr describe ${TASKRUN_NAME} -o  jsonpath='{.status.conditions[0].reason}'` != 'Succeeded' ] || [ $counter -gt $timeout ];
+do
+  echo "waiting for taskRun: $(tkn tr describe --last -o  jsonpath='{.metadata.name}') to finish"
+  sleep 1
+  counter=$((counter+1))
+done
+if [ $counter -gt $timeout ]; then
+  echo "exiting with error"
+  exit 1
+fi
+
+# Use a specific taskrun if provided, otherwise use the latest
+TASKRUN_NAME=taskrun/$( echo $TASKRUN_NAME | sed 's#.*/##' )
+
+# Let's not hard code the image url or the registry
+IMAGE_URL=$( oc get $TASKRUN_NAME -o json | jq -r '.status.taskResults[1].value' )
+
+SIG_KEY="k8s://tekton-chains/signing-secrets"
+
+kaniko-cosign-verify $TASKRUN_NAME $IMAGE_URL $SIG_KEY

--- a/appstudio-utils/util-scripts/tekton-chains/rekor-verify-taskrun.sh
+++ b/appstudio-utils/util-scripts/tekton-chains/rekor-verify-taskrun.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+source $(dirname $0)/_helpers.sh
+set -ue
+
+# Use a specific taskrun if provided, otherwise use the latest
+TASKRUN_NAME=${1:-$( tkn taskrun describe --last -o name )}
+TASKRUN_NAME=taskrun/$( echo $TASKRUN_NAME | sed 's#.*/##' )
+
+# Let's not hard code the image url or the registry
+IMAGE_URL=$( kubectl get $TASKRUN_NAME -o json | jq -r '.status.taskResults[1].value' )
+IMAGE_REGISTRY=$( echo $IMAGE_URL | cut -d/ -f1 )
+
+title "Image url"
+echo https://$IMAGE_URL
+
+TRANSPARENCY_URL=$(
+  kubectl get $TASKRUN_NAME -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/transparency}' )
+
+# Extract the log index from the url
+LOG_INDEX=$( echo $TRANSPARENCY_URL | cut -d= -f2 )
+
+# Todo: We're reading the transparency url from the taskrun annotations.
+# Is there another way to get it? How else can we link the image in the
+# registry to its rekor entry?
+
+# In the future we might use our own rekor servers, so let's not hard code that
+REKOR_SERVER=$( echo $TRANSPARENCY_URL | cut -d/ -f1-3 )
+
+title "Transparency url for $TASKRUN_NAME found in the annotations"
+echo $TRANSPARENCY_URL
+pause
+
+title "Take a look at it"
+curl-json $TRANSPARENCY_URL | yq e . -P -
+pause
+
+title "Extract the rekor body"
+curl -s -H "Accept: application/json" $TRANSPARENCY_URL | jq -r 'values[].body' | base64 -d | yq e . -PC -
+pause
+
+# Comment this out because there is no attestation data in the kaniko build task
+#title "Extract the rekor attestation"
+#curl -s -H "Accept: application/json" $TRANSPARENCY_URL | jq -r 'values[].attestation.data' | base64 -d | base64 -d | yq e . -PC -
+#pause
+
+title "Using the rekor-cli"
+show-then-run "rekor-cli get --log-index $LOG_INDEX --rekor_server $REKOR_SERVER"
+pause
+
+title "There's also a --format json option:"
+rekor-cli get --log-index $LOG_INDEX --rekor_server $REKOR_SERVER --format json | yq e . -P -
+pause
+
+title "Try a rekor-cli verify"
+show-then-run "rekor-cli verify --log-index $LOG_INDEX --rekor_server $REKOR_SERVER"


### PR DESCRIPTION
* Adds the rekor-cli to the appstudio-utils image
*  Moving chains utility scripts from infra-deployments to the appstudio-utils image