### PR TITLE
Produce materials for the build pipelines

### DIFF
--- a/pipelines/base/template-build/template-build.yaml
+++ b/pipelines/base/template-build/template-build.yaml
@@ -111,6 +111,10 @@ spec:
       value: "$(tasks.build-container.results.IMAGE_URL)"
     - name: IMAGE_DIGEST
       value: "$(tasks.build-container.results.IMAGE_DIGEST)"
+    - name: CHAINS-GIT_URL
+      value: "$(tasks.clone-repository.results.url)"
+    - name: CHAINS-GIT_COMMIT
+      value: "$(tasks.clone-repository.results.commit)"
   workspaces:
     - name: workspace
     - name: registry-auth


### PR DESCRIPTION
When Tekton Chains attests a PipelineRun, it looks for the presence of
either results, or parameters, named CHAINS-GIT_URL and
CHAINS-GIT_COMMIT. If found, this information is then propagated to the
.predicate.materials section of the SLSA Provenance attestation.

This commit makes the build pipelines produce this information in their
results. Although using parameters is also a possibility, it has a
stronger impact on the pipeline usability since users would have to
specify a different parameter for the git url and commit.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>