### PR TITLE
Set git-auth workspace only on git-clone task

### DIFF
--- a/pipelines/devfile-build.yaml
+++ b/pipelines/devfile-build.yaml
@@ -38,8 +38,6 @@ spec:
           workspace: workspace
         - name: registry-auth
           workspace: registry-auth
-        - name: git-auth
-          workspace: git-auth
     - name: clone-repository
       runAfter:
         -  appstudio-init
@@ -53,6 +51,8 @@ spec:
       workspaces:
         - name: output
           workspace: workspace
+        - name: basic-auth
+          workspace: git-auth
     - name: analyze-devfile
       runAfter:
         - clone-repository
@@ -75,8 +75,6 @@ spec:
           workspace: workspace
         - name: registry-auth
           workspace: registry-auth
-        - name: git-auth
-          workspace: git-auth
     - name: build-container
       params:
         - name: IMAGE

--- a/pipelines/docker-build.yaml
+++ b/pipelines/docker-build.yaml
@@ -38,8 +38,6 @@ spec:
           workspace: workspace
         - name: registry-auth
           workspace: registry-auth
-        - name: git-auth
-          workspace: git-auth
     - name: clone-repository
       when:
       - input: $(tasks.appstudio-init.results.exists)
@@ -57,6 +55,8 @@ spec:
       workspaces:
         - name: output
           workspace: workspace
+        - name: basic-auth
+          workspace: git-auth
     - name: appstudio-configure-build
       runAfter:
         - clone-repository
@@ -71,8 +71,6 @@ spec:
           workspace: workspace
         - name: registry-auth
           workspace: registry-auth
-        - name: git-auth
-          workspace: git-auth
     - name: build-container
       params:
         - name: IMAGE

--- a/pipelines/java-builder.yaml
+++ b/pipelines/java-builder.yaml
@@ -44,8 +44,6 @@ spec:
           workspace: workspace
         - name: registry-auth
           workspace: registry-auth
-        - name: git-auth
-          workspace: git-auth
     - name: git-clone
       when:
       - input: $(tasks.appstudio-init.results.exists)
@@ -78,6 +76,8 @@ spec:
       workspaces:
         - name: output
           workspace: workspace
+        - name: basic-auth
+          workspace: git-auth
     - name: appstudio-configure-build
       runAfter:
         - git-clone
@@ -88,8 +88,6 @@ spec:
           workspace: workspace
         - name: registry-auth
           workspace: registry-auth
-        - name: git-auth
-          workspace: git-auth
     - name: s2i-java
       runAfter:
         - appstudio-configure-build

--- a/pipelines/nodejs-builder.yaml
+++ b/pipelines/nodejs-builder.yaml
@@ -67,8 +67,6 @@ spec:
           workspace: workspace
         - name: registry-auth
           workspace: registry-auth
-        - name: git-auth
-          workspace: git-auth
     - name: appstudio-configure-build
       runAfter:
         - git-clone
@@ -77,10 +75,6 @@ spec:
       workspaces:
         - name: source
           workspace: workspace
-        - name: registry-auth
-          workspace: registry-auth
-        - name: git-auth
-          workspace: git-auth
     - name: s2i-nodejs
       params:
         - name: VERSION
@@ -133,6 +127,8 @@ spec:
       workspaces:
         - name: output
           workspace: workspace
+        - name: basic-auth
+          workspace: git-auth
     - name: show-summary
       runAfter:
         - s2i-nodejs

--- a/pipelines/prototype-build-compliance.yaml
+++ b/pipelines/prototype-build-compliance.yaml
@@ -40,10 +40,6 @@ spec:
       workspaces:
         - name: source
           workspace: workspace
-        - name: registry-auth
-          workspace: registry-auth
-        - name: git-auth
-          workspace: git-auth
     - name: source-clone-repository
       runAfter:
         - setup-appstudio-init
@@ -57,6 +53,8 @@ spec:
       workspaces:
         - name: output
           workspace: workspace
+        - name: basic-auth
+          workspace: git-auth
     - name: build-appstudio-configure-build
       runAfter:
         - source-clone-repository
@@ -67,8 +65,6 @@ spec:
           workspace: workspace
         - name: registry-auth
           workspace: registry-auth
-        - name: git-auth
-          workspace: git-auth
     - name: secret-detection-detect-secrets
       taskRef:
         name: utils-task

--- a/tasks/configure-build.yaml
+++ b/tasks/configure-build.yaml
@@ -10,14 +10,10 @@ spec:
       description: docker config location
     - name: buildah-auth-param
       description: pass this to the build optional params to conifigure secrets
-    - name: git-auth
-      description: git for registry.  
   workspaces:
     - name: source
       optional: true
     - name: registry-auth
-      optional: true
-    - name: git-auth 
       optional: true
   steps:
     - name: appstudio-configure-build  
@@ -43,11 +39,4 @@ spec:
           echo -n " " > /tekton/results/registry-auth  
           echo -n " " > /tekton/results/buildah-auth-param
           echo 
-        fi
-
-        if [ -f "/workspace/git-auth/.gitconfig" ]; then 
-          echo
-          echo "Git Auth found /workspace/git-auth/.gitconfig"
-          echo -n "/workspace/git-auth/.gitconfig" >  /tekton/results/git-auth  
-          echo
         fi

--- a/tasks/init.yaml
+++ b/tasks/init.yaml
@@ -15,14 +15,10 @@ spec:
       description: true if exists false otherwise 
     - name: registry-auth
       description: docker config location
-    - name: git-auth
-      description: git for registry.  
   workspaces:
     - name: source
       optional: true
     - name: registry-auth
-      optional: true
-    - name: git-auth 
       optional: true
   steps:
     - name: appstudio-init  


### PR DESCRIPTION
Fix of private repo cloning. Using feature of git-clone task directly.
No interaction with other steps.