### PR TITLE
sast-java-sec-check: test tasks should not fail

### DIFF
--- a/tasks/sast-java-sec-check.yaml
+++ b/tasks/sast-java-sec-check.yaml
@@ -33,6 +33,8 @@ spec:
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       image: quay.io/redhat-appstudio/hacbs-test:feature-sast
       script: |
+        #!/bin/bash -x
+
         pushd $(workspaces.workspace.path)
         if [ -f "$(params.PATH_CONTEXT)/pom.xml" ]; then
           mvn package -f $(params.PATH_CONTEXT)/


### PR DESCRIPTION
fix of #104 