### PR TITLE
Add policy namespace to sanity label task workingDir

### DIFF
--- a/tasks/hacbs-test-evaluation.yaml
+++ b/tasks/hacbs-test-evaluation.yaml
@@ -16,13 +16,23 @@ spec:
       script: |
         #!/usr/bin/env bash
 
-        # sanity-label-check
-        FAILURES=$(jq '.[] | .failures // {} | .[] | .msg' sanity-label-check/sanity_label_check_output.json)
+        # sanity-label-check required checks
+        FAILURES=$(jq '.[] | .failures // {} | .[] | .msg' sanity-label-check-required_checks/sanity_label_check_output.json)
         if [ -n "$FAILURES" ]; then
-          echo sanity-label-check test FAIL:
+          echo sanity-label-check-required_checks test FAIL:
           echo "$FAILURES"
         else
-          echo sanity-label-check test PASS
+          echo sanity-label-check-required_checks test PASS
+        fi
+        echo -------------
+        
+        # sanity-label-check optional checks
+        FAILURES=$(jq '.[] | .failures // {} | .[] | .msg' sanity-label-check-optional_checks/sanity_label_check_output.json)
+        if [ -n "$FAILURES" ]; then
+          echo sanity-label-check-optional_checks test FAIL:
+          echo "$FAILURES"
+        else
+          echo sanity-label-check-optional_checks test PASS
         fi
         echo -------------
 

--- a/tasks/sanity-label-check.yaml
+++ b/tasks/sanity-label-check.yaml
@@ -19,7 +19,7 @@ spec:
   steps:
     - name: basic-sanity-checks-required-labels
       image: quay.io/redhat-appstudio/hacbs-test:stable
-      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)-$(params.POLICY_NAMESPACE)
       script: |
         CONFTEST_OPTIONS=""
         if [ -s "../sanity-inspect-image/base_image_inspect.json" ]; then


### PR DESCRIPTION
* Avoid overwriting task results by using different workingDir
* Add optional label check to hacbs-test-evaluation