### PR TITLE
fix: e2e: use GITHUB_TOKEN

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -121,6 +121,8 @@ spec:
                   secretKeyRef:
                     name: github
                     key: token
+              - name: GITHUB_E2E_ORGANIZATION
+                value: redhat-appstudio-appdata
     finally:
       - name: e2e-cleanup
         params:

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -116,6 +116,11 @@ spec:
                 value: redhat-appstudio
               - name: E2E_APPLICATIONS_NAMESPACE
                 value: "$(params.e2e_test_namespace)"
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: github
+                    key: token
     finally:
       - name: e2e-cleanup
         params:


### PR DESCRIPTION
Recently I added a [health check](https://github.com/redhat-appstudio/e2e-tests/blob/dc56817d608a1a04cf0b98d2a66fc510e3e5b7b3/pkg/utils/has/controller.go#L68) to all e2e tests to make sure the component creation in the test doesn't start before the gitops resources for application CR are in place.

That change uncovered a bug hidden in the e2e task in this PR template: e2e tests were using a default github org for the health check, which should have been overridden by an env var in the build-definitions PR template. This PR fixes it.