### PR TITLE
Bump of the buildah image referenced

### DIFF
--- a/pipelines/devfile-build.yaml
+++ b/pipelines/devfile-build.yaml
@@ -48,7 +48,7 @@ spec:
           value: $(params.git-url)
         - name: revision
           value: "$(params.revision)"
-      taskRef: 
+      taskRef:
         name: git-clone
       workspaces:
         - name: output
@@ -84,7 +84,7 @@ spec:
             $(params.output-image)
         - name: BUILDER_IMAGE
           value: >-
-            registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+            registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
         - name: STORAGE_DRIVER
           value: vfs
         - name: DOCKERFILE
@@ -101,7 +101,7 @@ spec:
           value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
       runAfter:
         - appstudio-configure-build
-      taskRef: 
+      taskRef:
         name: buildah
       workspaces:
         - name: source

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -1,11 +1,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: docker-build 
+  name: docker-build
   labels:
     "pipelines.openshift.io/used-by" : "build-cloud"
     "pipelines.openshift.io/runtime" : "generic"
-    "pipelines.openshift.io/strategy" : "docker" 
+    "pipelines.openshift.io/strategy" : "docker"
 spec:
   params:
     - description: 'Source Repository URL'
@@ -19,7 +19,7 @@ spec:
       name: output-image
       type: string
     - description: The path to your source code
-      name: path-context 
+      name: path-context
       type: string
       default: .
     - description: Path to the Dockerfile
@@ -28,59 +28,59 @@ spec:
       default: Dockerfile
   tasks:
     - name: appstudio-init
-      params: 
-        - name: image-url 
+      params:
+        - name: image-url
           value: "$(params.output-image)"
       taskRef:
         name: init
       workspaces:
         - name: source
-          workspace: workspace  
+          workspace: workspace
         - name: registry-auth
-          workspace: registry-auth  
-        - name: git-auth 
-          workspace: git-auth  
-    - name: clone-repository      
+          workspace: registry-auth
+        - name: git-auth
+          workspace: git-auth
+    - name: clone-repository
       when:
-      - input: $(tasks.appstudio-init.results.exists) 
+      - input: $(tasks.appstudio-init.results.exists)
         operator: in
         values: ["false"]
       runAfter:
-        - appstudio-init 
+        - appstudio-init
       params:
         - name: url
           value: $(params.git-url)
         - name: revision
           value: "$(params.revision)"
-      taskRef: 
+      taskRef:
         name: git-clone
       workspaces:
         - name: output
           workspace: workspace
-    - name: appstudio-configure-build 
+    - name: appstudio-configure-build
       runAfter:
         - clone-repository
       when:
-      - input: $(tasks.appstudio-init.results.exists) 
+      - input: $(tasks.appstudio-init.results.exists)
         operator: in
-        values: ["false"] 
+        values: ["false"]
       taskRef:
         name: configure-build
       workspaces:
         - name: source
-          workspace: workspace  
+          workspace: workspace
         - name: registry-auth
-          workspace: registry-auth  
-        - name: git-auth 
-          workspace: git-auth   
-    - name: build-container 
+          workspace: registry-auth
+        - name: git-auth
+          workspace: git-auth
+    - name: build-container
       params:
         - name: IMAGE
           value: >-
             $(params.output-image)
         - name: BUILDER_IMAGE
           value: >-
-            registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+            registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
         - name: STORAGE_DRIVER
           value: vfs
         - name: DOCKERFILE
@@ -96,29 +96,29 @@ spec:
         - name: PUSH_EXTRA_ARGS
           value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
       runAfter:
-        - appstudio-configure-build 
-      taskRef: 
+        - appstudio-configure-build
+      taskRef:
         name: buildah
       workspaces:
         - name: source
           workspace: workspace
     - name: show-summary
       runAfter:
-        - build-container 
+        - build-container
       taskRef:
         name: summary
-      params: 
+      params:
       - name: pipeline-run-name
         value: "$(context.pipelineRun.name)"
       - name: git-url
         value: "$(params.git-url)"
       - name: image-url
-        value: $(params.output-image)   
-    - name: skip-rebuild-summary  
+        value: $(params.output-image)
+    - name: skip-rebuild-summary
       when:
-      - input: $(tasks.appstudio-init.results.exists) 
+      - input: $(tasks.appstudio-init.results.exists)
         operator: in
