### PR TITLE
[HACBS-723] use clair-in-ci for getting image vulns

### DIFF
--- a/pipelines/hacbs/hacbs-test.yaml
+++ b/pipelines/hacbs/hacbs-test.yaml
@@ -62,13 +62,15 @@
     taskRef:
       name: get-clair-scan
     params:
-    - name: SHA
+    - name: image-digest
       value: $(tasks.build-container.results.IMAGE_DIGEST)
-    - name: PULLSPEC
-      value: $(params.output-image)
+    - name: image-url
+      value: $(tasks.build-container.results.IMAGE_URL)
     workspaces:
     - name: clair-ws
       workspace: workspace
+    - name: registry-auth
+      workspace: registry-auth
 - op: add
   path: /spec/finally/-
   value:

--- a/tasks/get-clair-scan.yaml
+++ b/tasks/get-clair-scan.yaml
@@ -5,71 +5,24 @@ metadata:
   name: get-clair-scan
 spec:
   params:
-    - name: SHA
-      description: sha of an image
-      type: string
-    - name: PULLSPEC
-      description: image full name with a tag
-      type: string
+    - name: image-digest
+      description: Image digest to scan
+    - name: image-url
+      description: Url to image
   steps:
     - name: get-vulnerabilities
-      image: quay.io/redhat-appstudio/hacbs-test:latest
+      image: quay.io/redhat-appstudio/clair-in-ci:latest
       script: |
         #!/usr/bin/env bash
