### PR TITLE
Robust fetching of policies from git

### DIFF
--- a/appstudio-utils/util-scripts/fetch-test-data.sh
+++ b/appstudio-utils/util-scripts/fetch-test-data.sh
@@ -11,24 +11,26 @@ fi
 PR_NAME=$1
 TEST_NAME=$2
 
-source $(dirname $0)/lib/fetch.sh
+source "$(dirname "$0")/lib/fetch.sh"
 
 # search all task runs in a pipeline
 # write output in format $basdir/data/test/$task_name/data.json
 result_found=
-for tr in $( pr-get-tr-names $PR_NAME ); do
-  data=$( tr-get-result $tr $TEST_NAME )
-  if [[ ! -z "${data}" ]]; then
+task_runs=$( pr-get-tr-names "$PR_NAME" )
+for tr in $task_runs; do
+  data=$( tr-get-result "$tr" "$TEST_NAME" )
+  if [[ -n "${data}" ]]; then
       result_found=1
-      task_name=$( tr-get-task-name ${tr} )
-      echo "${data}" | jq > $( json-data-file test ${task_name} )
+      task_name=$( tr-get-task-name "${tr}" )
+      output_file="$( json-data-file test "${task_name}" )"
+      echo "${data}" | jq > "${output_file}"
   fi
 done
 
 if [[ -z $result_found ]]; then
   # let's put an an empty hash here to express the the idea
   # that we looked for test results and found none
-  echo '{}' > $( json-data-file test )
+  echo '{}' > "$( json-data-file test )"
 fi
 
 show-data

--- a/appstudio-utils/util-scripts/lib/fetch/data.sh
+++ b/appstudio-utils/util-scripts/lib/fetch/data.sh
@@ -19,7 +19,7 @@ json-data-file() {
   file="$dir/data.json"
 
   # Better not silently overwrite data
-  [[ -f $file ]] && echo "Name clash for $file!" && exit 1
+  [[ -f $file ]] && echo "ERROR: Name clash for $file!" 1>&2 && return 1
 
   echo "$file"
 }

--- a/appstudio-utils/util-scripts/lib/fetch/git.sh
+++ b/appstudio-utils/util-scripts/lib/fetch/git.sh
@@ -5,21 +5,28 @@ git-fetch-repo() {
   local directory="$3"
 
   mkdir -p "$directory"
-  cd "$directory"
+  cd "$directory" || return
 
   # Git clone might work but this avoids downloading the entire repo
-  git init -q .
-  git fetch -q --depth 1 --no-tags $repo $ref_or_sha
-  git checkout -q FETCH_HEAD
+  git init -q . && \
+  git fetch -q --depth 1 --no-tags "$repo" "$ref_or_sha" && \
+  git checkout -q FETCH_HEAD && \
 
   git rev-parse FETCH_HEAD
 }
 
 git-fetch-policies() {
   echo "Fetching policies from $POLICY_REPO_REF at $POLICY_REPO"
-  echo "sha: $( git-fetch-repo $POLICY_REPO $POLICY_REPO_REF $POLICIES_DIR )"
+  local sha
+  if ! sha=$( git-fetch-repo "$POLICY_REPO" "$POLICY_REPO_REF" "$POLICIES_DIR" ); then
+    echo "Unable to fetch polices repository from $POLICY_REPO at ref $POLICY_REPO_REF!"
+    return 1
+  fi
+  echo "sha: $sha"
 
-  # Clean up files we don't need including .git
-  cd $POLICIES_DIR
-  rm -rf .git .github .gitignore README.md Makefile scripts
+  if [[ -d "$POLICIES_DIR" ]]; then
+    # Clean up files we don't need including .git
+    cd "$POLICIES_DIR" || return
+    rm -rf .git .github .gitignore README.md Makefile scripts
+  fi
 }

--- a/test/fetch-ec-data_spec.sh
+++ b/test/fetch-ec-data_spec.sh
@@ -23,11 +23,18 @@ AfterAll 'final_cleanup'
 Include ./appstudio-utils/util-scripts/lib/fetch.sh
 
 Describe 'json-data-file'
-  local root_dir=$( git rev-parse --show-toplevel )
-
   It 'produces expected json file paths'
     When call json-data-file some dir 123 foo 456
     The output should eq "$EC_WORK_DIR/data/some/dir/123/foo/456/data.json"
+  End
+
+  It 'detects file clashes'
+    mkdir -p "${DATA_DIR}/x"
+    touch "${DATA_DIR}/x/data.json"
+
+    When call json-data-file x
+    The error should equal "ERROR: Name clash for ${DATA_DIR}/x/data.json!"
+    The status should be failure
   End
 End
 

