### PR TITLE
Add new task verify-enterprise-contract

### DIFF
--- a/appstudio-utils/util-scripts/verify-attestation-with-policy.sh
+++ b/appstudio-utils/util-scripts/verify-attestation-with-policy.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Verifies the given attestation passes the given rego policy
+# usage:
+#   verify-attestation-with-policy.sh <attestation file> <output file> <passed file>
+# where:
+#   <in-toto file> file containing the in-toto attestation to be verified
+#   <output file>  where to store the result in JSON format
+#   <passed file>  where to store the overall passing result
+set -euo pipefail
+
+in_toto="$1"
+output="$2"
+passed="$3"
+
+# An in-toto attestation is authenticated metadata about one or more software
+# artifacts, as per the SLSA Attestation Model:
+# https://github.com/slsa-framework/slsa/blob/main/controls/attestations.md
+# It is assumed at this point that the in-toto attestation has been fetched
+# securely and all signature checks have passed, e.g. via cosign. Therefore,
+# a policy is only applied to the embedded SLSA attestation.
+#
+# NOTE: By using "-s", jq will wrap the object in an array. If there is more
+# than one attestation, each will be a distinct object in the array. This is
+# convenient because "cosign verify-attestation" may output a stream containing
+# multiple objects - not wrapped in an array.
+attestations=$(jq -s '[.[].payload | @base64d | fromjson]' ${in_toto})
+
+cd $(dirname $0)
+source lib/fetch.sh
+
+# TODO: If git clone fails, the task does not fail - fix that!
+./fetch-ec-policies.sh
+
+save-policy-config
+
+title Attestations
+# Show a shortened version of the attestations to avoid excessive logging
+echo -n "$attestations" | jq -r '.[].predicate = "..."'
+# Save the attestations for opa processing
+echo -n "${attestations}" > $(json-data-file attestations)
+
+title Violations
+./check-ec-policy.sh | tee "${output}"
+
+title "Passed?"
+./ec-pass-fail.sh "${output}" | tee "${passed}"

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -50,11 +50,8 @@ for TASK in $SCRIPTDIR/../tasks/*.yaml; do
         rm $TASK_TEMP
     fi
     # Replace appstidio-utils placeholder by newly build appstudio-utils image
-    if yq -M -e e ".spec.steps[0].image==\"appstudio-utils\"" $TASK &>/dev/null; then
-        yq -M e ".spec.steps[0].image=\"$APPSTUDIO_UTILS_IMG\"" $TASK >> $TASK_TEMP
-    else
-        cat $TASK >> $TASK_TEMP
-    fi
+    yq -M e ".spec.steps[] |= select(.image == \"appstudio-utils\").image=\"$APPSTUDIO_UTILS_IMG\"" \
+        $TASK >> $TASK_TEMP
     echo --- >> $TASK_TEMP
     REF="$APPSTUDIO_TASKS_REPO:$BUILD_TAG-$PART"
     for file in $PIPELINE_TEMP/*.yaml; do

--- a/hack/start-verify-ec-task.sh
+++ b/hack/start-verify-ec-task.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/bash
+#
+# Rough hacking guide:
+#
+#  * Commit your changes as required. (No need to push to GitHub.)
+#
+#  * Push a new base image and new task bundles like this:
+#      env MY_QUAY_USER=$USER BUILD_TAG=$(git rev-parse HEAD) ./build-and-push.sh
+#
+#    (Assumes you have the required repos created in quay.io, you're signed in there with podman,
+#    and your quay.io username matches $USER)
+#
+#  * Create a Secret in the current namespace containing the cosign.pub key. This should be a
+#    partial copy of the Secret tekton-chains/signing-secrets. Only the public key should be
+#    included in this Secret. By default the name of the Secret is 'cosign-public-key', set
+#    the PUBLIC_KEY_SECRET environment variable to use a different name. For example:
+#    oc -n tekton-chains get secret signing-secrets -o json | jq '.data."cosign.pub" | @base64d' -r > cosign.pub
+#    oc create secret generic cosign-public-key --from-file=cosign.pub
+#
+#  * Make sure you have an image that has already been signed by Chains.
+#
+#  * (Optional) Modify the POLICY_REPO and POLICY_REPO_REF params below as required.
+#
+#  * Run this script:
+#      ./start-verify-ec-task.sh <image-ref>
+#    where <image-ref> is a valid image reference, e.g. quay.io/spam/bacon@sha256:...
+set -euo pipefail
+
+IMAGE_REF="$1"
+
+PUBLIC_KEY_SECRET="${PUBLIC_KEY_SECRET:-cosign-public-key}"
+
+NAMESPACE="$(oc get sa default -o jsonpath='{.metadata.namespace}')"
+
+#
+# Determine which bundle we should use
+#
+# Todo:
+# - How to discover BUNDLE_NUMBER so it isn't hard coded?
+# - Make this generally more robust
+#
+DEFAULT_BUNDLE=$(
+  # ./build-and-push.sh creates this cm in the current project
+  # and iiuc it overrides the default in `-n build-templates`
+  oc get cm build-pipelines-defaults --output=jsonpath='{.data.default_build_bundle}' )
+BUNDLE_NUMBER=2
+USE_BUNDLE="$(
+  echo "$DEFAULT_BUNDLE" | sed 's/build-templates-bundle/appstudio-tasks/' )-$BUNDLE_NUMBER"
+echo "Using bundle $USE_BUNDLE for task"
+
+#
+# Create the taskrun
+#
+# Todo:
+# - Test it with the default bundle
+# - Would it be nicer to use `tkn start`?
+#
+echo "apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: verify-enterprise-contract-
+spec:
+  taskRef:
+    name: verify-enterprise-contract
+    bundle: $USE_BUNDLE
+  params:
+    - name: IMAGE_REF
+      value: $IMAGE_REF
+
+    - name: PUBLIC_KEY
+      value: k8s://$NAMESPACE/$PUBLIC_KEY_SECRET
+
+    # Modify these defaults as required
+    #- name: POLICY_REPO
+    #  value: https://github.com/hacbs-contract/ec-policies.git
+    #- name: POLICY_REPO_REF
+    #  value: main
+" | oc create -f -
+
+#
+# Watch the taskrun that was created
+#
+tkn tr logs -f $( tkn tr describe --last -o name | sed 's|.*/||' )

