### PR TITLE
Create kcp pipeline without shared-resources

### DIFF
--- a/pipelines/base-no-shared/kustomization.yaml
+++ b/pipelines/base-no-shared/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - patch: |
+      - op: replace
+        path: /spec/tasks/2/taskRef/name
+        value: configure-build-no-shared
+    target:
+      group: tekton.dev
+      version: v1beta1
+      kind: Pipeline
+      labelSelector: skip-hacbs-test != true

--- a/tasks/configure-build-no-shared.yaml
+++ b/tasks/configure-build-no-shared.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: configure-build-no-shared
+spec:
+  description: >-
+    App Studio Configure Build Secrets in Source.
+  results:
+    - name: registry-auth
+      description: docker config location
+    - name: buildah-auth-param
+      description: pass this to the build optional params to configure secrets
+  workspaces:
+    - name: source
+    - name: registry-auth
+      optional: true
+  steps:
+    - name: appstudio-configure-build
+      image: quay.io/redhat-appstudio/appstudio-utils:4580b3ba3012095ff3981e50b6bbf753d4afd4c3
+      script: |
+        #!/usr/bin/env bash
+        echo "App Studio Configure Build"
+
+        DEST=/workspace/source/.dockerconfigjson
+        AUTH=/workspace/registry-auth/.dockerconfigjson
+        TMP=$(mktemp)
+        echo '{}' > $DEST
+        # Use secrets from serviceAccount
+        cd /tekton/creds-secrets
+        for file in $(ls); do
+          if [ -f "$file/.dockerconfigjson" ]; then
+            FILES="$FILES $file/.dockerconfigjson"
+          elif [ -f "$file/.dockercfg" ]; then
+            # convert format from .dockercfg to .dockerconfigjson
+            newformat=$(mktemp)
+            jq '{"auths": .}' $file/.dockercfg > $newformat
+            FILES="$FILES $newformat"
+          fi
+        done
+        # set highest priority on registry-auth workspace
+        FILES="$FILES $AUTH"
+        echo "Looking for Registry Auth Configs"
+        # Merge secrets into one file
+        for file in $FILES; do
+          if [ -f "$file" ]; then
+            echo "$file found"
+            jq -M -s '.[0] * .[1]' $DEST $file > $TMP
+            mv $TMP $DEST
+          fi
+        done
+        chmod 644 $DEST
+        echo -n $DEST > /tekton/results/registry-auth
+        echo -n "--authfile $DEST"  >  /tekton/results/buildah-auth-param

--- a/tasks/kustomization.yaml
+++ b/tasks/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - buildah.yaml
 - cleanup-build-directories.yaml
 - configure-build.yaml
+- configure-build-no-shared.yaml
 - git-clone.yaml
 - init.yaml
 - s2i-java.yaml


### PR DESCRIPTION
We do not support shared-resources in KCP, creating new pipeline without the usage of shared-secrets.