### PR TITLE
Set HOME for verify-ec2 task

### DIFF
--- a/tasks/verify-enterprise-contract-v2.yaml
+++ b/tasks/verify-enterprise-contract-v2.yaml
@@ -56,9 +56,19 @@ spec:
       description: Fail the task if policy fails. Set to "false" to disable it.
       default: "true"
 
+    - name: HOMEDIR
+      type: string
+      description: Value for the HOME environment variable.
+      default: /tekton/home
+
   results:
     - name: REPORT
       description: Details of the policy evaluation for each image
+
+  stepTemplate:
+    env:
+      - name: HOME
+        value: "$(params.HOMEDIR)"
 
   steps:
     - name: version


### PR DESCRIPTION
As recommended by https://access.redhat.com/solutions/6956010

This allows running the verify-enterprise-contract-v2 task with the
"restricted" scc (SecurityContextConstraint). This is the scc assigned
to ServiceAccounts by default, inluding the "default" ServiceAccount.

Since the release pipeline executes with a custom ServiceAccount, this
makes it easier to use the task in that environment.

https://issues.redhat.com/browse/HACBS-880

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>