### PR TITLE
Avoid performance issues when inspecting repo

### DIFF
--- a/appstudio-utils/util-scripts/image-exists.sh
+++ b/appstudio-utils/util-scripts/image-exists.sh
@@ -4,7 +4,7 @@
 # you need to pass a url (param1) and destination directory (param2) if running on shell
 # or /tekton/results if running in tekton
 echo "Image: $1"    
-DIGEST=$(skopeo inspect "docker://$1" 2> err | jq '.Digest')
+DIGEST=$(skopeo inspect --no-tags "docker://$1" 2> err | jq '.Digest')
 if [ -z "$DIGEST" ]
 then
   echo "Exists: false"    

--- a/tasks/sanity-label-check.yaml
+++ b/tasks/sanity-label-check.yaml
@@ -11,7 +11,7 @@ spec:
   steps:
     - name: inspect-image
       image: quay.io/redhat-appstudio/hacbs-test:stable
-      script: "skopeo inspect docker://$(inputs.params.sourceImage) > /tekton/home/image_inspect.json"
+      script: "skopeo inspect --no-tags docker://$(inputs.params.sourceImage) > /tekton/home/image_inspect.json"
     - name: basic-sanity-checks-required-labels
       image: quay.io/redhat-appstudio/hacbs-test:stable
       command:


### PR DESCRIPTION
By default, `skopeo inspect` will fetch a list of all the tags in the
repository. This can be an expensive operation if the repository has a
large amount of tags. A registry may paginate the results causing skopeo
to trigger an unbounded amount of queries to the registry.

Use the `--no-tags` parameter to avoid fetching the tags altogether
since they're not used.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>