### PR TITLE
Clair - do not wait for scan result

### DIFF
--- a/tasks/get-clair-scan.yaml
+++ b/tasks/get-clair-scan.yaml
@@ -50,7 +50,9 @@ spec:
         function retry {
           local n=0
           local max=5
-          local delay=60
+          # TODO Clair scan time varies too much at the moment, from 10 minutes to +5 hours. Decreasing delay.
+          #local delay=60
+          local delay=0
           while true; do
             "$@" && [ "$retval"==0 ]  && break || {
               if [[ $n -lt $max ]]; then


### PR DESCRIPTION
Since clair scan could take from 10 minutes to +5 hours then it does not
make sense to block pipelineRun by 5 minutes.