### PR TITLE
Fix fallback when missing ECP resource

### DIFF
--- a/appstudio-utils/util-scripts/lib/fetch/cluster.sh
+++ b/appstudio-utils/util-scripts/lib/fetch/cluster.sh
@@ -54,11 +54,6 @@ save-policy-config() {
   if ! non_blocking_data=$(kubectl get enterprisecontractpolicies.appstudio.redhat.com "${args[*]}" -o jsonpath='{.spec.exceptions.nonBlocking}'); then
     local namespace=${namespace_arg#-n }
     echo "ERROR: unable to find the ec-policy EnterpriseContractPolicy in namespace ${namespace:-$(kubectl config view --minify -o jsonpath='{..namespace}')}" 1>&2
-    # TODO remove this condition once $1 is mandatory, i.e. we no longer
-    # use the config map or the fallback policy below
-    if [[ $# -gt 0 ]]; then # remove to fail unconditionally
-      return 1
-    fi
   else
     # Save the config data from the ECP
     echo "$non_blocking_data" | jq '{"config": {"policy": {"non_blocking_checks": . }}}' > "${config_file}"


### PR DESCRIPTION
This fixes the e2e tests by allowing the fallback to be used if an ECP name was provided but does not exist which is now the case since `POLICY_CONFIGURATION` has a default value and is actually used in the bash scripts.