### PR TITLE
verify-ec-v2: fix display and strict

### DIFF
--- a/hack/start-verify-ec-task-v2.sh
+++ b/hack/start-verify-ec-task-v2.sh
@@ -99,7 +99,7 @@ spec:
 
     # Modify these defaults as required
     #- name: STRICT
-    #  value: "1"
+    #  value: "false"
     #- name: POLICY_CONFIGURATION
     #  value: ${NAMESPACE}/ec-policy
 

--- a/hack/start-verify-ec-task-v2.sh
+++ b/hack/start-verify-ec-task-v2.sh
@@ -32,6 +32,26 @@ PUBLIC_KEY_SECRET="${PUBLIC_KEY_SECRET:-cosign-public-key}"
 NAMESPACE="$(oc project -q)"
 
 #
+# Create a simple Policy
+#
+oc apply -f - <<EOF
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: ec-policy
+spec:
+  description: Red Hat's enterprise requirements
+  exceptions:
+    nonBlocking:
+    - not_useful
+  sources:
+  - git:
+      repository: https://github.com/hacbs-contract/ec-policies
+      revision: main
+EOF
+
+#
 # Create an ApplicationSnapshot resource to ensure we're using correct format.
 #
 oc apply -f - <<EOF

--- a/tasks/verify-enterprise-contract-v2.yaml
+++ b/tasks/verify-enterprise-contract-v2.yaml
@@ -53,8 +53,8 @@ spec:
 
     - name: STRICT
       type: string
-      description: Fail the task if policy fails. Set to "0" to disable it.
-      default: "1"
+      description: Fail the task if policy fails. Set to "false" to disable it.
+      default: "true"
 
   results:
     - name: REPORT
@@ -66,7 +66,7 @@ spec:
       command: [ec]
       args:
         - version
-    - name: verify
+    - name: validate
       image: appstudio-utils
       command: [ec]
       args:
@@ -80,8 +80,8 @@ spec:
         - "$(params.PUBLIC_KEY)"
         - "--rekor-url"
         - "$(params.REKOR_HOST)"
-        - "--strict"
-        - "$(params.STRICT)"
+        # NOTE: The syntax below is required to negate boolean parameters
+        - "--strict=false"
         - "--output-file"
         - "$(results.REPORT.path)"
       env:
@@ -94,3 +94,19 @@ spec:
           # value expected by Tekton Pipelines. NOTE: If params.SSL_CERT_DIR is empty, the value
           # will contain a trailing ":" - this is ok.
           value: "/tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs:/system/etc/security/cacerts:$(params.SSL_CERT_DIR)"
+    - name: display
+      image: appstudio-utils
+      command: [jq]
+      args:
+        - "."
+        - "$(results.REPORT.path)"
+    - name: assert
+      image: appstudio-utils
+      command: [jq]
+      args:
+        - "--argjson"
+        - "strict"
+        - "$(params.STRICT)"
+        - "-e"
+        - ".success or ($strict | not)"
+        - "$(results.REPORT.path)"


### PR DESCRIPTION
This change ensures the policy report is always displayed, regardless of its status.

It also fixes the STRICT parameter so it can be disabled.

https://issues.redhat.com/browse/HACBS-881
https://issues.redhat.com/browse/HACBS-882
