### PR TITLE
Temporarily raise the sidecar memory limits

### DIFF
--- a/tasks/patches/add-sbom-and-push.yaml
+++ b/tasks/patches/add-sbom-and-push.yaml
@@ -185,7 +185,7 @@
       periodSeconds: 3
     resources:
       requests:
-        memory: "128Mi"
+        memory: "256Mi"
         cpu: "250m"
       limits:
         memory: "512Mi"


### PR DESCRIPTION
We are seeing intermittent failures in our image builds caused by sidecar memory issues. This temporarily raises the limit to avoid this and allow our images to complete.

I am going to investigate a sidecar-less design that just delegates all of the sidecars current responsibilities to the cache.