### PR TITLE
Add Pipelines as Code CI

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: build-definitions-pull-request
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "pull_request"
+    pipelinesascode.tekton.dev/on-target-branch: "main"
+    pipelinesascode.tekton.dev/task: "git-clone"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  params:
+    - name: repo_url
+      value: "{{ repo_url }}"
+    - name: revision
+      value: "{{ revision }}"
+  pipelineSpec:
+    params:
+      - name: repo_url
+      - name: revision
+    workspaces:
+      - name: workspace
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: workspace
+        params:
+          - name: url
+            value: $(params.repo_url)
+          - name: revision
+            value: $(params.revision)
+      - name: noop-task
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: workspace
+        taskSpec:
+          workspaces:
+            - name: source
+          steps:
+            - name: noop-task
+              image: registry.access.redhat.com/ubi8/ubi-micro:8.4
+              workingDir: $(workspaces.source.path)
+              script: |
+                exit 0
+  workspaces:
+    - name: workspace
+      persistentVolumeClaim:
+        claimName: app-studio-default-workspace
+      subPath: build-definitions-{{ revision }}

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: build-definitions-bundle-push
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "push"
+    pipelinesascode.tekton.dev/on-target-branch: "main"
+    pipelinesascode.tekton.dev/task: "git-clone"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  params:
+    - name: git-url
+      value: "{{ repo_url }}"
+    - name: revision
+      value: "{{ revision }}"
+  pipelineSpec:
+    params:
+      - description: 'Source Repository URL'
+        name: git-url
+        type: string
+      - description: 'Revision of the Source Repository'
+        name: revision
+        type: string
+    tasks:
+      - name: clone-repository
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: "$(params.revision)"
+        taskRef:
+          kind: ClusterTask
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: workspace
+      - name: build-bundles
+        params:
+          - name: revision
+            value: "$(params.revision)"
+        runAfter:
+          - clone-repository
+        workspaces:
+          - name: source
+            workspace: workspace
+        taskSpec:
+          params:
+            - name: revision
+              type: string
+          steps:
+            - name: build-bundles
+              image: quay.io/redhat-appstudio/appstudio-utils:748fdc355f0595119e5dd7aa08722288df2ed1aa
+              workingDir: $(workspaces.source.path)
+              script: |
+                #!/usr/bin/env bash
+                MY_QUAY_USER=redhat-appstudio BUILD_TAG=$(params.revision) SKIP_BUILD=1 SKIP_INSTALL=1 hack/build-and-push.sh
+          workspaces:
+            - name: source
+      - name: update-infra-repo
+        runAfter:
+          - build-bundles
+        params:
+          - name: BASE_IMAGE
+            value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b1598a980f17d5f5d3d8a4b11ab4f5184677f7f17ad302baa36bd3c1
+          - name: GIT_USER_NAME
+            value: Build deployer
+          - name: GIT_SCRIPT
+            value: |
+              ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+              git clone https://github.com/redhat-appstudio/infra-deployments
+              cd infra-deployments
+              git remote add push git@github.com:redhat-appstudio-mr-creation/infra-deployments.git
+              git checkout -b build-definitions-update
+              BUNDLE=quay.io/redhat-appstudio/build-templates-bundle
+              for file in $(git grep -l $BUNDLE); do
+                sed -i "s|\($BUNDLE\):.*|\1:$(params.revision)|g" $file
+              done
+              git commit -a -m "Build definitions update" -m "from $(params.git-url) $(params.revision)"
+              git push -f --set-upstream push build-definitions-update
+
+              set +x
+              curl -H "Authorization: token $(cat /root/.ssh/token)" \
+                -X POST \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/redhat-appstudio/infra-deployments/pulls \
+                -d '{"head":"redhat-appstudio-mr-creation:build-definitions-update","base":"main","title":"Build definitions update"}'
+        taskRef:
+          kind: ClusterTask
+          name: git-cli
+        workspaces:
+          - name: source
+            workspace: workspace
+          - name: ssh-directory
+            workspace: deploy-key
+        taskRef:
+          kind: ClusterTask
+          name: git-cli
+        workspaces:
+          - name: source
+            workspace: workspace
+          - name: ssh-directory
+            workspace: deploy-key
+    workspaces:
+      - name: workspace
+      - name: deploy-key
+  serviceAccountName: pipeline
+  workspaces:
+    - name: workspace
+      persistentVolumeClaim:
+        claimName: app-studio-default-workspace
+      subPath: build-definitions-bundle-{{ revision }}
+    - name: deploy-key
+      secret:
+        secretName: build-definitions-deploy-key
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: build-definitions-appstudio-utils-push
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "push"
+    pipelinesascode.tekton.dev/on-target-branch: "main"
+    pipelinesascode.tekton.dev/task: "git-clone"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  params:
+    - name: git-url
+      value: "{{ repo_url }}"
+    - name: revision
+      value: "{{ revision }}"
+    - name: output-image
+      value: "quay.io/redhat-appstudio/appstudio-utils:{{ revision }}"
+    - name: path-context
+      value: appstudio-utils
+  pipelineRef:
+    name: docker-build
+    bundle: quay.io/redhat-appstudio/build-templates-bundle:b2cb5d5b21dc59d172379e639b336533bd8a8bf6
+  workspaces:
+    - name: workspace
+      persistentVolumeClaim:
+        claimName: app-studio-default-workspace
+      subPath: build-definitions-appstudio-utils-{{ revision }}


### PR DESCRIPTION
This PR moves the CI previously defined in the [infra-deployments](https://github.com/redhat-appstudio/infra-deployments/blob/fd658a632b1c4cce67eaaafa6becc26260017ac9/components/build/.tekton/trigger-template.yaml) repository to this repository, while also adapting it to be run on top of Pipelines as Code.