### PR TITLE
Bash utility function for merging json data

### DIFF
--- a/appstudio-utils/util-scripts/fetch-test-data.sh
+++ b/appstudio-utils/util-scripts/fetch-test-data.sh
@@ -24,6 +24,7 @@ for tr in $( pr-get-tr-names $PR_NAME ); do
   if [[ ! -z "${data}" ]]; then
       result_found=1
       task_name=$( tr-get-task-name ${tr} )
+      # Todo: Use json-merge-with-key to put all results into one file
       echo "${data}" | jq > $( json-data-file test ${task_name} )
   fi
 done

--- a/appstudio-utils/util-scripts/lib/fetch/data.sh
+++ b/appstudio-utils/util-scripts/lib/fetch/data.sh
@@ -16,12 +16,47 @@ json-data-file() {
   # prepared but not actually used but that's okay.
   mkdir -p "$dir"
 
-  file="$dir/data.json"
+  local file="$dir/data.json"
 
   # Better not silently overwrite data
   [[ -f $file ]] && echo "Name clash for $file!" && exit 1
 
   echo "$file"
+}
+
+# Emulate in-place editing with jq
+jq-in-place-edit() {
+  local file="$1"
+  local jq_filter="$2"
+  local tmp_file="$(mktemp)"
+
+  jq "$jq_filter" < "$file" > "$tmp_file"
+  mv "$tmp_file" "$file"
+}
+
+# Merge new data into an existing json file
+json-merge-with-key() {
+  local new_data="$1"
+  local file="$2"
+  local top_level_key="$3"
+  local second_level_key="$4"
+
+  local path=".$top_level_key.$second_level_key"
+
+  # Make sure the file exists
+  if [[ ! -f "$file" ]]; then
+    mkdir -p "$(dirname $file)"
+    echo "{}" > "$file"
+  fi
+
+  # Make sure we're not overwriting data
+  if [[ $( jq $path < "$file" ) != "null" ]]; then
+    echo "ERROR: Path '$path' exists already in file '$file'"
+    exit 1
+  fi
+
+  # Insert the new data
+  jq-in-place-edit "$file" ". | $path = $new_data"
 }
 
 clear-data() {

--- a/test/fetch-test-data_spec.sh
+++ b/test/fetch-test-data_spec.sh
@@ -55,6 +55,33 @@ Describe 'json-data-file'
   End
 End
 
+Describe 'json-merge-with-key'
+  local test_file="$EC_WORK_DIR/json-merge-test.json"
+
+  It 'works as expected'
+    When call \
+      json-merge-with-key '{"result":"yes"}' "$test_file" test strong && \
+      json-merge-with-key '{"result":"no"}' "$test_file" test fast && \
+      json-merge-with-key '["jq"]' "$test_file" moredata good
+    The contents of file "$test_file" should eq \
+'{
+  "test": {
+    "strong": {
+      "result": "yes"
+    },
+    "fast": {
+      "result": "no"
+    }
+  },
+  "moredata": {
+    "good": [
+      "jq"
+    ]
+  }
+}'
+  End
+End
+
 Describe 'rekor-log-entry'
   rekor-cli() {
     echo "rekor-cli $*"


### PR DESCRIPTION
Related to Enterprise Contract.

The motivation is so we can collect all test results into a single
data file that will work with conftest.

The current method of putting the data in nested directories works
nicely with opa, but doesn't work with conftest afaict since
conftest merges data from any file into a single object. So this is
a way to avoid conftest merge errors and get the data into the shape
we need.