### PR TITLE
feat: Add new enterprise-contract pipeline

### DIFF
--- a/pipelines/base/enterprise-contract.yaml
+++ b/pipelines/base/enterprise-contract.yaml
@@ -1,0 +1,64 @@
+# The purpose of this pipeline is to execute the verify-enterprise-contract-v2 task for container
+# images that are built but not automatically released in order to provide early feedback to users.
+# When auto release is enabled, the task is executed by the release pipeline immediately after the
+# container images are built, thus it is not necessary to execute the task via this pipeline.
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: enterprise-contract
+  labels:
+    "skip-hacbs-test": "true"
+spec:
+  params:
+    - name: SNAPSHOT
+      type: string
+      description: |
+        Spec section of an ApplicationSnapshot resource. Not all fields of the
+        resource are required. A minimal example:
+          {
+            "components": [
+              {
+                "containerImage": "quay.io/example/repo:latest"
+              }
+            ]
+          }
+        Each "containerImage" in the "components" array is validated.
+    - name: POLICY_CONFIGURATION
+      type: string
+      description: |
+        Name of the policy configuration (EnterpriseContractConfiguration
+        object) to use. `namespace/name` or `name` syntax supported. If
+        namespace is omitted the namespace where the task runs is used.
+      default: ec-policy
+    - name: SSL_CERT_DIR
+      type: string
+      description: |
+        Path to a directory containing SSL certs to be used when communicating
+        with external services. This is useful when using the integrated registry
+        and a local instance of Rekor on a development cluster which may use
+        certificates issued by a not-commonly trusted root CA. In such cases,
+        "/var/run/secrets/kubernetes.io/serviceaccount" is a good value. Multiple
+        paths can be provided by using the ":" separator.
+      default: ""
+  results:
+    - name: REPORT
+      value: "$(tasks.verify.results.REPORT)"
+  tasks:
+    - name: verify
+      params:
+        - name: POLICY_CONFIGURATION
+          value: "$(params.POLICY_CONFIGURATION)"
+        - name: IMAGES
+          value: "$(params.SNAPSHOT)"
+        - name: SSL_CERT_DIR
+          value: "$(params.SSL_CERT_DIR)"
+        # Tekton only creates results for successful tasks. Since the goal of this pipeline
+        # is not to gate an operation, but to provide feedback to users, do not fail if there
+        # are violations. This ensures users can view the full validation report.
+        - name: STRICT
+          value: "false"
+        # Public Key should come from the Policy Configuration
+        - name: PUBLIC_KEY
+          value: ""
+      taskRef:
+        name: verify-enterprise-contract-v2

--- a/pipelines/base/kustomization.yaml
+++ b/pipelines/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - nodejs-builder
 - noop.yaml
 - prototype-build-compliance.yaml
+- enterprise-contract.yaml

--- a/pipelines/hacbs/e2e-ec.yaml
+++ b/pipelines/hacbs/e2e-ec.yaml
@@ -21,8 +21,16 @@ spec:
     - name: IMAGES
       type: string
       description: |
-        Spec section of an ApplicationSnapshot. The containerImage of each
-        component will be verified.
+        Spec section of an ApplicationSnapshot resource. Not all fields of the
+        resource are required. A minimal example:
+          {
+            "components": [
+              {
+                "containerImage": "quay.io/example/repo:latest"
+              }
+            ]
+          }
+        Each "containerImage" in the "components" array is validated.
       # Eventually this will be a require parameter without a default value.
       default: ""
     - name: HACBS_TEST_OUTPUT

--- a/tasks/verify-enterprise-contract-v2.yaml
+++ b/tasks/verify-enterprise-contract-v2.yaml
@@ -16,9 +16,16 @@ spec:
     - name: IMAGES
       type: string
       description: |
-        The spec portion of an ApplicationSnapshot resource providing
-        the image references to verify.
-
+        Spec section of an ApplicationSnapshot resource. Not all fields of the
+        resource are required. A minimal example:
+          {
+            "components": [
+              {
+                "containerImage": "quay.io/example/repo:latest"
+              }
+            ]
+          }
+        Each "containerImage" in the "components" array is validated.
     - name: POLICY_CONFIGURATION
       type: string
       description: |


### PR DESCRIPTION
This pipeline is meant to be used by the integration controller to
provider faster feedback to users.

https://issues.redhat.com/browse/HACBS-1005

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>