### PR TITLE
HACBS-223: Add task to run gosec

### DIFF
--- a/pipelines/hacbs/hacbs-test.yaml
+++ b/pipelines/hacbs/hacbs-test.yaml
@@ -79,11 +79,11 @@
 - op: add
   path: /spec/tasks/-
   value:
-    name: gosec-check
+    name: sast-go
     runAfter:
       - build-container
     taskRef:
-      name: gosec-check
+      name: sast-go
     workspaces:
     - name: workspace
       workspace: workspace

--- a/pipelines/hacbs/hacbs-test.yaml
+++ b/pipelines/hacbs/hacbs-test.yaml
@@ -79,23 +79,9 @@
 - op: add
   path: /spec/tasks/-
   value:
-    name: git-clone
-    runAfter:
-      - build-container
-    taskRef:
-      name: git-clone
-    params:
-    - name: url
-      value: https://github.com/redhat-appstudio/application-service
-    workspaces:
-    - name: output
-      workspace: workspace
-- op: add
-  path: /spec/tasks/-
-  value:
     name: gosec-check
     runAfter:
-      - git-clone
+      - build-container
     taskRef:
       name: gosec-check
     workspaces:

--- a/pipelines/hacbs/hacbs-test.yaml
+++ b/pipelines/hacbs/hacbs-test.yaml
@@ -76,3 +76,28 @@
     workspaces:
     - name: conftest-ws
       workspace: workspace
+- op: add
+  path: /spec/tasks/-
+  value:
+    name: git-clone
+    runAfter:
+      - build-container
+    taskRef:
+      name: git-clone
+    params:
+    - name: url
+      value: https://github.com/redhat-appstudio/application-service
+    workspaces:
+    - name: output
+      workspace: workspace
+- op: add
+  path: /spec/tasks/-
+  value:
+    name: gosec-check
+    runAfter:
+      - git-clone
+    taskRef:
+      name: gosec-check
+    workspaces:
+    - name: workspace
+      workspace: workspace

--- a/tasks/hacbs-test-evaluation.yaml
+++ b/tasks/hacbs-test-evaluation.yaml
@@ -25,7 +25,7 @@ spec:
           echo sanity-label-check-required_checks test PASS
         fi
         echo -------------
-        
+
         # sanity-label-check optional checks
         FAILURES=$(jq '.[] | .failures // {} | .[] | .msg' sanity-label-check-optional_checks/sanity_label_check_output.json)
         if [ -n "$FAILURES" ]; then

--- a/tasks/kustomization.yaml
+++ b/tasks/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
 - get-clair-scan.yaml
 - conftest-clair.yaml
 - verify-enterprise-contract.yaml
+- sast-go.yaml

--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -10,8 +10,8 @@ spec:
     - description: Test output
       name: HACBS_TEST_OUTPUT
   steps:
-      image: quay.io/redhat-appstudio/hacbs-test:stable
     - name: sast-go
+      image: quay.io/redhat-appstudio/hacbs-test:feature-sast
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       script: |
         /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=gosec_output.json $(workspaces.workspace.path)/... | tee gosec_output.txt
@@ -24,7 +24,7 @@ spec:
         exit $GOSEC_EXIT_CODE
 
     - name: test-format-result
-      image: quay.io/redhat-appstudio/hacbs-test:stable
+      image: quay.io/redhat-appstudio/hacbs-test:feature-sast
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       script: |
         HACBS_ERROR_OUTPUT=$(jq -rc --arg date $(date +%s) --null-input \

--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -11,12 +11,12 @@ spec:
       name: HACBS_TEST_OUTPUT
   steps:
     - name: gosec-check
-      image: quay.io/rsaar/hacbs-test:latest
+      image: quay.io/redhat-appstudio/hacbs-test:stable
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       script: |
         /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=gosec_output.json $(workspaces.workspace.path)/...
     - name: test-format-result
-      image: quay.io/rsaar/hacbs-test:latest
+      image: quay.io/redhat-appstudio/hacbs-test:stable
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       script: |
         HACBS_ERROR_OUTPUT=$(jq -rc --arg date $(date +%s) --null-input \

--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -12,12 +12,12 @@ spec:
   steps:
     - name: gosec-check
       image: quay.io/rsaar/hacbs-test:latest
-      workingDir: $(workspaces.workspace.path)
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       script: |
-        ls $(workspaces.workspace.path)
-        /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=$(workspaces.workspace.path)/gosec_output.json $(workspaces.workspace.path)/...
+        /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=gosec_output.json $(workspaces.workspace.path)/...
     - name: test-format-result
       image: quay.io/rsaar/hacbs-test:latest
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       script: |
         HACBS_ERROR_OUTPUT=$(jq -rc --arg date $(date +%s) --null-input \
           '{result: "ERROR", timestamp: $date}')
@@ -27,5 +27,5 @@ spec:
                    namespace: "default",
                    successes: 0,
                    failures: (.runs[].results // [])|map(.message.text)
-                 }' $(workspaces.workspace.path)/gosec_output.json || true)
+                 }' gosec_output.json || true)
         echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)

