### PR TITLE
Fix fetching policy configuration

### DIFF
--- a/appstudio-utils/util-scripts/lib/fetch/cluster.sh
+++ b/appstudio-utils/util-scripts/lib/fetch/cluster.sh
@@ -55,6 +55,9 @@ save-policy-config() {
     local namespace=${namespace_arg#-n }
     echo "ERROR: unable to find the ec-policy EnterpriseContractPolicy in namespace ${namespace:-$(kubectl config view --minify -o jsonpath='{..namespace}')}" 1>&2
   else
+    if [[ -z "${non_blocking_data}" ]]; then
+      non_blocking_data='[]'
+    fi
     # Save the config data from the ECP
     echo "$non_blocking_data" | jq '{"config": {"policy": {"non_blocking_checks": . }}}' > "${config_file}"
     return 0

--- a/test/fetch-test-data_spec.sh
+++ b/test/fetch-test-data_spec.sh
@@ -317,7 +317,7 @@ Describe 'save-policy-config'
       The contents of file "${EC_WORK_DIR}/data/config.json" should eq "$(echo '{"config":{"policy":{"non_blocking_checks":["a", "b", "c"]}}}'| jq)"
     End
 
-    It 'can fail to fetch from custom resource'
+    It 'can fail to fetch from custom resource and ConfigMap - uses the default'
       Mock kubectl
         kubectl_args=$*
         %preserve kubectl_args
@@ -330,9 +330,20 @@ Describe 'save-policy-config'
       When call save-policy-config custom-namespace/custom-policy
       The variable kubectl_args should start with 'get enterprisecontractpolicies.appstudio.redhat.com -n custom-namespace custom-policy'
       The error should equal 'ERROR: unable to find the ec-policy EnterpriseContractPolicy in namespace custom-namespace'
-      The file "${EC_WORK_DIR}/data/config.json" should not be exist
-      The status should be failure
+      The contents of file "${EC_WORK_DIR}/data/config.json" should eq "$(echo '{"config":{"policy":{"non_blocking_checks":["not_useful"]}}}'| jq)"
     End
+
+    It 'nothing blocked'
+      Mock kubectl
+        kubectl_args=$*
+        %preserve kubectl_args
+        echo ''
+      End
+      When call save-policy-config custom-policy
+      The variable kubectl_args should start with 'get enterprisecontractpolicies.appstudio.redhat.com custom-policy'
+      The contents of file "${EC_WORK_DIR}/data/config.json" should eq "$(echo '{"config":{"policy":{"non_blocking_checks":[]}}}'| jq)"
+    End
+
   End
 
   Describe 'handles errors from cr-* functions'


### PR DESCRIPTION
When the EnterpriseContractPolicy custom resource has `nonBlocking` key
at all the result of piping an empty string to `jq` renders empty string
and the `config.json` ends up being empty file.
This makes sure that in that case the `config.json` doesn't end up being
empty by setting `non_blocking_data` to `[]` when fetching the
configuration from the cluster.