### PR TITLE
PLNSRVCE-534: have sidecar image pull policy conform with production grade k8s conventions

### DIFF
--- a/tasks/patches/add-sbom-and-push.yaml
+++ b/tasks/patches/add-sbom-and-push.yaml
@@ -156,7 +156,7 @@
   path: /spec/sidecars
   value:
   - image: quay.io/redhat-appstudio/hacbs-jvm-sidecar:09743ae5f54cc12068bbb31b7050d2bca40a91d3
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     env:
       - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
         value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"


### PR DESCRIPTION
Same rationale as https://github.com/redhat-appstudio/jvm-build-service/pull/154

So yeah in production k8s clusters, the general convention is to not use Always for the image pull policy. That policy best serves inner loop development.

And sure enough, "stress testing", i.e. building service registry, I did instances of

`Failed to pull image .... pull QPS exceeded`

So a low hanging fruit improvement.