### PR TITLE
[HACBS-426]: Integrate the deprecated base image check

### DIFF
--- a/pipelines/hacbs/hacbs-test.yaml
+++ b/pipelines/hacbs/hacbs-test.yaml
@@ -49,7 +49,7 @@
     - name: IMAGE_REGISTRY
       value: registry.access.redhat.com
     - name: IMAGE_REPOSITORY
-      value: $(params.git-url)
+      value: $(tasks.sanity-inspect-image.results.BASE_IMAGE_REPOSITORY)
     workspaces:
     - name: sanity-ws
       workspace: workspace

--- a/pipelines/hacbs/hacbs-test.yaml
+++ b/pipelines/hacbs/hacbs-test.yaml
@@ -47,7 +47,7 @@
       name: deprecated-image-check
     params:
     - name: IMAGE_REGISTRY
-      value: quay.io
+      value: registry.access.redhat.com
     - name: IMAGE_REPOSITORY
       value: $(params.git-url)
     workspaces:

--- a/pipelines/hacbs/hacbs-test.yaml
+++ b/pipelines/hacbs/hacbs-test.yaml
@@ -40,6 +40,22 @@
 - op: add
   path: /spec/tasks/-
   value:
+    name: deprecated-base-image-check
+    runAfter:
+      - sanity-inspect-image
+    taskRef:
+      name: deprecated-image-check
+    params:
+    - name: IMAGE_REGISTRY
+      value: quay.io
+    - name: IMAGE_REPOSITORY
+      value: $(params.git-url)
+    workspaces:
+    - name: sanity-ws
+      workspace: workspace
+- op: add
+  path: /spec/tasks/-
+  value:
     name: get-clair-results
     runAfter:
       - build-container

--- a/tasks/kustomization.yaml
+++ b/tasks/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - cosign-verify.yaml
 - cosign-verify-attestation.yaml
 - sanity-inspect-image.yaml
+- deprecated-image-check.yaml
 - hacbs-test-evaluation.yaml
 - update-infra-deployments.yaml
 - get-clair-scan.yaml

--- a/tasks/sanity-inspect-image.yaml
+++ b/tasks/sanity-inspect-image.yaml
@@ -52,6 +52,4 @@ spec:
       skopeo inspect --no-tags docker://$BASE_IMAGE  > $BASE_IMAGE_INSPECT || true
       echo "$BASE_IMAGE" | tee $(results.BASE_IMAGE.path)
 
-      BASE_IMAGE_INSPECT_RAW=$(skopeo inspect --no-tags --raw docker://$BASE_IMAGE)
-      BASE_IMAGE_REPOSITORY="$(echo $BASE_IMAGE_INSPECT_RAW | jq -r ".annotations.\"org.opencontainers.image.source\"")"
-      echo "$BASE_IMAGE_REPOSITORY" > $(results.BASE_IMAGE_REPOSITORY.path)
+      jq -r ".Name" $BASE_IMAGE_INSPECT | cut -d"/" -f2,3 | tee $(results.BASE_IMAGE_REPOSITORY.path)

--- a/tasks/sanity-inspect-image.yaml
+++ b/tasks/sanity-inspect-image.yaml
@@ -13,6 +13,8 @@ spec:
   results:
     - description: Base image the source image is built from
       name: BASE_IMAGE
+    - description: Base image repository URL
+      name: BASE_IMAGE_REPOSITORY
   workspaces:
     - name: workspace
   steps:
@@ -49,3 +51,7 @@ spec:
       echo "The base image is $BASE_IMAGE, get its manifest now"
       skopeo inspect --no-tags docker://$BASE_IMAGE  > $BASE_IMAGE_INSPECT || true
       echo "$BASE_IMAGE" | tee $(results.BASE_IMAGE.path)
+
+      BASE_IMAGE_INSPECT_RAW=$(skopeo inspect --no-tags --raw docker://$BASE_IMAGE)
+      BASE_IMAGE_REPOSITORY="$(echo $BASE_IMAGE_INSPECT_RAW | jq -r ".annotations.\"org.opencontainers.image.source\"")"
+      echo "$BASE_IMAGE_REPOSITORY" > $(results.BASE_IMAGE_REPOSITORY.path)


### PR DESCRIPTION
- Checks the base image using `org.opencontainers.image.source`
- Add the check to `hacbs-test` pipeline