### PR TITLE
fix[HACBS-951]-result size limit

### DIFF
--- a/tasks/conftest-clair.yaml
+++ b/tasks/conftest-clair.yaml
@@ -24,7 +24,7 @@ spec:
                    timestamp: $date,
                    namespace,
                    successes,
-                   failures: (.failures // [])|map(.metadata.details.name)
+                   failures: (.failures // [])|map(.metadata.details.name) | unique
                  }' $(workspaces.conftest-ws.path)/clair-vulnerabilities.json || true)
         echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
   workspaces:

--- a/tasks/deprecated-image-check.yaml
+++ b/tasks/deprecated-image-check.yaml
@@ -67,7 +67,7 @@ spec:
                    timestamp: $date,
                    namespace,
                    successes,
-                   failures: (.failures // [])|map(.metadata.details.name)
+                   failures: (.failures // [])|map(.metadata.details.name) | unique
                  }' $(workspaces.sanity-ws.path)/deprecated_image_check_output.json || true)
         echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
   workspaces:

--- a/tasks/sanity-label-check.yaml
+++ b/tasks/sanity-label-check.yaml
@@ -40,6 +40,6 @@ spec:
                    timestamp: $date,
                    namespace,
                    successes,
-                   failures: (.failures // [])|map(.metadata.details.name)
+                   failures: (.failures // [])|map(.metadata.details.name) | unique
                  }' sanity_label_check_output.json || true)
         echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)

--- a/tasks/sast-go.yaml
+++ b/tasks/sast-go.yaml
@@ -42,7 +42,7 @@ spec:
                namespace: "default",
                successes: 0,
                note: (if $tmp_not_skipped=="0" then $SKIP_MESSAGE else "" end),
-               failures: (.runs[].results // [])|map(.message.text)
+               failures: (.runs[].results // [])|map(.message.text) | unique
              }' gosec_output.json || true)
         else
           HACBS_TEST_OUTPUT=$(jq -rc --arg date $(date +%s) --arg tmp_not_skipped $test_not_skipped --null-input \

--- a/tasks/sast-snyk-check.yaml
+++ b/tasks/sast-snyk-check.yaml
@@ -50,7 +50,7 @@ spec:
                    namespace: "default",
                    successes: 0,
                    note: "",
-                   failures: (.runs[].results // [])|map(.message.text)
+                   failures: (.runs[].results // [])|map(.message.text) | unique
                  }' sast_snyk_check_out.json || true)
         # When the test is skipped, the "SNYK_EXIT_CODE" is 3 and it can also be 3 in some other situation
         elif [[ "$test_not_skipped" -eq 0 ]]; then


### PR DESCRIPTION
Tekton **result** capabilities are not sufficient for our use cases. We needed to avoid duplicities in gosec log.