### PR TITLE
PLNSRVCE-451: Adds Tekton result with couting of SBOM Java dependencies

### DIFF
--- a/tasks/patches/add-sbom-and-push.yaml
+++ b/tasks/patches/add-sbom-and-push.yaml
@@ -2,6 +2,12 @@
   path: /metadata/labels/build-definition.include
 
 - op: add
+  path: /spec/results/-
+  value:
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    description: The counting of Java components by publisher in JSON format
+
+- op: add
   path: /spec/steps/-
   value:
     image: $(params.BUILDER_IMAGE)
@@ -48,13 +54,17 @@
 - op: add
   path: /spec/steps/-
   value:
+    env:
+      - name: SBOM_JAVA_COMPONENTS_COUNT_PATH
+        value: $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
     image: registry.redhat.io/ubi8/python-39:1-51
     name: merge-sboms
     script: |
       #!/bin/python3
       import json
-      import os.path
+      import os
 
+      # load SBOMs
       with open("./sbom-image.json") as f:
         image_sbom = json.load(f)
 
@@ -66,6 +76,7 @@
         with open("./sbom-java.json") as f:
           java_sbom = json.load(f)
 
+      # fetch unique components from available SBOMs
       def get_identifier(component):
         return component["name"] + '@' + component.get("version", "")
 
@@ -82,14 +93,33 @@
 
       image_sbom["components"].sort(key=lambda c: get_identifier(c))
 
+      # write the CycloneDX unified SBOM
       with open("./sbom-cyclonedx.json", "w") as f:
         json.dump(image_sbom, f, indent=4)
 
+      # create and write the PURL unified SBOM
       purls = [{"purl": component["purl"]} for component in image_sbom["components"] if "purl" in component]
       purl_content = {"image_contents": {"dependencies": purls}}
 
       with open("sbom-purl.json", "w") as output_file:
-          json.dump(purl_content, output_file, indent=4)
+        json.dump(purl_content, output_file, indent=4)
+
+      # create Tekton result containing counting of Java publishers
+      java_publishers = {}
+
+      for component in java_sbom["components"]:
+        publisher = component.get("publisher", None)
+
+        if publisher is None:
+          continue
+
+        if publisher not in java_publishers.keys():
+          java_publishers[publisher] = 0
+
+        java_publishers[publisher] += 1
+
+      with open(os.getenv("SBOM_JAVA_COMPONENTS_COUNT_PATH"), "w") as f:
+        json.dump(java_publishers, f, indent=4)
 
     workingDir: $(workspaces.source.path)
     securityContext:


### PR DESCRIPTION
This PR updates the `merge-sbom` step to generate a simple JSON that contains how many Java components were identified in the SBOM for each publisher, e.g.:

```
{
   "central": 22,
   "rebuilt": 3,
   "gradle": 1
}
```

The goal is to make it simple to identify if a pipeline used community packages or not.