### PR TITLE
Disable Rekor lookup in e2e-ec Pipeline

### DIFF
--- a/pipelines/hacbs/e2e-ec.yaml
+++ b/pipelines/hacbs/e2e-ec.yaml
@@ -31,8 +31,8 @@ spec:
       default: HACBS_TEST_OUTPUT
     - name: COSIGN_EXPERIMENTAL
       type: string
-      description: Control transparency log lookups. Set to "0" to disable it.
-      default: "1"
+      description: Control transparency log lookups. Set to "1" to enable it.
+      default: "0"
     - name: REKOR_HOST
       type: string
       description: Rekor host for transparency log lookups


### PR DESCRIPTION
This was forgotten in #170, now the Pipeline used in the end to end
tests also disables Cosign experimental features by default.