### PR TITLE
[HACBS-959]-skip clamav scan for attestation images

### DIFF
--- a/tasks/clamav-scan.yaml
+++ b/tasks/clamav-scan.yaml
@@ -32,6 +32,12 @@ spec:
         # strip new-line escape symbol from parameter and save it to variable
         imageanddigest=$(echo $imagewithouttag@'$(params.image-digest)')
 
+        # check if image is attestation one, skip the clamav scan in such case
+        if [[ $imageanddigest == *.att ]]
+        then
+            echo "$imageanddigest is an attestation image, skipping clamav scan"
+            exit 0
+        fi
         [ -f /workspace/registry-auth/.dockerconfigjson ] && REGISTRY_ARGS="-a /workspace/registry-auth/.dockerconfigjson"
         mkdir content
         cd content
@@ -49,6 +55,11 @@ spec:
         #!/usr/bin/env python3.9
         import json
         import dateutil.parser as parser
+        import os
+
+        if os.stat("/tekton/home/clamscan-result.log").st_size == 0:
+            print("clamscan-result.log file is empty, meaning previous step didn't extracted the compiled code, skipping parsing.")
+            exit(0)
 
         with open("/tekton/home/clamscan-result.log", "r") as file:
             clam_result_str = file.read()


### PR DESCRIPTION
There is currently issue with attestation images causing errors during **oc image extract** command:

`error: unable to extract layer sha256:570dc024d08eb5044a0c29d41d4f777931b910ce30080b583e4aabdbc0eb43ff from quay.io/redhat-appstudio/user-workload:sha256-96aad71edef114ed6486116a66d9e2e1f6e469ca0f6e156ec0b062b3c98922a0.att: archive/tar: invalid tar header`

This change will be rolled-back after the attestation images are fixed.

In case of attestation image both clamav and parsing is skipped (exit 0)