-        values: ["true"]  
+        values: ["true"]
       runAfter:
         - appstudio-init
       taskRef:
@@ -129,10 +129,10 @@ spec:
       - name: git-url
         value: "$(params.git-url)"
       - name: image-url
-        value: $(params.output-image)   
+        value: $(params.output-image)
   workspaces:
     - name: workspace
     - name: registry-auth
       optional: true
-    - name: git-auth 
+    - name: git-auth
       optional: true

--- a/pipelines/java-builder.yaml
+++ b/pipelines/java-builder.yaml
@@ -1,6 +1,6 @@
 ## Sample Pipeline for a Java s2i build provided ootb.
 #
-## If changed by a user, the App Studio HAS service should push the modified 
+## If changed by a user, the App Studio HAS service should push the modified
 ## Pipeline definition into the user's repository.
 
 
@@ -11,7 +11,7 @@ metadata:
     "pipelines.openshift.io/used-by" : "build-cloud"
     "pipelines.openshift.io/runtime" : "java"
     "pipelines.openshift.io/strategy" : "s2i"
-  name: java-builder 
+  name: java-builder
 spec:
   params:
     - description: 'Source Repository URL'
@@ -25,7 +25,7 @@ spec:
       name: output-image
       type: string
     - description: The path to your source code
-      name: path-context 
+      name: path-context
       type: string
       default: .
     - description: Path to the Dockerfile
@@ -34,25 +34,25 @@ spec:
       default: Dockerfile
   tasks:
     - name: appstudio-init
-      params: 
-        - name: image-url 
+      params:
+        - name: image-url
           value: "$(params.output-image)"
       taskRef:
         name: init
       workspaces:
         - name: source
-          workspace: workspace  
+          workspace: workspace
         - name: registry-auth
-          workspace: registry-auth  
-        - name: git-auth 
-          workspace: git-auth  
+          workspace: registry-auth
+        - name: git-auth
+          workspace: git-auth
     - name: git-clone
       when:
-      - input: $(tasks.appstudio-init.results.exists) 
+      - input: $(tasks.appstudio-init.results.exists)
         operator: in
         values: ["false"]
       runAfter:
-        - appstudio-init 
+        - appstudio-init
       params:
         - name: url
           value: $(params.git-url)
@@ -73,24 +73,24 @@ spec:
             registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:da1aedf0b17f2b9dd2a46edc93ff1c0582989414b902a28cd79bad8a035c9ea4
         - name: userHome
           value: /tekton/home
-      taskRef: 
+      taskRef:
         name: git-clone
       workspaces:
         - name: output
           workspace: workspace
-    - name: appstudio-configure-build       
+    - name: appstudio-configure-build
       runAfter:
-        - git-clone 
+        - git-clone
       taskRef:
         name: configure-build
       workspaces:
         - name: source
-          workspace: workspace  
+          workspace: workspace
         - name: registry-auth
-          workspace: registry-auth  
-        - name: git-auth 
-          workspace: git-auth   
-    - name: s2i-java  
+          workspace: registry-auth
+        - name: git-auth
+          workspace: git-auth
+    - name: s2i-java
       runAfter:
         - appstudio-configure-build
       params:
@@ -106,36 +106,36 @@ spec:
           value: "$(params.output-image)"
         - name: BUILDER_IMAGE
           value: >-
-            registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
-      taskRef: 
+            registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
+      taskRef:
         name: s2i-java
       workspaces:
         - name: source
           workspace: workspace
     - name: show-summary
       runAfter:
-        - s2i-java 
+        - s2i-java
       taskRef:
         name: summary
       params:
       - name: pipeline-run-name
-        value: "$(context.pipelineRun.name)" 
+        value: "$(context.pipelineRun.name)"
       - name: git-url
         value: "$(params.git-url)"
       - name: image-url
-        value: $(params.output-image)  
-    - name: skip-rebuild-summary  
+        value: $(params.output-image)
+    - name: skip-rebuild-summary
       when:
-      - input: $(tasks.appstudio-init.results.exists) 
+      - input: $(tasks.appstudio-init.results.exists)
         operator: in
-        values: ["true"]  
+        values: ["true"]
       runAfter:
         - appstudio-init
       taskRef:
         name: summary
       params:
       - name: pipeline-run-name
