### PR TITLE
Disable automatic PR creation in main branch due to kcp transition

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -85,22 +85,23 @@ spec:
                   value: "$(results.PIPELINE_BUNDLES.path)"
           workspaces:
             - name: source
-      - name: update-infra-repo
-        runAfter:
-          - build-bundles
-        params:
-          - name: ORIGIN_REPO
-            value: $(params.git-url)
-          - name: REVISION
-            value: $(params.revision)
-          - name: SCRIPT
-            value: |
-              BUNDLE=quay.io/redhat-appstudio/build-templates-bundle
-              for file in $(git grep -l $BUNDLE); do
-                sed -i "s|\($BUNDLE\):.*|\1:$(params.revision)|g" $file
-              done
-        taskRef:
-          name: update-infra-deployments
+# Disable automatic PR creation in main branch due to kcp transition
+#      - name: update-infra-repo
+#        runAfter:
+#          - build-bundles
+#        params:
+#          - name: ORIGIN_REPO
+#            value: $(params.git-url)
+#          - name: REVISION
+#            value: $(params.revision)
+#          - name: SCRIPT
+#            value: |
+#              BUNDLE=quay.io/redhat-appstudio/build-templates-bundle
+#              for file in $(git grep -l $BUNDLE); do
+#                sed -i "s|\($BUNDLE\):.*|\1:$(params.revision)|g" $file
+#              done
+#        taskRef:
+#          name: update-infra-deployments
       - name: update-ec-policies
         runAfter:
           - build-bundles

--- a/pipelines/hacbs-core-service/kustomization.yaml
+++ b/pipelines/hacbs-core-service/kustomization.yaml
@@ -4,12 +4,13 @@ resources:
 - ../hacbs
 
 patches:
-  - path: infra-deploy.yaml
-    target:
-      group: tekton.dev
-      version: v1beta1
-      kind: Pipeline
-      labelSelector: skip-hacbs-test != true
+# Disable automatic PR creation in main branch due to kcp transition
+#  - path: infra-deploy.yaml
+#    target:
+#      group: tekton.dev
+#      version: v1beta1
+#      kind: Pipeline
+#      labelSelector: skip-hacbs-test != true
   - path: csi-secret.yaml
     target:
       group: tekton.dev


### PR DESCRIPTION
Skip creation of PR in infra-deployments since new main branch is used
for kcp transition.