-        temp='$(params.SHA)'
-        modifiedSha=${temp//:/%3A}
 
-        #ugly safety mechanism - need to be improved in future, bleh :(
+        imagewithouttag=$(echo '$(params.image-url)' | sed "s/\(.*\):.*/\1/" | tr -d '\n')
+        # strip new-line escape symbol from parameter and save it to variable
+        imageanddigest=$(echo $imagewithouttag@'$(params.image-digest)')
 
-        function safety_mechanism {
+        [ -f /workspace/registry-auth/.dockerconfigjson ] && REGISTRY_ARGS="/workspace/registry-auth/"
 
-        #curl request
-        http_code=$(curl -o $(workspaces.clair-ws.path)/clair-result.json -w '%{http_code}' -H "Content-type: application/json" -XGET https://quay.io/api/v1/repository/$(echo '$(params.PULLSPEC)' | sed "s/\(.*\):.*/\1/" | sed "s/^[^/]*\///")/manifest/$modifiedSha/security?vulnerabilities=true)
-        scan_file=$(workspaces.clair-ws.path)/clair-result.json
-
-        if [[ "$http_code" != "200" ]]
-        then
-          echo "Error, response code is not 200. Response code: $http_code"
-          echo "Body of response: $(cat $scan_file)"
-          rm -f $scan_file
-          exit 0
-        fi
-
-        #scan_file logic
-        if [[ ($(jq '.data' $scan_file) == null) ]]
-        then
-          retval=1
-        else
-          retval=0
-        fi
-        return $retval
-        }
-
-        retval=$(safety_mechanism)
-
-        function retry {
-          local n=0
-          local max=5
-          # TODO Clair scan time varies too much at the moment, from 10 minutes to +5 hours. Decreasing delay.
-          #local delay=60
-          local delay=0
-          while true; do
-            "$@" && [ "$retval"==0 ]  && break || {
-              if [[ $n -lt $max ]]; then
-                let n++
-                echo "Getting clair scan failed, because data were: $(jq '.data' $scan_file). Attempt $n/$max"
-                sleep $delay;
-              else
-                echo "The clair scan has status $(jq '.status' $scan_file) and was not obtained in $n attempts."
-                rm -f $scan_file
-                exit 0
-              fi
-            }
-          done
-        }
-
-        retry safety_mechanism
-
-
+        clair-action report --image-ref=$imageanddigest --db-path=/tmp/matcher.db --format=quay --docker-config-dir=$REGISTRY_ARGS > $(workspaces.clair-ws.path)/clair-result.json
   workspaces:
     - name: clair-ws
+    - name: registry-auth
+      optional: true


### PR DESCRIPTION
Adding solution to run clair scan on demand on customers image.

Runtimes on local crc:

**get-clair-db** : 1m 27s
**get-clair-results** : 1m 41s

example output of conftest-clair step:

```
STEP-CONFTEST-VULNERABILITIES

[
	{
		"filename": "/workspace/conftest-ws/clair-result.json",
		"namespace": "required_checks",
		"successes": 0,
		"failures": [
			{
				"msg": "Found packages with critical vulnerabilities: binutils, binutils-common, binutils-x86-64-linux-gnu, curl, libaom0, libbinutils, libc-bin, libc-dev-bin, libc6, libc6-dev, libctf-nobfd0, libctf0, libcurl3-gnutls, libcurl4, libcurl4-openssl-dev, libdb5.3, libdb5.3-dev, libde265-0, libfreetype-dev, libfreetype6, libfreetype6-dev, libopenjp2-7, libopenjp2-7-dev, libpcre2-16-0, libpcre2-32-0, libpcre2-8-0, libpcre2-dev, libpcre2-posix2, libpython3.9-minimal, libpython3.9-stdlib, libtiff-dev, libtiff5, libtiffxx5, python3.9, python3.9-minimal, wget",
				"metadata": {
					"details": {
						"description": "The image musn't contain packages that have critical severity vulnerabilities.",
						"name": "clair_critical_vulnerabilities",
						"url": "https://source.redhat.com/groups/public/product-security/content/product_security_folder/understanding_red_hat_security_vulnerabilities_10pdf"
					}
				}
			},
			{
				"msg": "Found packages with high vulnerabilities: binutils, binutils-common, binutils-x86-64-linux-gnu, comerr-dev, curl, e2fsprogs, gir1.2-gdkpixbuf-2.0, git, git-man, imagemagick, imagemagick-6-common, imagemagick-6.q16, krb5-multidev, libaom0, libbinutils, libc-bin, libc-dev-bin, libc6, libc6-dev, libcom-err2, libctf-nobfd0, libctf0, libcurl3-gnutls, libcurl4, libcurl4-openssl-dev, libde265-0, libext2fs2, libfreetype-dev, libfreetype6, libfreetype6-dev, libgcrypt20, libgdk-pixbuf-2.0-0, libgdk-pixbuf-2.0-dev, libgdk-pixbuf2.0-bin, libgdk-pixbuf2.0-common, libgssapi-krb5-2, libgssrpc4, libheif1, libk5crypto3, libkadm5clnt-mit12, libkadm5srv-mit12, libkdb5-10, libkrb5-3, libkrb5-dev, libkrb5support0, libldap-2.4-2, libmagickcore-6-arch-config, libmagickcore-6-headers, libmagickcore-6.q16-6, libmagickcore-6.q16-6-extra, libmagickcore-6.q16-dev, libmagickcore-dev, libmagickwand-6-headers, libmagickwand-6.q16-6, libmagickwand-6.q16-dev, libmagickwand-dev, libmariadb-dev, libmariadb-dev-compat, libmariadb3, libncurses-dev, libncurses5-dev, libncurses6, libncursesw5-dev, libncursesw6, libopenjp2-7, libopenjp2-7-dev, libpcre16-3, libpcre3, libpcre3-dev, libpcre32-3, libpcrecpp0v5, libperl5.32, libpython3.9-minimal, libpython3.9-stdlib, libsqlite3-0, libsqlite3-dev, libss2, libtiff-dev, libtiff5, libtiffxx5, libtinfo6, login, logsave, mariadb-common, ncurses-base, ncurses-bin, openssh-client, passwd, patch, perl, perl-base, perl-modules-5.32, python3.9, python3.9-minimal",
				"metadata": {
					"details": {
						"description": "The image musn't contain packages that have high severity vulnerabilities.",
						"name": "clair_high_vulnerabilities",
						"url": "https://source.redhat.com/groups/public/product-security/content/product_security_folder/understanding_red_hat_security_vulnerabilities_10pdf"
					}
				}
			},
			{
				"msg": "Found packages with medium vulnerabilities: binutils, binutils-common, binutils-x86-64-linux-gnu, bsdutils, coreutils, curl, imagemagick, imagemagick-6-common, imagemagick-6.q16, libaom0, libbinutils, libblkid-dev, libblkid1, libc-bin, libc-dev-bin, libc6, libc6-dev, libcairo-gobject2, libcairo-script-interpreter2, libcairo2, libcairo2-dev, libctf-nobfd0, libctf0, libcurl3-gnutls, libcurl4, libcurl4-openssl-dev, libde265-0, libjbig-dev, libjbig0, libjpeg-dev, libjpeg62-turbo, libjpeg62-turbo-dev, libldap-2.4-2, libmagickcore-6-arch-config, libmagickcore-6-headers, libmagickcore-6.q16-6, libmagickcore-6.q16-6-extra, libmagickcore-6.q16-dev, libmagickcore-dev, libmagickwand-6-headers, libmagickwand-6.q16-6, libmagickwand-6.q16-dev, libmagickwand-dev, libmount-dev, libmount1, libopenexr-dev, libopenexr25, libopenjp2-7, libopenjp2-7-dev, libpcre16-3, libpcre3, libpcre3-dev, libpcre32-3, libpcrecpp0v5, libpng-dev, libpng16-16, libpython3.9-minimal, libpython3.9-stdlib, libsmartcols1, libsqlite3-0, libsqlite3-dev, libsystemd0, libtiff-dev, libtiff5, libtiffxx5, libudev1, libuuid1, libxslt1-dev, libxslt1.1, login, mount, openssh-client, passwd, patch, python3.9, python3.9-minimal, unzip, util-linux, uuid-dev",
				"metadata": {
					"details": {
						"description": "The image musn't contain packages that have medium severity vulnerabilities.",
						"name": "clair_medium_vulnerabilities",
						"url": "https://source.redhat.com/groups/public/product-security/content/product_security_folder/understanding_red_hat_security_vulnerabilities_10pdf"
					}
				}
			},
			{
				"msg": "Found packages with low vulnerabilities: apt, binutils, binutils-common, binutils-x86-64-linux-gnu, curl, libapt-pkg6.0, libbinutils, libctf-nobfd0, libctf0, libcurl3-gnutls, libcurl4, libcurl4-openssl-dev, libsepol1, libsepol1-dev, libwebp-dev, libwebp6, libwebpdemux2, libwebpmux3, openssh-client",
				"metadata": {
					"details": {
						"description": "The image musn't contain packages that have low severity vulnerabilities.",
						"name": "clair_low_vulnerabilities",
						"url": "https://source.redhat.com/groups/public/product-security/content/product_security_folder/understanding_red_hat_security_vulnerabilities_10pdf"
					}
				}
			}
		]
	}
]
STEP-TEST-FORMAT-RESULT

{"result":"FAILURE","timestamp":"1656600099","namespace":"required_checks","successes":0,"failures":["clair_critical_vulnerabilities","clair_high_vulnerabilities","clair_medium_vulnerabilities","clair_low_vulnerabilities"]}
```
