### PR TITLE
Fetch policy configuration from ConfigMap

### DIFF
--- a/appstudio-utils/util-scripts/lib/fetch/cluster.sh
+++ b/appstudio-utils/util-scripts/lib/fetch/cluster.sh
@@ -13,8 +13,17 @@ k8s-save-data() {
   oc get $namespace_opt $kind $name -o json > $file
 }
 
+_policy-config-from-configmap() {
+  oc get configmap ec-policy -o go-template='{{index .data "policy.json"}}' 2>/dev/null
+}
+
+_default-policy-config() {
+  echo '{"non_blocking_checks":["not_useful"]}'
+}
+
 # Placeholder. In future it will likely come from
 # an EnterpriseContractPolicy crd, see HACBS-244
 save-policy-config() {
-  echo '{"non_blocking_checks":["not_useful"]}' | jq > $( json-data-file config policy )
+  # Note: the namespace the task is running in needs to have the ec-policy ConfigMap
+  { _policy-config-from-configmap || _default-policy-config ; } | jq > "$( json-data-file config policy )"
 }


### PR DESCRIPTION
For the policy configuration, namely specifying what rules are
non-blocking we can now provide a ConfigMap named `ec-policy` in the
namespace the task is running in. From the ConfigMap a key with the name
`policy.json` needs to hold the JSON file with the policy configuration.
If the ConfigMap doesn't exist the current fixed value is used as a
fallback.
This will most likely be replaced with a EnterpriseContractPolicy custom
resource in the future.

Ref. https://issues.redhat.com/browse/HACBS-244