### PR TITLE
PLNSRVCE-533: bump jvm analyzer/sidecar with recent features/fixes

### DIFF
--- a/tasks/patches/add-sbom-and-push.yaml
+++ b/tasks/patches/add-sbom-and-push.yaml
@@ -39,7 +39,7 @@
   path: /spec/steps/-
   value:
     name: analyse-dependencies-java-sbom
-    image: quay.io/redhat-appstudio/hacbs-jvm-dependency-analyser:09743ae5f54cc12068bbb31b7050d2bca40a91d3
+    image: quay.io/redhat-appstudio/hacbs-jvm-dependency-analyser:70a63556e607e02fe6a19a3f13bb35cedc1f3043
     script: |
       if [ -f /var/lib/containers/java ]; then
         /opt/jboss/container/java/run/run-java.sh path $(cat /workspace/container_path) -s $(workspaces.source.path)/sbom-java.json
@@ -155,7 +155,7 @@
 - op: add
   path: /spec/sidecars
   value:
-  - image: quay.io/redhat-appstudio/hacbs-jvm-sidecar:09743ae5f54cc12068bbb31b7050d2bca40a91d3
+  - image: quay.io/redhat-appstudio/hacbs-jvm-sidecar:70a63556e607e02fe6a19a3f13bb35cedc1f3043
     env:
       - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
         value: "http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local"


### PR DESCRIPTION
If I see it correctly we have not bumped the analyzer and sidecar in the bundle in 22 days since https://github.com/redhat-appstudio/build-definitions/pull/159

@psturc I've tagged this into PLNSRVCE-533 because I think you are going to need various fixes in these images when you test using a component that leverages the bundle.  In particluar, there were discussion in jvm build service PRs which indicated you would need https://github.com/redhat-appstudio/jvm-build-service/pull/155

I should also note though that as I open this PR @Michkov @stuartwdouglas https://github.com/redhat-appstudio/infra-deployments/pull/558 has not caught up yet and does not include the 27a8ba29a84a23b829afd7daee5f9ed91c802a02 from PR 155.  It is only up to PR 154 and commit c42cb3e8ebad4022e13552eedf829842e549ad6a.

I assume that will change soon enough, but I would think that we do not merge this PR until https://github.com/redhat-appstudio/infra-deployments/pull/558 includes 27a8ba29a84a23b829afd7daee5f9ed91c802a02