### PR TITLE
Fix build error when an SBOM component does not have a version

### DIFF
--- a/tasks/buildah.yaml
+++ b/tasks/buildah.yaml
@@ -95,7 +95,7 @@ spec:
         source_sbom = json.load(f)
 
       def get_identifier(component):
-        return component["name"] + '@' + component["version"]
+        return component["name"] + '@' + component.get("version", "")
 
       existing_components = [get_identifier(component) for component in image_sbom["components"]]
 


### PR DESCRIPTION
During the merging of the generated SBOMs for a build, all identified components are sorted by name and version. But we found some specific scenarios (e.g. Golang builds) in which a component is reported without a version.

This fix will allow the merging to handle components even if the version information is missing.