### PR TITLE
Use pipeline task name instead of task name

### DIFF
--- a/appstudio-utils/util-scripts/lib/fetch/tekton.sh
+++ b/appstudio-utils/util-scripts/lib/fetch/tekton.sh
@@ -27,7 +27,7 @@ tr-get-result() {
 
 tr-get-task-name() {
   local tr=$1
-  oc get tr/$tr -o jsonpath="{.spec.taskRef.name}"
+   oc get tr/$tr -o jsonpath="{.metadata.labels['tekton\.dev/pipelineTask']}"
 }
 
 tr-transparency-url() {


### PR DESCRIPTION
It is entirely possible that the same task is used within the pipeline multiple times. For that reason we can't rely on the Task name from the definition of the task, but rather the name of the task in the Pipeline.

Ref. https://issues.redhat.com/browse/HACBS-414