-        value: "$(context.pipelineRun.name)" 
+        value: "$(context.pipelineRun.name)"
       - name: git-url
         value: "$(params.git-url)"
       - name: image-url
@@ -144,5 +144,5 @@ spec:
     - name: workspace
     - name: registry-auth
       optional: true
-    - name: git-auth 
+    - name: git-auth
       optional: true

--- a/pipelines/nodejs-builder.yaml
+++ b/pipelines/nodejs-builder.yaml
@@ -1,6 +1,6 @@
 ## Sample Pipeline for a NodeJs s2i build provided ootb.
 #
-## If changed by a user, the App Studio HAS service should push the modified 
+## If changed by a user, the App Studio HAS service should push the modified
 ## Pipeline definition into the user's repository.
 
 ## Sample usage by client
@@ -30,13 +30,13 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: nodejs-builder 
+  name: nodejs-builder
   labels:
     "pipelines.openshift.io/used-by" : "build-cloud"
     "pipelines.openshift.io/runtime" : "nodejs"
     "pipelines.openshift.io/strategy" : "s2i"
 spec:
-  params: 
+  params:
     - description: 'Source Repository URL'
       name: git-url
       type: string
@@ -48,7 +48,7 @@ spec:
       name: output-image
       type: string
     - description: The path to your source code
-      name: path-context 
+      name: path-context
       type: string
       default: .
     - description: Path to the Dockerfile
@@ -57,30 +57,30 @@ spec:
       default: Dockerfile
   tasks:
     - name: appstudio-init
-      params: 
-        - name: image-url 
+      params:
+        - name: image-url
           value: "$(params.output-image)"
       taskRef:
         name: init
       workspaces:
         - name: source
-          workspace: workspace  
+          workspace: workspace
         - name: registry-auth
-          workspace: registry-auth  
-        - name: git-auth 
+          workspace: registry-auth
+        - name: git-auth
           workspace: git-auth
-    - name: appstudio-configure-build       
+    - name: appstudio-configure-build
       runAfter:
-        - git-clone 
+        - git-clone
       taskRef:
         name: configure-build
       workspaces:
         - name: source
-          workspace: workspace  
+          workspace: workspace
         - name: registry-auth
-          workspace: registry-auth  
-        - name: git-auth 
-          workspace: git-auth    
+          workspace: registry-auth
+        - name: git-auth
+          workspace: git-auth
     - name: s2i-nodejs
       params:
         - name: VERSION
@@ -93,21 +93,21 @@ spec:
           value: "$(params.output-image)"
         - name: BUILDER_IMAGE
           value: >-
-            registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+            registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
       runAfter:
-        - appstudio-configure-build 
-      taskRef: 
+        - appstudio-configure-build
+      taskRef:
         name: s2i-nodejs
       workspaces:
         - name: source
           workspace: workspace
     - name: git-clone
       when:
-      - input: $(tasks.appstudio-init.results.exists) 
+      - input: $(tasks.appstudio-init.results.exists)
         operator: in
         values: ["false"]
       runAfter:
-        - appstudio-init 
+        - appstudio-init
       params:
         - name: url
           value: "$(params.git-url)"
@@ -128,7 +128,7 @@ spec:
             registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:da1aedf0b17f2b9dd2a46edc93ff1c0582989414b902a28cd79bad8a035c9ea4
         - name: userHome
           value: /tekton/home
-      taskRef: 
+      taskRef:
         name: git-clone
       workspaces:
         - name: output
@@ -140,23 +140,23 @@ spec:
         name: summary
       params:
       - name: pipeline-run-name
-        value: "$(context.pipelineRun.name)" 
+        value: "$(context.pipelineRun.name)"
       - name: git-url
         value: "$(params.git-url)"
       - name: image-url
         value: $(params.output-image)
-    - name: skip-rebuild-summary 
+    - name: skip-rebuild-summary
       when:
-      - input: $(tasks.appstudio-init.results.exists) 
+      - input: $(tasks.appstudio-init.results.exists)
         operator: in
-        values: ["true"]  
+        values: ["true"]
       runAfter:
         - appstudio-init
       taskRef:
         name: summary
       params:
       - name: pipeline-run-name
-        value: "$(context.pipelineRun.name)" 
+        value: "$(context.pipelineRun.name)"
       - name: git-url
         value: "$(params.git-url)"
       - name: image-url
