### PR TITLE
Split buildah task to make the SBOM generation steps reusable

### DIFF
--- a/hack/test-build.sh
+++ b/hack/test-build.sh
@@ -42,4 +42,4 @@ else
   echo Building $IMG
 fi
 
-tkn pipeline start $PIPELINE_NAME -w name=workspace,claimName=appstudio,subPath=$BUILD_TAG $PUSH_WORKSPACE -p git-url=$GITREPO -p output-image=$IMG --use-param-defaults
+tkn pipeline start $PIPELINE_NAME -w name=workspace,claimName=appstudio,subPath=$BUILD_TAG -w name=varlibcontainers,volumeClaimTemplateFile=$SCRIPTDIR/volume-claim-template.yaml $PUSH_WORKSPACE -p git-url=$GITREPO -p output-image=$IMG --use-param-defaults

--- a/hack/volume-claim-template.yaml
+++ b/hack/volume-claim-template.yaml
@@ -1,0 +1,6 @@
+spec:
+   accessModes:
+     - ReadWriteOnce
+   resources:
+     requests:
+       storage: 10Gi

--- a/pipelines/base/template-build/template-build.yaml
+++ b/pipelines/base/template-build/template-build.yaml
@@ -95,6 +95,58 @@ spec:
       workspaces:
         - name: source
           workspace: workspace
+        - name: varlibcontainers
+          workspace: varlibcontainers
+    - name: generate-sbom
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: BUILD_EXTRA_ARGS
+          value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+        - name: PUSH_EXTRA_ARGS
+          value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+      when:
+      - input: $(tasks.appstudio-init.results.build)
+        operator: in
+        values: ["true"]
+      runAfter:
+        - build-container
+      taskRef:
+        name: generate-sbom
+      workspaces:
+        - name: source
+          workspace: workspace
+        - name: varlibcontainers
+          workspace: varlibcontainers
+    - name: push-image
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: BUILD_EXTRA_ARGS
+          value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+        - name: PUSH_EXTRA_ARGS
+          value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+      when:
+      - input: $(tasks.appstudio-init.results.build)
+        operator: in
+        values: ["true"]
+      runAfter:
+        - generate-sbom
+      taskRef:
+        name: push-image
+      workspaces:
+        - name: source
+          workspace: workspace
+        - name: varlibcontainers
+          workspace: varlibcontainers
   finally:
     - name: show-summary
       taskRef:
@@ -117,6 +169,7 @@ spec:
       value: "$(tasks.clone-repository.results.commit)"
   workspaces:
     - name: workspace
+    - name: varlibcontainers
     - name: registry-auth
       optional: true
     - name: git-auth

--- a/tasks/generate-sbom.yaml
+++ b/tasks/generate-sbom.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build
-  name: buildah
+  name: generate-sbom
 spec:
   description: |-
     Buildah task builds source into a container image and then pushes it to a container registry.
@@ -51,18 +51,53 @@ spec:
   - description: Image repository where the built image was pushed
     name: IMAGE_URL
   steps:
-  - image: $(params.BUILDER_IMAGE)
-    name: build
-    resources:
-      limits:
-        memory: 2Gi
-        cpu: 2
+  - image: quay.io/redhat-appstudio/syft:v0.46.2
+    name: sbom-source
+    args:
+      - dir:$(workspaces.source.path)
+      - --file=$(workspaces.source.path)/sbom-source.json
+      - --output=cyclonedx-json
+  - image: quay.io/redhat-appstudio/syft:v0.46.2
+    name: sbom-image
+    args:
+      - oci-dir:/var/lib/containers/oci
+      - --file=$(workspaces.source.path)/sbom-image.json
+      - --output=cyclonedx-json
+  - image: registry.redhat.io/ubi8/python-39:1-51
+    name: merge-sboms
     script: |
-      buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
-        $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
-        --tls-verify=$(params.TLSVERIFY) --no-cache \
-        -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
-      buildah push --storage-driver=$(params.STORAGE_DRIVER) $(params.IMAGE) oci:/var/lib/containers/oci
+      #!/bin/python3
+      import json
+
+      with open("./sbom-image.json") as f:
+        image_sbom = json.load(f)
+
+      with open("./sbom-source.json") as f:
+        source_sbom = json.load(f)
+
+      def get_identifier(component):
+        return component["name"] + '@' + component.get("version", "")
+
+      existing_components = [get_identifier(component) for component in image_sbom["components"]]
+
+      for component in source_sbom["components"]:
+        if get_identifier(component) not in existing_components:
+          image_sbom["components"].append(component)
+
+      image_sbom["components"].sort(key=lambda c: get_identifier(c))
+
+      with open("./sbom.json", "w") as f:
+        json.dump(image_sbom, f)
+    workingDir: $(workspaces.source.path)
+    securityContext:
+      runAsUser: 0
+  - image: $(params.BUILDER_IMAGE)
+    name: inject-sbom
+    resources: {}
+    script: |
+      container=$(buildah from --storage-driver=$(params.STORAGE_DRIVER) --pull-never $(params.IMAGE))
+      buildah --storage-driver=$(params.STORAGE_DRIVER) copy $container sbom.json /root/
+      buildah --storage-driver=$(params.STORAGE_DRIVER) commit $container $(params.IMAGE)
     workingDir: $(workspaces.source.path)
   workspaces:
   - name: source

--- a/tasks/kustomization.yaml
+++ b/tasks/kustomization.yaml
@@ -21,3 +21,5 @@ resources:
 - verify-enterprise-contract.yaml
 - sast-go.yaml
 - sast-java-sec-check.yaml