--- a/tasks/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: verify-enterprise-contract
+  annotations:
+    tekton.dev/displayName: Verify Enterprise Contract
+    tekton.dev/pipelines.minVersion: "0.19"
+    tekton.dev/tags: cosign, chains, signature, opa
+  labels:
+    app.kubernetes.io/version: "0.1"
+
+spec:
+  description: Verify the enterprise contract is met
+  params:
+    - name: IMAGE_REF
+      type: string
+      description: Image reference to verify
+
+    - name: PUBLIC_KEY
+      type: string
+      description: >-
+        Public key used to verify signatures. Must be a valid k8s cosign
+        reference, e.g. k8s://my-space/my-secret where my-secret contains
+        the expected cosign.pub attribute.
+
+    - name: COSIGN_EXPERIMENTAL
+      type: string
+      description: Control transparency log lookups. Set to "1" to enabled it.
+      default: "1"
+
+    - name: REKOR_HOST
+      type: string
+      description: Rekor host for transparency log lookups
+      default: https://rekor.sigstore.dev
+
+    # TODO: We should probably use a bundle URL for this:
+    # https://www.openpolicyagent.org/docs/v0.12.2/bundles/#bundle-file-format
+    # Or an OCI image:
+    # https://github.com/open-policy-agent/opa/issues/1413
+    - name: POLICY_REPO
+      type: string
+      description: Git url for rego policies
+      default: https://github.com/hacbs-contract/ec-policies.git
+
+    - name: POLICY_REPO_REF
+      type: string
+      description: Git sha, branch or tag in git repo for rego policies
+      default: main
+
+  results:
+    - name: OUTPUT
+      description: A list of policy violations
+    - name: PASSED
+      description: A string formatted boolean, either true or false
+
+  steps:
+    - name: verify-image-signature
+      image: appstudio-utils
+      command: [cosign]
+      args:
+        - verify
+        - "--key=$(params.PUBLIC_KEY)"
+        - "--rekor-url=$(params.REKOR_HOST)"
+        - $(params.IMAGE_REF)
+      env:
+        # TODO: What if the workspace is not set? Seems to have no effect:
+        #   https://issues.redhat.com/browse/HACBS-316
+        # TODO: Is it SSL_CERT_DIR or SSL_CERTS_DIR ?
+        - name: SSL_CERT_DIR
+          value: $(workspaces.sslcertdir.path)
+        - name: COSIGN_EXPERIMENTAL
+          value: $(params.COSIGN_EXPERIMENTAL)
+      volumeMounts:
+        - name: shared
+          mountPath: /shared
+
+    - name: verify-image-attestation-signature
+      image: appstudio-utils
+      command: [cosign]
+      args:
+        - verify-attestation
+        - "--key=$(params.PUBLIC_KEY)"
+        - "--rekor-url=$(params.REKOR_HOST)"
+        - "--output-file=/shared/image-in-toto-attestation.json"
+        - $(params.IMAGE_REF)
+      env:
+        # TODO: What if the workspace is not set? Seems to have no effect:
+        #   https://issues.redhat.com/browse/HACBS-316
+        # TODO: Is it SSL_CERT_DIR or SSL_CERTS_DIR ?
+        - name: SSL_CERT_DIR
+          value: $(workspaces.sslcertdir.path)
+        - name: COSIGN_EXPERIMENTAL
+          value: $(params.COSIGN_EXPERIMENTAL)
+      volumeMounts:
+        - name: shared
+          mountPath: /shared
+
+    - name: verify-attestation-with-policy
+      image: appstudio-utils
+      command: [/appstudio-utils/util-scripts/verify-attestation-with-policy.sh]
+      args:
+        - /shared/image-in-toto-attestation.json
+        - $(results.OUTPUT.path)
+        - $(results.PASSED.path)
+      env:
+        - name: EC_WORK_DIR
+          value: /shared/ec-work-dir
+        - name: POLICY_REPO_REF
+          value: $(params.POLICY_REPO_REF)
+        - name: POLICY_REPO
+          value: $(params.POLICY_REPO)
+      volumeMounts:
+        - name: shared
+          mountPath: /shared
+
+  workspaces:
+    - name: sslcertdir
+      optional: true
+
+  volumes:
+    - name: shared
+      emptyDir: {}


### PR DESCRIPTION
Notable differences from the existing enterprise-contract.yaml task:

* The only data being validated is the image attestation. No data
  data is fetched from the cluster.
* No support for inline public key. The parameter PUBLIC_KEY is used
  as is. I didn't want to wrap cosign in a bash script just to support
  this. Realistically, the key is going to be stored in the cluster
  anyways, just use that. Do note that the Secret for the key does not
  have to be the same one used by Chains. In fact, users of this
  task are expected to create their own Secret containing just the
  cosign.pub key in their own namespaces.
* The whole enterprise contract is verified by this task. This is the
  same approach used by the existing enterprise-contract.yaml task,
  but differs from the cosign-verify*.yaml tasks.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>