### PR TITLE
Dynamically determine built bundles

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -60,13 +60,29 @@ spec:
           params:
             - name: revision
               type: string
+          results:
+            - name: TASK_BUNDLES
+              description: A "\n" separated list of created task bundles
+            - name: PIPELINE_BUNDLES
+              description: A "\n" separated list of created pipeline bundles
           steps:
             - name: build-bundles
               image: quay.io/redhat-appstudio/appstudio-utils:{{ revision }}
               workingDir: $(workspaces.source.path)
-              script: |
-                #!/usr/bin/env bash
-                MY_QUAY_USER=redhat-appstudio BUILD_TAG=$(params.revision) SKIP_BUILD=1 SKIP_INSTALL=1 hack/build-and-push.sh
+              command: ["./hack/build-and-push.sh"]
+              env:
+                - name: MY_QUAY_USER
+                  value: redhat-appstudio
+                - name: BUILD_TAG
+                  value: "$(params.revision)"
+                - name: SKIP_BUILD
+                  value: "1"
+                - name: SKIP_INSTALL
+                  value: "1"
+                - name: OUTPUT_TASK_BUNDLE_LIST
+                  value: "$(results.TASK_BUNDLES.path)"
+                - name: OUTPUT_PIPELINE_BUNDLE_LIST
+                  value: "$(results.PIPELINE_BUNDLES.path)"
           workspaces:
             - name: source
       - name: update-infra-repo
@@ -101,21 +117,17 @@ spec:
             value: "25969606"
           - name: SCRIPT
             value: |
-              TAG='$(params.revision)'
-
+              BUNDLES=(
+                $(tasks.build-bundles.results.TASK_BUNDLES)
+                $(tasks.build-bundles.results.PIPELINE_BUNDLES)
+              )
+              BUNDLES_PARAM=(
+                $(printf -- '--bundle=%s ' "${BUNDLES[@]}")
+              )
               ec track bundle \
                 --input data/acceptable_tekton_bundles.yml \
-                --type task-bundles \
                 --replace \
-                --bundle "quay.io/redhat-appstudio/appstudio-tasks:${TAG}-1" \
-                --bundle "quay.io/redhat-appstudio/appstudio-tasks:${TAG}-2" \
-                --bundle "quay.io/redhat-appstudio/appstudio-tasks:${TAG}-3"
-
-              ec track bundle \
-                --input data/acceptable_tekton_bundles.yml \
-                --type pipeline-bundles \
-                --replace \
-                --bundle "quay.io/redhat-appstudio/build-templates-bundle:${TAG}"
+                "${BUNDLES_PARAM[@]}"
         taskRef:
           name: update-infra-deployments
     workspaces:


### PR DESCRIPTION
Changed hack/build-and-push.sh to record the Tekton bundles that it
produces. Then, use that output to call the "ec track" command.

This handles the case where the number of bundles changes unexpectedly.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>