+- generate-sbom.yaml
+- push-image.yaml

--- a/tasks/push-image.yaml
+++ b/tasks/push-image.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build
-  name: buildah
+  name: push-image
 spec:
   description: |-
     Buildah task builds source into a container image and then pushes it to a container registry.
@@ -52,18 +52,20 @@ spec:
     name: IMAGE_URL
   steps:
   - image: $(params.BUILDER_IMAGE)
-    name: build
-    resources:
-      limits:
-        memory: 2Gi
-        cpu: 2
+    name: push
+    resources: {}
     script: |
-      buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
-        $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
-        --tls-verify=$(params.TLSVERIFY) --no-cache \
-        -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
-      buildah push --storage-driver=$(params.STORAGE_DRIVER) $(params.IMAGE) oci:/var/lib/containers/oci
+      buildah --storage-driver=$(params.STORAGE_DRIVER) push \
+        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+        docker://$(params.IMAGE)
     workingDir: $(workspaces.source.path)
+  - image: $(params.BUILDER_IMAGE)
+    name: digest-to-results
+    resources: {}
+    script: |
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
   workspaces:
   - name: source
   - name: varlibcontainers

--- a/tasks/s2i-java.yaml
+++ b/tasks/s2i-java.yaml
@@ -101,17 +101,11 @@ spec:
     - mountPath: /env-params
       name: envparams
     workingDir: $(workspaces.source.path)
-  - command:
-    - buildah
-    - bud
-    - --storage-driver=vfs
-    - --tls-verify=$(params.TLSVERIFY)
-    - --layers
-    - -f
-    - /gen-source/Dockerfile.gen
-    - -t
-    - $(params.IMAGE)
-    - .
+  - script: |
+      buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+      --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+
+      buildah push --storage-driver=vfs $(params.IMAGE) oci:/var/lib/containers/oci
     image: $(params.BUILDER_IMAGE)
     name: build
     resources:
@@ -119,36 +113,10 @@ spec:
         memory: 2Gi
         cpu: 2
     volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
     - mountPath: /gen-source
       name: gen-source
     workingDir: /gen-source
-  - script: >
-      buildah
-      push
-      --storage-driver=vfs
-      --tls-verify=$(params.TLSVERIFY)
-      --digestfile=$(workspaces.source.path)/image-digest
-      $(params.PUSH_EXTRA_ARGS)
-      $(params.IMAGE)
-      docker://$(params.IMAGE)
-    image: $(params.BUILDER_IMAGE)
-    name: push
-    resources: {}
-    volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
-    workingDir: $(workspaces.source.path)
-  - image: $(params.BUILDER_IMAGE)
-    name: digest-to-results
-    resources: {}
-    script: |
-      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
-      echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
   volumes:
-  - emptyDir: {}
-    name: varlibcontainers
   - emptyDir: {}
     name: gen-source
   - emptyDir: {}
@@ -156,3 +124,6 @@ spec:
   workspaces:
   - mountPath: /workspace/source
     name: source
+  - name: varlibcontainers
+    mountPath: /var/lib/containers
+  

--- a/tasks/s2i-nodejs.yaml
+++ b/tasks/s2i-nodejs.yaml
@@ -56,17 +56,11 @@ spec:
     - mountPath: /gen-source
       name: gen-source
     workingDir: $(workspaces.source.path)
-  - command:
-    - buildah
-    - bud
-    - --storage-driver=vfs
-    - --tls-verify=$(params.TLSVERIFY)
-    - --layers
-    - -f
-    - /gen-source/Dockerfile.gen
-    - -t
-    - $(params.IMAGE)
-    - .
+  - script: |
+      buildah bud --storage-driver=vfs --tls-verify=$(params.TLSVERIFY) \
+      --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+      
+      buildah push --storage-driver=vfs $(params.IMAGE) oci:/var/lib/containers/oci
     image: $(params.BUILDER_IMAGE)
     name: build
     resources:
@@ -74,38 +68,16 @@ spec:
         memory: 2Gi
         cpu: 2
     volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
     - mountPath: /gen-source
       name: gen-source
     workingDir: /gen-source
-  - script: >
-      buildah
-      push
-      --storage-driver=vfs
-      --tls-verify=$(params.TLSVERIFY)
-      --digestfile=$(workspaces.source.path)/image-digest
-      $(params.PUSH_EXTRA_ARGS)
-      $(params.IMAGE)
-      docker://$(params.IMAGE)
-    image: $(params.BUILDER_IMAGE)
-    name: push
-    resources: {}
-    volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
-    workingDir: $(workspaces.source.path)
-  - image: $(params.BUILDER_IMAGE)
-    name: digest-to-results
-    resources: {}
-    script: |
-      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
-      echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
   volumes:
   - emptyDir: {}
-    name: varlibcontainers
-  - emptyDir: {}
     name: gen-source
+  - emptyDir: {}
+    name: envparams
   workspaces:
   - mountPath: /workspace/source
     name: source
+  - name: varlibcontainers
+    mountPath: /var/lib/containers


### PR DESCRIPTION
This is a proposal to have the sbom generation steps from the buildah task split into a new task. But in order to do that, the push step will also need to be separated into a new task. 

Here's how the docker-build pipeline will look like after the split:
![image](https://user-images.githubusercontent.com/4075353/171659260-6b1f2b5d-a7cc-41b3-ba2d-4b7b9119bf91.png)

The code still needs some clean up, but I created this draft so I could get early comments on the proposal.