### PR TITLE
sast-java-sec-check: increase memory limit to 8Gi

### DIFF
--- a/tasks/sast-java-sec-check.yaml
+++ b/tasks/sast-java-sec-check.yaml
@@ -34,7 +34,7 @@ spec:
       image: quay.io/redhat-appstudio/hacbs-test:feature-sast
       resources:
         limits:
-          memory: 4Gi
+          memory: 8Gi
           cpu: 2
         requests:
           memory: 512Mi


### PR DESCRIPTION
Follow up on https://coreos.slack.com/archives/C030SGP2VB9/p1657832614510839