@@ -165,5 +165,5 @@ spec:
     - name: workspace
     - name: registry-auth
       optional: true
-    - name: git-auth 
+    - name: git-auth
       optional: true

--- a/pipelines/prototype-build-compliance.yaml
+++ b/pipelines/prototype-build-compliance.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     "pipelines.openshift.io/used-by" : "build-cloud"
     "pipelines.openshift.io/runtime" : "generic"
-    "pipelines.openshift.io/strategy" : "docker" 
+    "pipelines.openshift.io/strategy" : "docker"
 spec:
   params:
     - description: 'Source Repository URL'
@@ -19,7 +19,7 @@ spec:
       name: output-image
       type: string
     - description: The path to your source code
-      name: path-context 
+      name: path-context
       type: string
       default: .
     - description: Path to the Dockerfile
@@ -32,42 +32,42 @@ spec:
       default: ""
   tasks:
     - name: setup-appstudio-init
-      params: 
-        - name: image-url 
+      params:
+        - name: image-url
           value: "$(params.output-image)"
       taskRef:
         name: init
       workspaces:
         - name: source
-          workspace: workspace  
+          workspace: workspace
         - name: registry-auth
-          workspace: registry-auth  
-        - name: git-auth 
-          workspace: git-auth  
-    - name: source-clone-repository      
+          workspace: registry-auth
+        - name: git-auth
+          workspace: git-auth
+    - name: source-clone-repository
       runAfter:
-        - setup-appstudio-init 
+        - setup-appstudio-init
       params:
         - name: url
           value: $(params.git-url)
         - name: revision
           value: "$(params.revision)"
-      taskRef: 
+      taskRef:
         name: git-clone
       workspaces:
         - name: output
           workspace: workspace
-    - name: build-appstudio-configure-build 
+    - name: build-appstudio-configure-build
       runAfter:
         - source-clone-repository
       taskRef:
         name: configure-build
       workspaces:
         - name: source
-          workspace: workspace  
+          workspace: workspace
         - name: registry-auth
-          workspace: registry-auth  
-        - name: git-auth 
+          workspace: registry-auth
+        - name: git-auth
           workspace: git-auth
     - name: secret-detection-detect-secrets
       taskRef:
@@ -75,139 +75,139 @@ spec:
       runAfter:
         - source-clone-repository
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
+            #!/usr/bin/env bash
             echo "This is a placeholder for secret-detection-detect-secrets"
     - name: policy-code-reviews-check
       taskRef:
         name: utils-task
       runAfter:
-        - setup-appstudio-init 
+        - setup-appstudio-init
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for policy-code-reviews-check"  
+            #!/usr/bin/env bash
+            echo "This is a placeholder for policy-code-reviews-check"
     - name: policy-branch-protection-check
       taskRef:
         name: utils-task
       runAfter:
-        - setup-appstudio-init 
+        - setup-appstudio-init
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for policy-branch-protection-check"   
+            #!/usr/bin/env bash
+            echo "This is a placeholder for policy-branch-protection-check"
     - name: build-placeholder-build-step
       taskRef:
         name: utils-task
       runAfter:
         - build-appstudio-configure-build
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for build-placeholder-build-step"  
+            #!/usr/bin/env bash
+            echo "This is a placeholder for build-placeholder-build-step"
     - name: discovery-create-build-graph
       taskRef:
         name: utils-task
       runAfter:
         - build-placeholder-build-step
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for discovery-create-build-graph"  
+            #!/usr/bin/env bash
+            echo "This is a placeholder for discovery-create-build-graph"
     - name: bill-of-materials-create-build-bom
       taskRef:
         name: utils-task
       runAfter:
         - discovery-create-build-graph
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for bill-of-materials-create-build-bom"   
+            #!/usr/bin/env bash
+            echo "This is a placeholder for bill-of-materials-create-build-bom"
     - name: test-unit-test
       taskRef:
         name: utils-task
       runAfter:
         - build-placeholder-build-step
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for test-unit-test" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for test-unit-test"
     - name: coverage-unit-test-coverage
       taskRef:
         name: utils-task
       runAfter:
         - test-unit-test
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for coverage-unit-test-coverage" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for coverage-unit-test-coverage"
     - name: scan-lint
       taskRef:
         name: utils-task
       runAfter:
         - build-placeholder-build-step
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for scan-lint" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for scan-lint"
     - name: scan-dependency-vulnerability-scan
       taskRef:
         name: utils-task
       runAfter:
         - bill-of-materials-create-build-bom
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for scan-dependency-vulnerability-scan"  
+            #!/usr/bin/env bash
+            echo "This is a placeholder for scan-dependency-vulnerability-scan"
     - name: scan-static-security-test
       taskRef:
         name: utils-task
       runAfter:
         - build-placeholder-build-step
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for scan-static-security-test" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for scan-static-security-test"
     - name: scan-code-smells
       taskRef:
         name: utils-task
       runAfter:
         - build-placeholder-build-step
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for scan-code-smells" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for scan-code-smells"
     - name: policy-provenance-check
       taskRef:
         name: utils-task
       runAfter:
         - bill-of-materials-create-build-bom
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for policy-provenance-check" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for policy-provenance-check"
     - name: policy-cis-checks
       taskRef:
         name: utils-task
       runAfter:
         - bill-of-materials-create-build-bom
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
+            #!/usr/bin/env bash
             echo "This is a placeholder for policy-cis-checks"
     - name: policy-license-check
       taskRef:
