### PR TITLE
Automatically resolve short-names

### DIFF
--- a/tasks/buildah.yaml
+++ b/tasks/buildah.yaml
@@ -70,6 +70,7 @@ spec:
         sed -i -e 's|RUN mvn|RUN echo "<settings><mirrors><mirror><id>mirror.default</id><url>$(params.MAVEN_MIRROR_URL)</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>" > /tmp/settings.yaml; mvn -s /tmp/settings.yaml|g' $(params.CONTEXT)/$(params.DOCKERFILE)
         touch /var/lib/containers/java
       fi
+      sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
       buildah bud \
         $(params.BUILD_EXTRA_ARGS) \
         --tls-verify=$(params.TLSVERIFY) --no-cache \

--- a/tasks/s2i-java.yaml
+++ b/tasks/s2i-java.yaml
@@ -83,6 +83,7 @@ spec:
       name: gen-source
   - script: |
       touch /var/lib/containers/java
+      sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
       buildah bud --tls-verify=$(params.TLSVERIFY) --layers --ulimit nofile=4096:4096 -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
     image: $(params.BUILDER_IMAGE)
     name: build

--- a/tasks/s2i-nodejs.yaml
+++ b/tasks/s2i-nodejs.yaml
@@ -71,6 +71,7 @@ spec:
       name: gen-source
     workingDir: $(workspaces.source.path)
   - script: |
+      sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
       buildah bud --tls-verify=$(params.TLSVERIFY) --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
     image: $(params.BUILDER_IMAGE)
     name: build


### PR DESCRIPTION
Buildah started to require full image names which breaks current image
builds.

Setting short-name-mode to disabled -> Use all unqualified-search registries without prompting.