### PR TITLE
Use original base image in annotation

### DIFF
--- a/tasks/patches/add-sbom-and-push.yaml
+++ b/tasks/patches/add-sbom-and-push.yaml
@@ -90,8 +90,11 @@
     name: inject-sbom-and-push
     resources: {}
     script: |
+      base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $(params.IMAGE))
+      base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $(params.IMAGE))
       container=$(buildah from --pull-never $(params.IMAGE))
       buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
+      buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
       buildah commit $container $(params.IMAGE)
       buildah push \
         $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \


### PR DESCRIPTION
Since we are injecting sbom files the base image annotation is changed
to new image. Overriding with the original value.