### PR TITLE
sast-go: increase memory limit to 4GB

### DIFF
--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -15,7 +15,7 @@ spec:
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       resources:
         limits:
-          memory: 2Gi
+          memory: 4Gi
           cpu: 2
         requests:
           memory: 512Mi


### PR DESCRIPTION
Building of jvm-build-service is failing on sast-go on OOMKilled.