### PR TITLE
Remove unneeded config from the sidecar

### DIFF
--- a/tasks/patches/add-sbom-and-push.yaml
+++ b/tasks/patches/add-sbom-and-push.yaml
@@ -168,16 +168,6 @@
     env:
       - name: QUARKUS_REST_CLIENT_CACHE_SERVICE_URL
         value: "http://jvm-build-workspace-artifact-cache.$(context.taskRun.namespace).svc.cluster.local"
-      - name: QUARKUS_S3_ENDPOINT_OVERRIDE
-        value: "http://jvm-build-workspace-localstack.$(context.taskRun.namespace).svc.cluster.local"
-      - name: QUARKUS_S3_AWS_REGION
-        value: "us-east-1"
-      - name: QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID
-        value: "accesskey"
-      - name: QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY
-        value: "secretkey"
-      - name: QUARKUS_S3_AWS_CREDENTIALS_TYPE
-        value: "static"
     name: proxy
     securityContext:
       runAsUser: 0


### PR DESCRIPTION
This config is only needed when doing dependency rebuilds, which don't
use this pipeline.