### PR TITLE
Improvements to allow build apicurio-registry

### DIFF
--- a/pipelines/base/template-build/template-build.yaml
+++ b/pipelines/base/template-build/template-build.yaml
@@ -14,7 +14,7 @@ spec:
     - description: 'Revision of the Source Repository'
       name: revision
       type: string
-      default: main
+      default: ""
     - description: 'Fully Qualified Output Image'
       name: output-image
       type: string

--- a/tasks/buildah.yaml
+++ b/tasks/buildah.yaml
@@ -55,7 +55,7 @@ spec:
     name: build
     resources:
       limits:
-        memory: 2Gi
+        memory: 4Gi
         cpu: 2
       requests:
         memory: 512Mi
@@ -64,6 +64,7 @@ spec:
       buildah bud \
         $(params.BUILD_EXTRA_ARGS) \
         --tls-verify=$(params.TLSVERIFY) --no-cache \
+        --ulimit nofile=4096:4096 \
         -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
       buildah push $(params.IMAGE) oci:/var/lib/containers/oci
     volumeMounts:

--- a/tasks/s2i-java.yaml
+++ b/tasks/s2i-java.yaml
@@ -27,7 +27,7 @@ spec:
     description: Additional Maven arguments
     name: MAVEN_ARGS_APPEND
     type: string
-  - default: "false"
+  - default: "true"
     description: Remove the Maven repository after the artifact is built
     name: MAVEN_CLEAR_REPO
     type: string
@@ -110,13 +110,13 @@ spec:
       name: envparams
     workingDir: $(workspaces.source.path)
   - script: |
-      buildah bud --tls-verify=$(params.TLSVERIFY) --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+      buildah bud --tls-verify=$(params.TLSVERIFY) --layers --ulimit nofile=4096:4096 -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
       buildah push $(params.IMAGE) oci:/var/lib/containers/oci
     image: $(params.BUILDER_IMAGE)
     name: build
     resources:
       limits:
-        memory: 2Gi
+        memory: 4Gi
         cpu: 2
       requests:
         memory: 512Mi


### PR DESCRIPTION
Modifications:
- Do not force main branch, use repository default
- Increase opened files limit
- Increase memory for the build

Test:
./hack/test-build.sh https://github.com/Michkov/apicurio-registry java-builder

Only modification of the repo in fork is .s2i folder