### PR TITLE
sast-go: ignore return code of gosec

### DIFF
--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -21,7 +21,7 @@ spec:
           memory: 512Mi
           cpu: 10m
       script: |
-        /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=gosec_output.json $(workspaces.workspace.path)/... 2> gosec_output.txt
+        /usr/local/go/bin/gosec -no-fail -fmt=sarif -out=gosec_output.json $(workspaces.workspace.path)/... 2> gosec_output.txt || :
 
         # Test if any package was found
         # Even with -no-fail, gosec uses exit code 1 for several states,


### PR DESCRIPTION
Gosec could return different return code than 0 which aborts
pipelinerun. Before there was 'tee' command used which hide this
problem.