### PR TITLE
Disable Cosign experimental features by default

### DIFF
--- a/tasks/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract.yaml
@@ -40,8 +40,8 @@ spec:
 
     - name: COSIGN_EXPERIMENTAL
       type: string
-      description: Control transparency log lookups. Set to "0" to disable it.
-      default: "1"
+      description: Control transparency log lookups. Set to "1" to enable it.
+      default: "0"
 
     - name: REKOR_HOST
       type: string


### PR DESCRIPTION
This disables Rekor transparency log validation and Fulcio CA support
by setting the default value of `COSIGN_EXPERIMENTAL` to `0`, instead of
previous `1` - meaning enabled by default.

Seems that there was a change in how TUF is deployed at Sigstore so the
call to fetch the Fulcio CA certificate done by the code to verify
against the transparency log now results in a panic:

```
panic: error getting targets

goroutine 1 [running]:
github.com/sigstore/cosign/cmd/cosign/cli/fulcio/fulcioroots.Get.func1()
	github.com/sigstore/cosign@v1.8.0/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go:68 +0x74
sync.(*Once).doSlow(0xc00021be40, 0x1c)
	sync/once.go:68 +0xd2
sync.(*Once).Do(...)
	sync/once.go:59
github.com/sigstore/cosign/cmd/cosign/cli/fulcio/fulcioroots.Get()
	github.com/sigstore/cosign@v1.8.0/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go:64 +0x31
github.com/sigstore/cosign/cmd/cosign/cli/fulcio.GetRoots(...)
	github.com/sigstore/cosign@v1.8.0/cmd/cosign/cli/fulcio/fulcio.go:157
github.com/sigstore/cosign/cmd/cosign/cli/verify.(*VerifyCommand).Exec(0xc000751c48, {0x2e75ee8, 0xc000052040}, {0xc0008eced0, 0x1, 0x6906e5})
	github.com/sigstore/cosign@v1.8.0/cmd/cosign/cli/verify/verify.go:113 +0x2fc
github.com/sigstore/cosign/cmd/cosign/cli.Verify.func1(0xc00095d680, {0xc0008eced0, 0x1, 0x3})
	github.com/sigstore/cosign@v1.8.0/cmd/cosign/cli/verify.go:115 +0x265
github.com/spf13/cobra.(*Command).execute(0xc00095d680, {0xc0008ecea0, 0x3, 0x3})
	github.com/spf13/cobra@v1.4.0/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003c6280)
	github.com/spf13/cobra@v1.4.0/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.4.0/command.go:902
main.main()
	github.com/sigstore/cosign@v1.8.0/cmd/cosign/main.go:51 +0x4c
```

This disables that Fulcio CA certificate lookup to avoid the panic.