### PR TITLE
Fix passing of `STRICT` parameter to VEC V2

### DIFF
--- a/pipelines/hacbs/e2e-ec.yaml
+++ b/pipelines/hacbs/e2e-ec.yaml
@@ -49,8 +49,12 @@ spec:
       default: ""
     - name: STRICT_POLICY
       type: string
-      description: Fail the task if policy fails. Set to "0" to disable it.
+      description: Fail the V1 task if policy fails. Set to "0" to disable it.
       default: "1"
+    - name: STRICT
+      type: string
+      description: Fail the V2 task if policy fails. Set to "false" to disable it.
+      default: "true"
   tasks:
     - name: verify-enterprise-contract
       params:
@@ -85,6 +89,6 @@ spec:
         - name: SSL_CERT_DIR
           value: "$(params.SSL_CERT_DIR)"
         - name: STRICT
-          value: "$(params.STRICT_POLICY)"
+          value: "$(params.STRICT)"
       taskRef:
         name: verify-enterprise-contract-v2


### PR DESCRIPTION
For `verify-enterprise-task` we need to pass `"1"` as `STRICT_POLICY`
PipelineRun parameter, and for `verify-enterprise-task-v2` we need to
pass `"true"` as `STRICT` PipelineRun parameter, for the enforcement to
be strict.

Likewise we can pass anything but `"1"` to as `STRICT_POLICY`, and
almost anything but `"true"` for `STRICT` parameter for the enforcement
not to be strict.

This makes it difficult to have a single PipelineRun parameter, so this
introduces a second parameter to cater to the V2 task.

Ref. https://issues.redhat.com/browse/HACBS-762