### PR TITLE
Produce results for the build pipelines

### DIFF
--- a/pipelines/base/template-build/template-build.yaml
+++ b/pipelines/base/template-build/template-build.yaml
@@ -106,6 +106,11 @@ spec:
         value: "$(params.git-url)"
       - name: image-url
         value: $(params.output-image)
+  results:
+    - name: IMAGE_URL
+      value: "$(tasks.build-container.results.IMAGE_URL)"
+    - name: IMAGE_DIGEST
+      value: "$(tasks.build-container.results.IMAGE_DIGEST)"
   workspaces:
     - name: workspace
     - name: registry-auth


### PR DESCRIPTION
In order to attest PipelineRuns, we are working towards a change in
Chains. The likely mechanism to determine which image needs the
attestation should be assocaited with is by producing the type hinting
results on the PipelineRun itself, instead of the TaskRun. Although this
mechanism is pending approval, making this change in the Pipeline
definitions now allows us to more easily experiment with it.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>