### PR TITLE
Update ec-policies bundle update

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -105,17 +105,10 @@ spec:
 
               ec track bundle \
                 --input data/acceptable_tekton_bundles.yml \
-                --type task-bundles \
                 --replace \
                 --bundle "quay.io/redhat-appstudio/appstudio-tasks:${TAG}-1" \
                 --bundle "quay.io/redhat-appstudio/appstudio-tasks:${TAG}-2" \
                 --bundle "quay.io/redhat-appstudio/appstudio-tasks:${TAG}-3"
-
-              ec track bundle \
-                --input data/acceptable_tekton_bundles.yml \
-                --type pipeline-bundles \
-                --replace \
-                --bundle "quay.io/redhat-appstudio/build-templates-bundle:${TAG}"
         taskRef:
           name: update-infra-deployments
     workspaces:


### PR DESCRIPTION
With hacbs-contract/ec-cli#109 we removed the `--type` parameter from
the `track bundle` subcommand, and replaced this with detecting the
content of the bundle by examining the bundle image. This updates to
remove the `--type` parameter from the PipelineRun that is used to
update the bundles stored in hacbs-contract/ec-policies repository.