### PR TITLE
sast-go: increase memory limit to 8Gi

### DIFF
--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -15,7 +15,7 @@ spec:
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       resources:
         limits:
-          memory: 4Gi
+          memory: 8Gi
           cpu: 2
         requests:
           memory: 512Mi


### PR DESCRIPTION
4Gi is not enough to build KCP.

For container building 2Gi is enough but for building project like kcp we need more than 4 GB.