### PR TITLE
Add extra tools to utils image for contract

### DIFF
--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -1,12 +1,19 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
+RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/bin/jq && chmod +x /usr/bin/jq
 RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.9/openshift-client-linux.tar.gz | tar -xz -C /usr/bin/
 RUN curl -L https://github.com/sigstore/cosign/releases/download/v1.5.1/cosign-linux-amd64 -o /usr/bin/cosign && chmod +x /usr/bin/cosign
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.21.0/tkn-linux-amd64-0.21.0.tar.gz | tar -xz --no-same-owner -C /usr/bin/
 RUN curl -L https://github.com/sigstore/rekor/releases/download/v0.5.0/rekor-cli-linux-amd64 -o /usr/bin/rekor-cli && chmod +x /usr/bin/rekor-cli
+
+RUN curl -L https://github.com/open-policy-agent/opa/releases/download/v0.39.0/opa_linux_amd64_static -o /usr/bin/opa && \
+    echo 19a24f51d954190c02aafeac5867c9add286c6ab12ea85b3d8d348c98d633319 /usr/bin/opa | sha256sum --check && \
+    chmod +x /usr/bin/opa
+
 RUN dnf -y --setopt=tsflags=nodocs install \
-    jq \
-    https://github.com/tektoncd/cli/releases/download/v0.22.0/tektoncd-cli-0.22.0_Linux-64bit.rpm && \
-    dnf clean all
+    git \
+    https://github.com/tektoncd/cli/releases/download/v0.22.0/tektoncd-cli-0.22.0_Linux-64bit.rpm \
+    && dnf clean all
+
 COPY util-scripts /appstudio-utils/util-scripts


### PR DESCRIPTION
* OPA cli tool: Used for for validating rego policies such
  as the ones that will be used by the Enterprise Contract to
  validate pipeline runs. Also verifies the checksum because
  it seems like a good idea.

* Newer jq: Install it directly rather than with dnf. I was hitting
  a weird jq problem when running the contract fetch scripts (see
  upcoming commits) in the container and it went away when I
  upgraded to jq-1.6. The dnf installed version was jq-1.5.

* Git: I want to use git to checkout rego policy files.

See also:
- https://github.com/open-policy-agent/opa/releases
- https://www.openpolicyagent.org/
- https://issues.redhat.com/browse/HACBS-233
- https://issues.redhat.com/browse/HACBS-235