### PR TITLE
PLNSRVCE-452: parameterize hacbs dependency analyser image so it can be overwritten in PR tests

### DIFF
--- a/tasks/buildah.yaml
+++ b/tasks/buildah.yaml
@@ -22,6 +22,10 @@ spec:
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
+  - default: quay.io/redhat-appstudio/hacbs-jvm-dependency-analyser:3f4824c3a29836a33a5bca3bcad386930b4197bc
+    description: The location of the HACBS dependency analyser image.
+    name: DEPENDENCY_ANALYSER_IMAGE
+    type: string
   - default: ./Dockerfile
     description: Path to the Dockerfile to build.
     name: DOCKERFILE

--- a/tasks/patches/add-sbom-and-push.yaml
+++ b/tasks/patches/add-sbom-and-push.yaml
@@ -33,7 +33,7 @@
   path: /spec/steps/-
   value:
     name: analyse-dependencies-java-sbom
-    image: quay.io/redhat-appstudio/hacbs-jvm-dependency-analyser:3f4824c3a29836a33a5bca3bcad386930b4197bc
+    image: $(params.DEPENDENCY_ANALYSER_IMAGE)
     script: |
       if [ -f /var/lib/containers/java ]; then
         /opt/jboss/container/java/run/run-java.sh path $(cat /workspace/container_path)

--- a/tasks/s2i-java.yaml
+++ b/tasks/s2i-java.yaml
@@ -34,6 +34,10 @@ spec:
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
+  - default: quay.io/redhat-appstudio/hacbs-jvm-dependency-analyser:3f4824c3a29836a33a5bca3bcad386930b4197bc
+    description: The location of the HACBS dependency analyser image.
+    name: DEPENDENCY_ANALYSER_IMAGE
+    type: string
   # Additional parameter for auth configuration
   - default: ""
     description: Extra parameters passed for the push command when pushing images.

--- a/tasks/s2i-nodejs.yaml
+++ b/tasks/s2i-nodejs.yaml
@@ -30,6 +30,10 @@ spec:
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
+  - default: quay.io/redhat-appstudio/hacbs-jvm-dependency-analyser:3f4824c3a29836a33a5bca3bcad386930b4197bc
+    description: The location of the HACBS dependency analyser image.
+    name: DEPENDENCY_ANALYSER_IMAGE
+    type: string
   # Additional parameter for auth configuration
   - default: ""
     description: Extra parameters passed for the push command when pushing images.


### PR DESCRIPTION
Unlike with the infra-deployments/preview.sh pattern, the only way I see where we can override the image used for the dependency analyser produced by jvm-build-service PRs is to

a) make the image a parameter in the task
b) when we eventually have e2e tests for jvm-build-service, those tests look for the env vars already being set by the ci config in openshift/release and *somehow* specify an override for this parameter when a build is invoked

Not knowing yet how b) will be implemented, this PR does a), which pending a better idea, is the first step regardless.

@mmorhun @mbharatk @dwalluck FYI

@sbose78 - what do you think?  Right approach, or should I pivot to another idea you may have?

@Michkov @stuartwdouglas @psturc FYI when you get back from PTO