### PR TITLE
PLNSRVCE-534: depend on IfNotPresent being default (consistent with other steps) and use of specific sha's

### DIFF
--- a/tasks/patches/add-sbom-and-push.yaml
+++ b/tasks/patches/add-sbom-and-push.yaml
@@ -156,7 +156,6 @@
   path: /spec/sidecars
   value:
   - image: quay.io/redhat-appstudio/hacbs-jvm-sidecar:09743ae5f54cc12068bbb31b7050d2bca40a91d3
-    imagePullPolicy: IfNotPresent
     env:
       - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
         value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"


### PR DESCRIPTION
had some good exchange with @fgiloux in https://coreos.slack.com/archives/C032EJ007C0/p1659512174591189

I think the consistent approach, given if not present is default, all are image refs are sha specific, and as the other steps in general for app studio do not set image pull policy, is just to remove the setting here.

I will be making a similar update in jvm-build-service as well