### PR TITLE
PLNSRVCE-624: set hacbs tekton bundle key

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -99,6 +99,10 @@ spec:
               for file in $(git grep -l $BUNDLE); do
                 sed -i "s|\($BUNDLE\):.*|\1:$(params.revision)|g" $file
               done
+              BUNDLE=quay.io/redhat-appstudio/hacbs-templates-bundle
+              for file in $(git grep -l $BUNDLE); do
+                sed -i "s|\($BUNDLE\):.*|\1:$(params.revision)|g" $file
+              done
         taskRef:
           name: update-infra-deployments
       - name: update-ec-policies


### PR DESCRIPTION
Set global hacbs tekton bundle so it can be used directly in hacbs
workflow.