### PR TITLE
sast-java-sec-check: increase memory limit to 4Gi

### DIFF
--- a/tasks/sast-java-sec-check.yaml
+++ b/tasks/sast-java-sec-check.yaml
@@ -34,7 +34,7 @@ spec:
       image: quay.io/redhat-appstudio/hacbs-test:feature-sast
       resources:
         limits:
-          memory: 2Gi
+          memory: 4Gi
           cpu: 2
         requests:
           memory: 512Mi


### PR DESCRIPTION
The SAST java check is failing with an OutOfMemory error for https://github.com/stuartwdouglas/code-with-quarkus

See more in the Slack conversation at https://coreos.slack.com/archives/C030SGP2VB9/p1657832614510839