### PR TITLE
skipping the hacbs-test.yaml patch for noop.yaml and prototype-build-compliance.yaml

### DIFF
--- a/pipelines/base/noop.yaml
+++ b/pipelines/base/noop.yaml
@@ -6,6 +6,7 @@ metadata:
     "pipelines.openshift.io/used-by": "build-cloud"
     "pipelines.openshift.io/runtime": "generic"
     "pipelines.openshift.io/strategy": "docker" 
+    "skip-hacbs-test": "true"
 spec:
   params:
     - description: 'Source Repository URL'

--- a/pipelines/base/prototype-build-compliance.yaml
+++ b/pipelines/base/prototype-build-compliance.yaml
@@ -6,6 +6,7 @@ metadata:
     "pipelines.openshift.io/used-by": "build-cloud"
     "pipelines.openshift.io/runtime": "generic"
     "pipelines.openshift.io/strategy": "docker"
+    "skip-hacbs-test": "true"
 spec:
   params:
     - description: 'Source Repository URL'

--- a/pipelines/hacbs/kustomization.yaml
+++ b/pipelines/hacbs/kustomization.yaml
@@ -9,3 +9,4 @@ patches:
       group: tekton.dev
       version: v1beta1
       kind: Pipeline
+      labelSelector: skip-hacbs-test != true


### PR DESCRIPTION
Skipping the pipelines/hacbs/hacbs-test.yaml patch for pipelines/base/noop.yaml and pipelines/base/prototype-build-compliance.yaml as the patch checks for the build-container task and the task is not available in noop.yaml and prototype-build-compliance.yaml.