### PR TITLE
Add opa cli tool to appstudio-utils docker image

### DIFF
--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -5,8 +5,11 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/lat
 RUN curl -L https://github.com/sigstore/cosign/releases/download/v1.5.1/cosign-linux-amd64 -o /usr/bin/cosign && chmod +x /usr/bin/cosign
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.21.0/tkn-linux-amd64-0.21.0.tar.gz | tar -xz --no-same-owner -C /usr/bin/
 RUN curl -L https://github.com/sigstore/rekor/releases/download/v0.5.0/rekor-cli-linux-amd64 -o /usr/bin/rekor-cli && chmod +x /usr/bin/rekor-cli
+RUN curl -L https://github.com/open-policy-agent/opa/releases/download/v0.39.0/opa_linux_amd64_static -o /usr/bin/opa && chmod +x /usr/bin/opa
+
 RUN dnf -y --setopt=tsflags=nodocs install \
     jq \
     https://github.com/tektoncd/cli/releases/download/v0.22.0/tektoncd-cli-0.22.0_Linux-64bit.rpm && \
     dnf clean all
+
 COPY util-scripts /appstudio-utils/util-scripts


### PR DESCRIPTION
OPA is the tool used for for validating rego policies such as the
ones that will be used by the Enterprise Contract to validate
pipeline runs.

It's not clear yet whether the final version of the Enterprise
Contract tasks will use this base image, but there's a reasonable
chance they will, and either way it seems like this is generally
useful tool to add alongside the others.

See also:
* https://github.com/open-policy-agent/opa/releases
* https://www.openpolicyagent.org/
* https://issues.redhat.com/browse/HACBS-233
* https://issues.redhat.com/browse/HACBS-235