### PR TITLE
Update tool versions

### DIFF
--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -1,14 +1,14 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
 RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/bin/jq && chmod +x /usr/bin/jq
-RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.9/openshift-client-linux.tar.gz | tar -xz -C /usr/bin/
-RUN curl -L https://github.com/sigstore/cosign/releases/download/v1.5.1/cosign-linux-amd64 -o /usr/bin/cosign && chmod +x /usr/bin/cosign
+RUN curl -L https://github.com/sigstore/cosign/releases/download/v1.8.0/cosign-linux-amd64 -o /usr/bin/cosign && chmod +x /usr/bin/cosign
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.21.0/tkn-linux-amd64-0.21.0.tar.gz | tar -xz --no-same-owner -C /usr/bin/
 RUN curl -L https://github.com/sigstore/rekor/releases/download/v0.5.0/rekor-cli-linux-amd64 -o /usr/bin/rekor-cli && chmod +x /usr/bin/rekor-cli
 
-RUN curl -L https://github.com/open-policy-agent/opa/releases/download/v0.39.0/opa_linux_amd64_static -o /usr/bin/opa && \
-    echo 19a24f51d954190c02aafeac5867c9add286c6ab12ea85b3d8d348c98d633319 /usr/bin/opa | sha256sum --check && \
+RUN curl -L https://github.com/open-policy-agent/opa/releases/download/v0.40.0/opa_linux_amd64_static -o /usr/bin/opa && \
+    echo 73e96d8071c6d71b4a9878d7f55bcb889173c40c91bbe599f9b7b06d3a472c5f /usr/bin/opa | sha256sum --check && \
     chmod +x /usr/bin/opa
 
 RUN dnf -y --setopt=tsflags=nodocs install \


### PR DESCRIPTION
This commit updates the following tools to the specified versions:
- cosign updated to v1.8.0
- yq updated to v4.25.1
- opa updated to v0.40.0

Signed-off-by: Rob Nester <rnester@redhat.com>