### PR TITLE
Allow to use custom registry secret for s2i builds

### DIFF
--- a/pipelines/java-builder.yaml
+++ b/pipelines/java-builder.yaml
@@ -107,6 +107,8 @@ spec:
         - name: BUILDER_IMAGE
           value: >-
             registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
+        - name: PUSH_EXTRA_ARGS
+          value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
       taskRef:
         name: s2i-java
       workspaces:

--- a/pipelines/nodejs-builder.yaml
+++ b/pipelines/nodejs-builder.yaml
@@ -94,6 +94,8 @@ spec:
         - name: BUILDER_IMAGE
           value: >-
             registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
+        - name: PUSH_EXTRA_ARGS
+          value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
       runAfter:
         - appstudio-configure-build
       taskRef:

--- a/tasks/s2i-java.yaml
+++ b/tasks/s2i-java.yaml
@@ -40,6 +40,11 @@ spec:
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
+  # Additional parameter for auth configuration
+  - default: ""
+    description: Extra parameters passed for the push command when pushing images.
+    name: PUSH_EXTRA_ARGS
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -116,14 +121,15 @@ spec:
     - mountPath: /gen-source
       name: gen-source
     workingDir: /gen-source
-  - command:
-    - buildah
-    - push
-    - --storage-driver=vfs
-    - --tls-verify=$(params.TLSVERIFY)
-    - --digestfile=$(workspaces.source.path)/image-digest
-    - $(params.IMAGE)
-    - docker://$(params.IMAGE)
+  - script: >
+      buildah
+      push
+      --storage-driver=vfs
+      --tls-verify=$(params.TLSVERIFY)
+      --digestfile=$(workspaces.source.path)/image-digest
+      $(params.PUSH_EXTRA_ARGS)
+      $(params.IMAGE)
+      docker://$(params.IMAGE)
     image: $(params.BUILDER_IMAGE)
     name: push
     resources: {}

--- a/tasks/s2i-nodejs.yaml
+++ b/tasks/s2i-nodejs.yaml
@@ -28,6 +28,11 @@ spec:
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
+  # Additional parameter for auth configuration
+  - default: ""
+    description: Extra parameters passed for the push command when pushing images.
+    name: PUSH_EXTRA_ARGS
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -71,14 +76,15 @@ spec:
     - mountPath: /gen-source
       name: gen-source
     workingDir: /gen-source
-  - command:
-    - buildah
-    - push
-    - --storage-driver=vfs
-    - --tls-verify=$(params.TLSVERIFY)
-    - --digestfile=$(workspaces.source.path)/image-digest
-    - $(params.IMAGE)
-    - docker://$(params.IMAGE)
+  - script: >
+      buildah
+      push
+      --storage-driver=vfs
+      --tls-verify=$(params.TLSVERIFY)
+      --digestfile=$(workspaces.source.path)/image-digest
+      $(params.PUSH_EXTRA_ARGS)
+      $(params.IMAGE)
+      docker://$(params.IMAGE)
     image: $(params.BUILDER_IMAGE)
     name: push
     resources: {}


### PR DESCRIPTION
Use the same way for s2i build as for buildah. Allow to define push
secret for each pipelinerun.