### PR TITLE
e2e: use stable image for cleanup

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -127,7 +127,7 @@ spec:
               type: string
           steps:
             - name: e2e-cleanup
-              image: quay.io/redhat-appstudio/pull-request-builds:build-definitions-utils-{{revision}}
+              image: registry.redhat.io/openshift4/ose-cli:v4.10
               script: |
                 #!/usr/bin/env bash
                 # Perform cleanup of resources created by e2e test run


### PR DESCRIPTION
When pipelinerun fails on yamllint then the image for e2e-cleanup is not
created.