### PR TITLE
PR E2E test

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -15,10 +15,13 @@ spec:
       value: "{{ repo_url }}"
     - name: revision
       value: "{{ revision }}"
+    - name: e2e_test_namespace
+      value: build-templates-e2e
   pipelineSpec:
     params:
       - name: repo_url
       - name: revision
+      - name: e2e_test_namespace
     workspaces:
       - name: workspace
     tasks:
@@ -44,6 +47,93 @@ spec:
         params:
         - name: args
           value: ["."]
+      - name: build-container
+        runAfter:
+          - yaml-lint-check
+        params:
+          - name: IMAGE
+            value: quay.io/redhat-appstudio/pull-request-builds:build-definitions-utils-{{revision}}
+          - name: CONTEXT
+            value: appstudio-utils
+        taskRef:
+          name: buildah
+        workspaces:
+          - name: source
+            workspace: workspace
+      - name: build-bundles
+        params:
+          - name: revision
+            value: "{{ revision }}"
+          - name: e2e_test_namespace
+            value: $(params.e2e_test_namespace)
+        runAfter:
+          - build-container
+        workspaces:
+          - name: source
+            workspace: workspace
+        taskSpec:
+          params:
+            - name: revision
+              type: string
+            - name: e2e_test_namespace
+              type: string
+          steps:
+            - name: build-bundles
+              image: quay.io/redhat-appstudio/pull-request-builds:build-definitions-utils-{{revision}}
+              workingDir: $(workspaces.source.path)
+              script: |
+                #!/usr/bin/env bash
+                MY_QUAY_USER=redhat-appstudio \
+                TEST_REPO_NAME=pull-request-builds \
+                BUILD_TAG=$(params.revision) \
+                SKIP_BUILD=1 \
+                INSTALL_BUNDLE_NS=$(params.e2e_test_namespace) \
+                hack/build-and-push.sh
+          workspaces:
+            - name: source
+      - name: e2e-test
+        params:
+          - name: e2e_test_namespace
+            value: $(params.e2e_test_namespace)
+        runAfter:
+          - build-bundles
+        taskSpec:
+          params:
+            - name: e2e_test_namespace
+              type: string
+          steps:
+            - name: e2e-test
+              image: quay.io/redhat-appstudio/e2e-tests:latest
+              imagePullPolicy: Always
+              args: [
+                "--ginkgo.focus=build-service-suite",
+                "--ginkgo.progress",
+                "--ginkgo.v",
+                "--ginkgo.no-color"
+              ]
+              env:
+              - name: QUAY_E2E_ORGANIZATION
+                value: redhat-appstudio
+              - name: E2E_APPLICATIONS_NAMESPACE
+                value: "$(params.e2e_test_namespace)"
+    finally:
+      - name: e2e-cleanup
+        params:
+          - name: e2e_test_namespace
+            value: $(params.e2e_test_namespace)
+        taskSpec:
+          params:
+            - name: e2e_test_namespace
+              type: string
+          steps:
+            - name: e2e-cleanup
+              image: quay.io/redhat-appstudio/pull-request-builds:build-definitions-utils-{{revision}}
+              script: |
+                #!/usr/bin/env bash
+                # Perform cleanup of resources created by e2e test run
+                # TODO: Application and Component names should be unique, so the cleanup task doesn't affect other pipelineruns
+                oc delete --ignore-not-found application build-suite-test-application -n $(params.e2e_test_namespace)
+                oc delete --ignore-not-found component build-suite-test-component-git-source -n $(params.e2e_test_namespace)
   workspaces:
     - name: workspace
       persistentVolumeClaim:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Currently a set of utilities are bundled with App Studio in `quay.io/redhat-apps
 Script `hack/build-and-push.sh` creates bundles for pipelines, tasks and create appstudio-utils image. Images are pushed into your quay.io repository. You will need to set `MY_QUAY_USER` to use this feature and be logged into quay.io on your workstation.
 Once you run the `hack/build-and-push.sh` all pipelines will come from your bundle instead of from the default installed by gitops into the cluster.
 
+> **Note**
+>
+> If you're using Mac OS, you need to install [GNU coreutils](https://formulae.brew.sh/formula/coreutils) before running the `hack/build-and-push.sh` script:
+> ```bash
+> brew install coreutils
+> ```
+
+There is an option to push all bundles to a single quay.io repository (this method is used in PR testing). It is used by setting `TEST_REPO_NAME` environment variable. Bundle names are then specified in the container image tag, i.e. `quay.io/<quay-user>/$TEST_REPO_NAME:<bundle-name>-<tag>`
+
 ### Pipelines
 
 The pipelines can be found in the `pipelines` directories.

--- a/hack/util-install-bundle.sh
+++ b/hack/util-install-bundle.sh
@@ -2,14 +2,15 @@
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 BUNDLE=$1
+NAMESPACE=${2:-$(oc project -q)}
 if [  -z "$BUNDLE" ]; then 
     echo "No Bundle Name"
     exit 1 
 fi   
 
-oc create configmap build-pipelines-defaults --from-literal=default_build_bundle=$BUNDLE -o yaml --dry-run=client | oc apply -f-
+oc create configmap build-pipelines-defaults --from-literal=default_build_bundle=$BUNDLE -o yaml --dry-run=client | oc -n "$NAMESPACE" apply -f-
 
-echo "Default Pipelines Configured to come from build-templates : "
+echo "Default Pipelines configured to come from the namespace 'build-templates':"
 oc get cm build-pipelines-defaults -n build-templates -o jsonpath='{.data}{"\n"}'
-echo "Override Pipelines Configured to come from $( oc project --short): "
-oc get cm build-pipelines-defaults -o jsonpath='{.data}{"\n"}'
+echo "Override Pipelines configured to come from the namespace '$NAMESPACE':"
+oc get cm build-pipelines-defaults -n "$NAMESPACE" -o jsonpath='{.data}{"\n"}'


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/PLNSRVCE-149

### What
* updated PR pipeline to build & push bundles to `pull-request-builds` repo
* after bundles are pushed, configmap `build-pipelines-defaults` is updated to point to the pipeline bundle that was built
* E2E tests are triggered - pipeline used in E2E test should be extracted from the pipeline bundle ^

### Blockers
- [x] **[this PR](https://github.com/redhat-appstudio/build-service/pull/4) that will allow E2E tests to use the pipeline bundle defined in the configmap from the same namespace where apps and components are created.**
- [x] [this PR](https://github.com/redhat-appstudio/e2e-tests/pull/47) - allows to run E2E tests in a specific namespace with a service account that has just basic (namespace-scoped) permissions set
- [x] creation of a dockerconfig-type secret `redhat-appstudio-registry-pull-secret` in the same namespace where these tests will run (currently we're using `build-templates` ns)
- [x] creation of a secret containing a value for `GITHUB_TOKEN` env var used in E2E test