--- a/test/fetch-ec-policies_spec.sh
+++ b/test/fetch-ec-policies_spec.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+eval "$(shellspec -)"
+
+# we're sourcing in the specs below, so `dirname $0` will return this script's directory
+dirname() {
+  echo ./appstudio-utils/util-scripts
+}
+
+Describe 'fetch-ec-policies'
+  It 'fails fetching from bogus repositories'
+    POLICY_REPO=bogus
+    When run source ./appstudio-utils/util-scripts/fetch-ec-policies.sh
+    The output should include 'Fetching policies from main at bogus'
+    The error should start with "fatal: 'bogus' does not appear to be a git repository"
+    The status should be failure
+  End
+End

--- a/test/fetch-git_spec.sh
+++ b/test/fetch-git_spec.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+eval "$(shellspec -)"
+
+Include ./appstudio-utils/util-scripts/lib/fetch/git.sh
+
+setup() {
+  git_repository="$(mktemp -d)"
+  work_dir="$(mktemp -d)"
+}
+Before 'setup'
+
+cleanup() {
+  rm -rf "${git_repository}"
+  rm -rf "${work_dir}"
+}
+After 'cleanup'
+
+Describe 'git-fetch-repo'
+  rev_main=""
+  rev_branch=""
+
+  setup_repo() {
+    cd "${git_repository}" || exit
+    git init -q -b main
+    echo main > file
+    git add file
+    git commit -q -m initial file
+    rev_main="$(git rev-parse HEAD)"
+    git checkout -q -b branch
+    echo branch > file
+    git commit -a -q -m branch
+    rev_branch="$(git rev-parse HEAD)"
+  }
+
+  Before setup_repo
+
+  zero_tags() {
+    cd "${work_dir}" || exit
+    [ "$(git tag |wc -l)" == "0" ]
+  }
+
+  one_branch() {
+    cd "${work_dir}" || exit
+    [ "$(git branch |wc -l)" == "1" ]
+  }
+
+  It 'fetches'
+    When call git-fetch-repo "${git_repository}" main "${work_dir}"
+    The contents of file "${work_dir}/file" should equal 'main'
+    The output should equal "${rev_main}"
+    The result of 'zero_tags()' should be successful
+    The result of 'one_branch()' should  be successful
+  End
+
+  It 'fetches from different branch'
+    When call git-fetch-repo "${git_repository}" branch "${work_dir}"
+    The contents of file "${work_dir}/file" should equal 'branch'
+    The output should equal "${rev_branch}"
+    The result of 'zero_tags()' should be successful
+    The result of 'one_branch()' should  be successful
+  End
+
+  It 'fails on bogus repository'
+    When call git-fetch-repo bogus main "${work_dir}"
+    The status should be failure
+    The error should start with "fatal: 'bogus' does not appear to be a git repository"
+    The file "${work_dir}/.git/FETCH_HEAD" should be empty file
+  End
+
+  It 'fails on bogus ref'
+    When call git-fetch-repo "${git_repository}" bogus "${work_dir}"
+    The status should be failure
+    The error should start with "fatal: couldn't find remote ref bogus"
+    The file "${work_dir}/.git/FETCH_HEAD" should be empty file
+  End
+End
+
+Describe 'git-fetch-policies'
+  POLICY_REPO_REF=main
+  POLICY_REPO=repo
+  POLICIES_DIR=dir
+
+  It 'fetches policies'
+    git-fetch-repo() {
+      args="$*"
+      %preserve args
+      echo sha-here
+    }
+
+    When call git-fetch-policies
+    The output should equal 'Fetching policies from main at repo
+sha: sha-here'
+    The variable args should eq 'repo main dir'
+  End
+
+  It 'can fail to fetch policies'
+    git-fetch-repo() {
+      exit 1
+    }
+
+    When call git-fetch-policies
+    The output should equal 'Fetching policies from main at repo
+Unable to fetch polices repository from repo at ref main!'
+    The status should be failure
+  End
+End

--- a/test/verify-attestation-with-policy_spec.sh
+++ b/test/verify-attestation-with-policy_spec.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+eval "$(shellspec -)"
+
+# we're sourcing in the specs below, so `dirname $0` will return this script's directory
+dirname() {
+  echo ./appstudio-utils/util-scripts
+}
+
+Describe 'verify-attestation-with-policy'
+  setup() {
+    data_file=$(mktemp)
+    echo '{"payload":"e30K"}'  > "${data_file}"
+  }
+  Before setup
+
+  cleanup() {
+    rm "${data_file}"
+  }
+  After cleanup
+
+  It 'fails verifying if unable to fetch policies'
+    export POLICY_REPO=bogus
+    When run source ./appstudio-utils/util-scripts/verify-attestation-with-policy.sh "${data_file}" output.json result.json
+    The output should include 'Fetching policies from main at bogus'
+    The error should start with "fatal: 'bogus' does not appear to be a git repository"
+    The status should be failure
+  End
+End


### PR DESCRIPTION
This makes sure that in case of errors when fetching from git don't
proceed with the evaluation of the policy. In addition an error is
outputted to explain the issue.

Ref. https://issues.redhat.com/browse/HACBS-400