--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gosec-check
+spec:
+  workspaces:
+    - name: workspace
+  results:
+    - description: Test output
+      name: HACBS_TEST_OUTPUT
+  steps:
+    - name: gosec-check
+      image: quay.io/rsaar/hacbs-test:latest
+      workingDir: $(workspaces.workspace.path)
+      script: |
+        ls $(workspaces.workspace.path)
+        /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=$(workspaces.workspace.path)/gosec_output.json $(workspaces.workspace.path)/...
+    - name: test-format-result
+      image: quay.io/rsaar/hacbs-test:latest
+      script: |
+        HACBS_ERROR_OUTPUT=$(jq -rc --arg date $(date +%s) --null-input \
+          '{result: "ERROR", timestamp: $date}')
+        HACBS_TEST_OUTPUT=$(jq -rce --arg date $(date +%s) \
+          '{ result: (if (.runs[].results | length > 0) then "FAILURE" else "SUCCESS" end),
+                   timestamp: $date,
+                   namespace: "default",
+                   successes: 0,
+                   failures: (.runs[].results // [])|map(.message.text)
+                 }' $(workspaces.workspace.path)/gosec_output.json || true)
+        echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)

--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: gosec-check
+  name: sast-go
 spec:
   workspaces:
     - name: workspace
@@ -10,8 +10,8 @@ spec:
     - description: Test output
       name: HACBS_TEST_OUTPUT
   steps:
-    - name: gosec-check
       image: quay.io/redhat-appstudio/hacbs-test:stable
+    - name: sast-go
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       script: |
         /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=gosec_output.json $(workspaces.workspace.path)/... | tee gosec_output.txt

--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -14,7 +14,15 @@ spec:
       image: quay.io/redhat-appstudio/hacbs-test:stable
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       script: |
-        /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=gosec_output.json $(workspaces.workspace.path)/...
+        /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=gosec_output.json $(workspaces.workspace.path)/... | tee gosec_output.txt
+        GOSEC_EXIT_CODE=$?
+
+        # Test if any package was found
+        # Even with -no-fail, gosec uses exit code 1 for several states,
+        # including when there are no packages found.
+        grep "No packages found$" gosec_output.txt && echo "Exit 0 because no packages found" && exit 0
+        exit $GOSEC_EXIT_CODE
+
     - name: test-format-result
       image: quay.io/redhat-appstudio/hacbs-test:stable
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)

--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -15,25 +15,32 @@ spec:
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       script: |
         /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=gosec_output.json $(workspaces.workspace.path)/... | tee gosec_output.txt
-        GOSEC_EXIT_CODE=$?
 
         # Test if any package was found
         # Even with -no-fail, gosec uses exit code 1 for several states,
         # including when there are no packages found.
-        grep "No packages found$" gosec_output.txt && echo "Exit 0 because no packages found" && exit 0
-        exit $GOSEC_EXIT_CODE
+        grep "No packages found$" gosec_output.txt && echo "Skipping because no Go packages were found"
 
-    - name: test-format-result
-      image: quay.io/redhat-appstudio/hacbs-test:feature-sast
-      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
-      script: |
         HACBS_ERROR_OUTPUT=$(jq -rc --arg date $(date +%s) --null-input \
           '{result: "ERROR", timestamp: $date}')
-        HACBS_TEST_OUTPUT=$(jq -rce --arg date $(date +%s) \
-          '{ result: (if (.runs[].results | length > 0) then "FAILURE" else "SUCCESS" end),
-                   timestamp: $date,
-                   namespace: "default",
-                   successes: 0,
-                   failures: (.runs[].results // [])|map(.message.text)
-                 }' gosec_output.json || true)
+
+        if [ -f gosec_output.json ];
+        then
+          HACBS_TEST_OUTPUT=$(jq -rce --arg date $(date +%s) \
+            '{ result: (if (.runs[].results | length > 0) then "FAILURE" else "SUCCESS" end),
+               timestamp: $date,
+               namespace: "default",
+               successes: 0,
+               failures: (.runs[].results // [])|map(.message.text)
+             }' gosec_output.json || true)
+        else
+          HACBS_TEST_OUTPUT=$(jq -rc --arg date $(date +%s) --null-input \
+            '{ result: "SUCCESS",
+               timestamp: $date,
+               namespace: "default",
+               successes: 0,
+               failures: 0
+             }')
+        fi
+
         echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)


### PR DESCRIPTION
- Test on a Go app: `./hack/test-build.sh https://github.com/redhat-appstudio/application-service docker-build`
- Test on a non-Go app: `./hack/test-build.sh https://github.com/jduimovich/single-container-app docker-build`

Both should pass, but `HACBS_TEST_OUTPUT` should only contain data for the Go app