### PR TITLE
Don't fail immediately if hacbs test results are missing

### DIFF
--- a/appstudio-utils/util-scripts/fetch-test-data.sh
+++ b/appstudio-utils/util-scripts/fetch-test-data.sh
@@ -15,12 +15,20 @@ source $(dirname $0)/lib/fetch.sh
 
 # search all task runs in a pipeline
 # write output in format $basdir/data/test/$task_name/data.json
+result_found=
 for tr in $( pr-get-tr-names $PR_NAME ); do
   data=$( tr-get-result $tr $TEST_NAME )
   if [[ ! -z "${data}" ]]; then
+      result_found=1
       task_name=$( tr-get-task-name ${tr} )
       echo "${data}" | jq > $( json-data-file test ${task_name} )
   fi
 done
+
+if [[ -z $result_found ]]; then
+  # let's put an an empty hash here to express the the idea
+  # that we looked for test results and found none
+  echo '{}' > $( json-data-file test )
+fi
 
 show-data

--- a/appstudio-utils/util-scripts/lib/fetch.sh
+++ b/appstudio-utils/util-scripts/lib/fetch.sh
@@ -16,6 +16,8 @@ EC_WORK_DIR=${EC_WORK_DIR:-/tmp/ecwork}
 
 DATA_DIR=${DATA_DIR:-"$EC_WORK_DIR/data"}
 POLICIES_DIR=${POLICIES_DIR:-"$EC_WORK_DIR/policies"}
+mkdir -p $DATA_DIR
+mkdir -p $POLICIES_DIR
 
 POLICY_REPO=${POLICY_REPO:-"https://github.com/hacbs-contract/ec-policies.git"}
 POLICY_REPO_REF=${POLICY_REPO_REF:-"main"}


### PR DESCRIPTION
If the pipeline run is missing or doesn't have the expected test
results, we get the following error and the task fails:

    find: '/shared/ec-work-dir/data': No such file or directory

Actually `mkdir -p $DATA_DIR` alone would be enough to avoid the
error, but I thought it would be nice to write something to the data
dir.

JIRA: [HACBS-377](https://issues.redhat.com/browse/HACBS-377)