### PR TITLE
Add configure-build-csi-secret to get sharedSecret

### DIFF
--- a/hack/test-build.sh
+++ b/hack/test-build.sh
@@ -26,14 +26,13 @@ if [ -z "$MY_QUAY_USER" ]; then
   IMG=image-registry.openshift-image-registry.svc:5000/$NS/$APPNAME:$IMAGE_SHORT_TAG
   echo MY_QUAY_USER env variable is not set, pushing to $IMG
 else
-  if ! oc get secret redhat-appstudio-staginguser-pull-secret &>/dev/null; then
-     echo Secret redhat-appstudio-staginguser-pull-secret please create it
-     echo If you are logged into the registry with docker/podman then you can run:
+  if oc get secret redhat-appstudio-staginguser-pull-secret &>/dev/null; then
+     PUSH_WORKSPACE="-w name=registry-auth,secret=redhat-appstudio-staginguser-pull-secret"
+  else
+     echo redhat-appstudio-staginguser-pull-secret is not created, can be created by:
      echo oc create secret docker-registry redhat-appstudio-staginguser-pull-secret --from-file=.dockerconfigjson=$HOME/.docker/config.json
-     exit 1
   fi
   IMG=quay.io/$MY_QUAY_USER/$APPNAME:$IMAGE_SHORT_TAG
-  PUSH_WORKSPACE="-w name=registry-auth,secret=redhat-appstudio-staginguser-pull-secret"
   echo Building $IMG
 fi
 

--- a/hack/test-builds.sh
+++ b/hack/test-builds.sh
@@ -1,14 +1,14 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Script for execution of the pipelines as Application Service
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 oc apply -k $SCRIPTDIR/test-build
-if [ "$1" == "hacbs" ]; then
-  oc apply -k $SCRIPTDIR/../pipelines/hacbs
-else
+if [ "$1" == "" ]; then
   oc apply -k $SCRIPTDIR/../pipelines/base
+else
+  oc apply -k $SCRIPTDIR/../pipelines/$1
 fi
 
 $SCRIPTDIR/test-build.sh https://github.com/jduimovich/spring-petclinic java-builder

--- a/pipelines/hacbs-core-service/csi-secret.yaml
+++ b/pipelines/hacbs-core-service/csi-secret.yaml
@@ -1,0 +1,13 @@
+- op: remove
+  path: /spec/tasks/2/workspaces/1
+  value:
+    name: infra-deployment-update-script
+    default: ""
+- op: replace
+  path: /spec/tasks/2/taskRef/name
+  value: configure-build-csi-secret
+- op: add
+  path: /spec/tasks/2/params
+  value:
+    - name: shared-secret
+      value: redhat-appstudio-staginguser

--- a/pipelines/hacbs-core-service/kustomization.yaml
+++ b/pipelines/hacbs-core-service/kustomization.yaml
@@ -10,3 +10,9 @@ patches:
       version: v1beta1
       kind: Pipeline
       labelSelector: skip-hacbs-test != true
+  - path: csi-secret.yaml
+    target:
+      group: tekton.dev
+      version: v1beta1
+      kind: Pipeline
+      labelSelector: skip-hacbs-test != true

--- a/tasks/configure-build-csi-secret.yaml
+++ b/tasks/configure-build-csi-secret.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: configure-build-csi-secret
+spec:
+  description: >-
+    App Studio Configure Build Secrets in Source.
+  params:
+    - name: shared-secret
+  results:
+    - name: registry-auth
+      description: docker config location
+    - name: buildah-auth-param
+      description: pass this to the build optional params to conifigure secrets
+  workspaces:
+    - name: source
+  volumes:
+    - name: appstudio-push-secret
+      csi:
+        readOnly: true
+        driver: csi.sharedresource.openshift.io
+        volumeAttributes:
+          sharedSecret: $(params.shared-secret)
+  steps:
+    - name: appstudio-configure-build
+      image: registry.access.redhat.com/ubi8-minimal@sha256:574f201d7ed185a9932c91cef5d397f5298dff9df08bc2ebb266c6d1e6284cd1
+      volumeMounts:
+        - name: appstudio-push-secret
+          mountPath: /workspace/registry-auth
+      script: |
+        #!/usr/bin/env bash
+        echo "App Studio Configure Build"
+
+        AUTH=/workspace/registry-auth/.dockerconfigjson
+        DEST=/workspace/source/.dockerconfigjson
+        echo "Looking for Registry Auth Config: $AUTH"
+        if [ -f "$AUTH" ]; then
+          echo "$AUTH found"
+          echo
+
+          cp $AUTH $DEST
+
+          echo -n $DEST > /tekton/results/registry-auth
+          echo -n "--authfile $DEST"  >  /tekton/results/buildah-auth-param
+          echo
+        else
+          echo "No $AUTH found."
+          echo -n " " > /tekton/results/registry-auth
+          echo -n " " > /tekton/results/buildah-auth-param
+          echo
+        fi

--- a/tasks/kustomization.yaml
+++ b/tasks/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - buildah.yaml
 - cleanup-build-directories.yaml
 - configure-build.yaml
+- configure-build-csi-secret.yaml
 - git-clone.yaml
 - init.yaml
 - s2i-java.yaml


### PR DESCRIPTION
Used in hacbs-core-service bundle to use shared secret for pushing into quay.io/redhat-appstudio/*

Dependency on https://github.com/redhat-appstudio/infra-deployments/pull/330