### PR TITLE
Set type for the `rebuild` parameter

### DIFF
--- a/pipelines/base/template-build/template-build.yaml
+++ b/pipelines/base/template-build/template-build.yaml
@@ -28,6 +28,7 @@ spec:
       default: Dockerfile
     - description: Force rebuild image
       name: rebuild
+      type: string
       default: "false"
   tasks:
     - name: appstudio-init


### PR DESCRIPTION
Without type it seems to default to `[]string` which leads to pipeline failing with:

```
Pipeline demo/nodejs-builder can't be Run; it has an invalid spec: "" type does not match default value's type: "string": finally.params[rebuild].default.type, finally.params[rebuild].type, tasks.params[rebuild].default.type, tasks.params[rebuild].type
invalid value: : finally.params[rebuild].type, tasks.params[rebuild].type
```

This sets the type to `string`.

This is how it the default value is interpreted without the type set:

```
$ tkn pipeline describe nodejs-builder
Name:        nodejs-builder
Namespace:   demo

⚓ Params

 NAME             TYPE     DESCRIPTION              DEFAULT VALUE
 ∙ git-url        string   Source Repository U...   ---
 ∙ revision       string   Revision of the Sou...   main
 ∙ output-image   string   Fully Qualified Out...   ---
 ∙ path-context   string   The path to your so...   .
 ∙ dockerfile     string   Path to the Dockerf...   Dockerfile
 ∙ rebuild                 Force rebuild image      []
...
```

And with the type set to `string`:

```
$ tkn pipeline describe nodejs-builder
Name:        nodejs-builder
Namespace:   demo

⚓ Params

 NAME             TYPE     DESCRIPTION              DEFAULT VALUE
 ∙ git-url        string   Source Repository U...   ---
 ∙ revision       string   Revision of the Sou...   main
 ∙ output-image   string   Fully Qualified Out...   ---
 ∙ path-context   string   The path to your so...   .
 ∙ dockerfile     string   Path to the Dockerf...   Dockerfile
 ∙ rebuild        string   Force rebuild image      false
...
```

cc @Michkov 