### PR TITLE
additional jvm related steps need runasuser 0 on 4.11

### DIFF
--- a/tasks/patches/add-sbom-and-push.yaml
+++ b/tasks/patches/add-sbom-and-push.yaml
@@ -152,6 +152,7 @@
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
     securityContext:
+      runAsUser: 0
       capabilities:
         add:
           - SETFCAP
@@ -178,6 +179,8 @@
       - name: QUARKUS_S3_AWS_CREDENTIALS_TYPE
         value: "static"
     name: proxy
+    securityContext:
+      runAsUser: 0
     livenessProbe:
       httpGet:
         path: /q/health/live

--- a/tasks/s2i-java.yaml
+++ b/tasks/s2i-java.yaml
@@ -95,6 +95,7 @@ spec:
         memory: 512Mi
         cpu: 10m
     securityContext:
+      runAsUser: 0
       capabilities:
         add:
           - SETFCAP


### PR DESCRIPTION
continuing running on 4.11 effort that @Michkov started recently (where he alerted me there were some items wrt java that still needed to be handled)

in testing on a 4.11 OCP cluster with boostrapped appstudio, I saw these problems when running @psturc new  component based e2e

```
[build-container : build] Error: error writing "0 0 4294967295\n" to /proc/23/uid_map: write /proc/23/uid_map: operation not permitted
[build-container : build] time="2022-08-23T00:24:44Z" level=error msg="error writing \"0 0 4294967295\\n\" to /proc/23/uid_map: write /proc/23/uid_map: operation not permitted"
[build-container : build] time="2022-08-23T00:24:44Z" level=error msg="(Unable to determine exit status)"

[build-container : inject-sbom-and-push] writing blob: initiating layer upload to /v2/redhat-appstudio-qe/test-images/blobs/uploads/ in quay.io: unauthorized: access to the requested resource is not authorized

[build-container : sidecar-proxy] rpc error: code = NotFound desc = could not find container "837f5960acff128c01de4ed42db6fc0baca78fa185ce35125eb55efbb56e6be6": container with ID starting with 837f5960acff128c01de4ed42db6fc0baca78fa185ce35125eb55efbb56e6be6 not found: ID does not exist

```

these errors wen away after making these changes to the bundle and updating my running cluster with build-and-push.sh

I have a temp e2e-tests PR ready to go, attempting the use the PR pairing @Michkov told us about recently, and that @psturc and I used successfully last week, so we can get some level of regression coverage