### PR TITLE
Tweak verify-pipeline so future violations work

### DIFF
--- a/hack/verify-pipeline.sh
+++ b/hack/verify-pipeline.sh
@@ -23,6 +23,7 @@ EC_WORK_DIR=${EC_WORK_DIR:-/tmp/ecwork}
 POLICIES_DIR=${POLICIES_DIR:-"$EC_WORK_DIR/policies"}
 POLICY_REPO=${POLICY_REPO:-"https://github.com/hacbs-contract/ec-policies.git"}
 POLICY_REPO_REF=${POLICY_REPO_REF:-"main"}
+DATA_DIR=${DATA_DIR:-"$EC_WORK_DIR/data"}
 
 # This produces a bunch of output that we don't particularly care about here,
 # hence the redirect to /dev/null.
@@ -31,6 +32,9 @@ POLICY_REPO_REF=${POLICY_REPO_REF:-"main"}
 mkdir -p $POLICIES_DIR > /dev/null
 $SCRIPTS_DIR/fetch-ec-policies.sh >/dev/null 2>&1
 
+# Workaround a bug that causes future warnings to become denies if this isn't present
+echo '{"config":{}}' > $DATA_DIR/data.json
+
 echo "# Input file: $INPUT_FILE"
 echo "# Pipeline name: $( yq e .metadata.name $INPUT_FILE )"
 echo "# Policy repo: $POLICY_REPO"
@@ -38,6 +42,7 @@ echo "# Git ref: $POLICY_REPO_REF"
 
 # Execute our conftest to validate our resource against our policy
 conftest test $INPUT_FILE \
+  --data $DATA_DIR \
   --policy $POLICIES_DIR/policy \
   --namespace pipeline.main \
   --output json \


### PR DESCRIPTION
There's a rego bug in ec-policies that means the future policy
violations are not handled correctly if data.config is missing
entirely.

This is a quick workaround for the demo. Hopefully the rego bug will
be fixed later properly and the workaround won't be needed.