### PR TITLE
Tag newest pipeline bundle images with `devel`

### DIFF
--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -11,6 +11,7 @@ RUN curl -L https://github.com/hacbs-contract/ec-cli/releases/download/snapshot/
 
 RUN dnf -y --setopt=tsflags=nodocs install \
     git \
+    skopeo \
     https://github.com/tektoncd/cli/releases/download/v0.22.0/tektoncd-cli-0.22.0_Linux-64bit.rpm \
     && dnf clean all
 

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -106,6 +106,13 @@ tkn bundle push $HACBS_BUNDLE_IMG -f ${PIPELINE_TEMP}/hacbs.yaml
 tkn bundle push $HACBS_BUNDLE_LATEST_IMG -f ${PIPELINE_TEMP}/hacbs.yaml
 tkn bundle push $HACBS_CORE_BUNDLE_IMG -f ${PIPELINE_TEMP}/hacbs-core-service.yaml
 
+if [ "$SKIP_DEVEL_TAG" == "" ] && [ "$MY_QUAY_USER" == "redhat-appstudio" ] && [ -z "$TEST_REPO_NAME" ]; then
+    for img in "$PIPELINE_BUNDLE_IMG" "$HACBS_BUNDLE_IMG" "$HACBS_BUNDLE_LATEST_IMG" "$HACBS_CORE_BUNDLE_IMG"; do
+        NEW_TAG="${img%:*}:devel"
+        skopeo copy "docker://${img}" "docker://${NEW_TAG}"
+    done
+fi
+
 if [ "$SKIP_INSTALL" == "" ]; then
     $SCRIPTDIR/util-install-bundle.sh $PIPELINE_BUNDLE_IMG $INSTALL_BUNDLE_NS
 fi


### PR DESCRIPTION
For ease of consumption in development folk would like to utilize the newest versions of the pipeline bundle images with a fixed tag: `devel`.

This re-taggs the pipeline bundle images with the `devel` if `SKIP_DEVEL_TAG` environment variable is not empty and image push is directed to `redhat-appstudio` organization.

Fixes https://issues.redhat.com/browse/HACBS-1088