### PR TITLE
Create jvm build config and default secret for pull

### DIFF
--- a/pipelines/hacbs/hacbs-java-builds.yaml
+++ b/pipelines/hacbs/hacbs-java-builds.yaml
@@ -3,3 +3,8 @@
   value:
     name: MAVEN_MIRROR_URL
     value: http://localhost:2000/maven2
+- op: add
+  path: /spec/tasks/0/params/-
+  value:
+    name: jvm-build-service-init
+    value: "true"

--- a/pipelines/hacbs/kustomization.yaml
+++ b/pipelines/hacbs/kustomization.yaml
@@ -26,4 +26,10 @@ patches:
       group: tekton.dev
       version: v1beta1
       kind: Pipeline
-      labelSelector: skip-hacbs-test != true
+      labelSelector: skip-hacbs-test != true, pipelines.openshift.io/runtime == java
+  - path: hacbs-java-builds.yaml
+    target:
+      group: tekton.dev
+      version: v1beta1
+      kind: Pipeline
+      labelSelector: skip-hacbs-test != true, pipelines.openshift.io/runtime == generic

--- a/tasks/init.yaml
+++ b/tasks/init.yaml
@@ -11,6 +11,9 @@ spec:
     - name: rebuild
       description: Rebuild the image if exists
       default: "false"
+    - name: jvm-build-service-init
+      description: Set jvm build service config
+      default: "false"
   results:
     - name: build
   steps:
@@ -26,4 +29,10 @@ spec:
           echo -n "true" > $(results.build.path)
         else
           echo -n "false" > $(results.build.path)
+        fi
+    - name: hacbs-init
+      image: registry.redhat.io/openshift4/ose-cli:v4.10
+      script: |
+        if [ "$(params.jvm-build-service-init)" == "true" ] && ! oc get configmap jvm-build-config &>/dev/null; then
+          oc create configmap jvm-build-config --from-literal enable-rebuilds="false"
         fi

--- a/tasks/init.yaml
+++ b/tasks/init.yaml
@@ -36,3 +36,7 @@ spec:
         if [ "$(params.jvm-build-service-init)" == "true" ] && ! oc get configmap jvm-build-config &>/dev/null; then
           oc create configmap jvm-build-config --from-literal enable-rebuilds="false"
         fi
+        # Create empty secret which is now hardcoded in PaC Pipelinerun template
+        if ! oc get secret redhat-appstudio-registry-pull-secret &>/dev/null; then
+          oc create secret generic redhat-appstudio-registry-pull-secret
+        fi


### PR DESCRIPTION
- Ensure that jvm-build-config is created so cache service is deployed and can be used
- Ensure redhat-appstudio-registry-pull-secret is created so the build task will not be blocked in PaC workflow