@@ -215,18 +215,18 @@ spec:
       runAfter:
         - bill-of-materials-create-build-bom
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for policy-license-check" 
-    - name: package-build-container 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for policy-license-check"
+    - name: package-build-container
       params:
         - name: IMAGE
           value: >-
             $(params.output-image)
         - name: BUILDER_IMAGE
           value: >-
-            registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+            registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
         - name: STORAGE_DRIVER
           value: vfs
         - name: DOCKERFILE
@@ -243,40 +243,40 @@ spec:
           value: "$(tasks.build-appstudio-configure-build.results.buildah-auth-param)"
       runAfter:
         - build-placeholder-build-step
-      taskRef: 
+      taskRef:
         name: buildah
       workspaces:
         - name: source
-          workspace: workspace 
+          workspace: workspace
     - name: discovery-create-output-graph
       taskRef:
         name: utils-task
       runAfter:
         - package-build-container
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for discovery-create-output-graph" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for discovery-create-output-graph"
     - name: bill-of-materials-create-output-bom
       taskRef:
         name: utils-task
       runAfter:
         - discovery-create-output-graph
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for bill-of-materials-create-output-bom" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for bill-of-materials-create-output-bom"
     - name: sign-artifacts-build
       taskRef:
         name: utils-task
       runAfter:
         - bill-of-materials-create-output-bom
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
+            #!/usr/bin/env bash
             echo "This is a placeholder for sign-artifacts-build"
     - name: publish-push-to-quay
       taskRef:
@@ -284,19 +284,19 @@ spec:
       runAfter:
         - sign-artifacts-build
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for publish-push-to-quay" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for publish-push-to-quay"
     - name: scan-twistlock
       taskRef:
         name: utils-task
       runAfter:
         - publish-push-to-quay
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
+            #!/usr/bin/env bash
             echo "This is a placeholder for scan-twistlock"
     - name: provision-provision-dev
       taskRef:
@@ -304,10 +304,10 @@ spec:
       runAfter:
         - package-build-container
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for provision-provision-dev" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for provision-provision-dev"
     - name: deploy-deploy-in-dev
       taskRef:
         name: utils-task
@@ -315,39 +315,39 @@ spec:
         - publish-push-to-quay
         - provision-provision-dev
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for deploy-deploy-in-dev" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for deploy-deploy-in-dev"
     - name: verify-deployment-verify-dev-deployment
       taskRef:
         name: utils-task
       runAfter:
         - deploy-deploy-in-dev
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for verify-deployment-verify-dev-deployment" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for verify-deployment-verify-dev-deployment"
     - name: test-acceptance-test
       taskRef:
         name: utils-task
       runAfter:
         - verify-deployment-verify-dev-deployment
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
-            echo "This is a placeholder for test-acceptance-test" 
+            #!/usr/bin/env bash
+            echo "This is a placeholder for test-acceptance-test"
     - name: scan-dynamic-security-test
       taskRef:
         name: utils-task
       runAfter:
         - verify-deployment-verify-dev-deployment
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
+            #!/usr/bin/env bash
             echo "This is a placeholder for scan-dynamic-security-test"
     - name: cleanup-deprovision-dev
       taskRef:
