### PR TITLE
fix: filter e2e tests to run using labels

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -103,10 +103,12 @@ spec:
               type: string
           steps:
             - name: e2e-test
-              image: quay.io/redhat-appstudio/e2e-tests:latest
+              # TODO: revert once https://github.com/redhat-appstudio/e2e-tests/pull/105/commits is merged
+              #image: quay.io/redhat-appstudio/e2e-tests:latest
+              image: quay.io/redhat-appstudio/pull-request-builds:e2e-c70495bffdc8fb9f49398b6f7b7fbb32cce51abd
               imagePullPolicy: Always
               args: [
-                "--ginkgo.focus=build-service-suite",
+                "--ginkgo.label-filter=build-templates-e2e",
                 "--ginkgo.progress",
                 "--ginkgo.v",
                 "--ginkgo.no-color"

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -103,9 +103,7 @@ spec:
               type: string
           steps:
             - name: e2e-test
-              # TODO: revert once https://github.com/redhat-appstudio/e2e-tests/pull/105/commits is merged
-              #image: quay.io/redhat-appstudio/e2e-tests:latest
-              image: quay.io/redhat-appstudio/pull-request-builds:e2e-c70495bffdc8fb9f49398b6f7b7fbb32cce51abd
+              image: quay.io/redhat-appstudio/e2e-tests:latest
               imagePullPolicy: Always
               args: [
                 "--ginkgo.label-filter=build-templates-e2e",


### PR DESCRIPTION
### What
A follow-up on https://github.com/redhat-appstudio/e2e-tests/pull/105

Some new test specs (irrelevant to e2e build-definitions tests) were introduced to a build-service test suite that cannot be easily filtered out via `--ginkgo.focus` flag.
Using label filters is an elegant way to do it.