### PR TITLE
fix(HACBS-1002): Missing backslash and output in Java sast jq

### DIFF
--- a/tasks/sast-java-sec-check.yaml
+++ b/tasks/sast-java-sec-check.yaml
@@ -54,6 +54,7 @@ spec:
         if [ -n "$JAR_PATH" ]; then
           /home/findsecbugs-cli/findsecbugs.sh $(params.OPTIONAL_ARGS) $(params.OUTPUT_ONLY_ANALYZE) -$(params.OUTPUT_FORMAT) \
             -output sast_java_sec_output.json $JAR_PATH  2> stderr.txt
+          cat sast_java_sec_output.json
           test_skipped=0
         else
           echo "jar file $JAR_PATH doesn't exist" > stderr.txt
@@ -62,7 +63,7 @@ spec:
 
         ERR_MSG="$(echo -n $(cat stderr.txt))"
         ERR_MSG="${ERR_MSG:-unknown}"
-        HACBS_ERROR_OUTPUT=$(jq -rc --arg date $(date +%s) --arg MSG "${ERR_MSG: 0: 3000}"
+        HACBS_ERROR_OUTPUT=$(jq -rc --arg date $(date +%s) --arg MSG "${ERR_MSG: 0: 3000}" \
                               --arg test_skipped $test_skipped --null-input \
             '{result: (if $test_skipped=="1" then "SKIPPED" else "ERROR" end),
               timestamp: $date,


### PR DESCRIPTION
* Fix the missing backlash
* Output the sast output to task log