@@ -357,39 +357,39 @@ spec:
         - scan-twistlock
         - test-acceptance-test
       params:
-        - name: SCRIPT 
+        - name: SCRIPT
           value: |
-            #!/usr/bin/env bash 
+            #!/usr/bin/env bash
             echo "This is a placeholder for cleanup-deprovision-dev"
     - name: record-results-show-summary
       runAfter:
         - cleanup-deprovision-dev
       taskRef:
         name: summary
-      params: 
+      params:
       - name: pipeline-run-name
         value: "$(context.pipelineRun.name)"
       - name: git-url
         value: "$(params.git-url)"
       - name: image-url
-        value: $(params.output-image)     
-    - name: message-slack-summary      
+        value: $(params.output-image)
+    - name: message-slack-summary
       when:
-      - input: $(params.slack-webhook) 
+      - input: $(params.slack-webhook)
         operator: notin
         values: [""]
       runAfter:
         - record-results-show-summary
       taskRef:
         name: utils-task
-      params: 
-      - name: SCRIPT 
+      params:
+      - name: SCRIPT
         value: |
-          #!/usr/bin/env bash 
-          echo "This is a placeholder for message-slack-summary"  
+          #!/usr/bin/env bash
+          echo "This is a placeholder for message-slack-summary"
   workspaces:
     - name: workspace
     - name: registry-auth
       optional: true
-    - name: git-auth 
+    - name: git-auth
       optional: true

--- a/tasks/buildah.yaml
+++ b/tasks/buildah.yaml
@@ -3,8 +3,8 @@ kind: Task
 metadata:
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
-    tekton.dev/tags: image-build   
-  name: buildah 
+    tekton.dev/tags: image-build
+  name: buildah
 spec:
   description: |-
     Buildah task builds source into a container image and then pushes it to a container registry.
@@ -13,7 +13,7 @@ spec:
   - description: Reference of the image buildah will produce.
     name: IMAGE
     type: string
-  - default: registry.redhat.io/rhel8/buildah@sha256:e19cf23d5f1e0608f5a897f0a50448beb9f8387031cca49c7487ec71bd91c4d3
+  - default: registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string

--- a/tasks/s2i-java.yaml
+++ b/tasks/s2i-java.yaml
@@ -4,8 +4,8 @@ metadata:
   annotations:
     tekton.dev/displayName: s2i java
     tekton.dev/pipelines.minVersion: "0.19"
-    tekton.dev/tags: s2i, java, workspace 
-  name: s2i-java 
+    tekton.dev/tags: s2i, java, workspace
+  name: s2i-java
 spec:
   description: s2i-java task clones a Git repository and builds and pushes a container image using S2I and a Java builder image.
   params:
@@ -36,7 +36,7 @@ spec:
   - description: Location of the repo where image has to be pushed
     name: IMAGE
     type: string
-  - default: registry.redhat.io/rhel8/buildah@sha256:e19cf23d5f1e0608f5a897f0a50448beb9f8387031cca49c7487ec71bd91c4d3
+  - default: registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string

--- a/tasks/s2i-nodejs.yaml
+++ b/tasks/s2i-nodejs.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     tekton.dev/displayName: s2i nodejs
     tekton.dev/pipelines.minVersion: "0.19"
-    tekton.dev/tags: s2i, nodejs, workspace  
+    tekton.dev/tags: s2i, nodejs, workspace
   name: s2i-nodejs
 spec:
   description: s2i-nodejs task clones a Git repository and builds and pushes a container image using S2I and a nodejs builder image.
@@ -24,7 +24,7 @@ spec:
   - description: Location of the repo where image has to be pushed
     name: IMAGE
     type: string
-  - default: registry.redhat.io/rhel8/buildah@sha256:e19cf23d5f1e0608f5a897f0a50448beb9f8387031cca49c7487ec71bd91c4d3
+  - default: registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string


### PR DESCRIPTION
This aims at having
- a recent image, supporting automatic setting of [OCI standard annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) for base images
- references consistent across Tasks and Pipelines
- manifest-list used
- an image based on UBI8 rather than RHEL8: (no redistribution allowed of RHEL according to EULA)
- published on registry.access.redhat.com (unauthenticated) instead of registry.redhat.io (authenticated) due to the above

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>