### PR TITLE
feat[HACBS-1072]: disable java and go SAST tasks

### DIFF
--- a/pipelines/hacbs/hacbs-test.yaml
+++ b/pipelines/hacbs/hacbs-test.yaml
@@ -97,31 +97,6 @@
 - op: add
   path: /spec/tasks/-
   value:
-    name: sast-go
-    runAfter:
-      - build-container
-    taskRef:
-      name: sast-go
-    workspaces:
-    - name: workspace
-      workspace: workspace
-- op: add
-  path: /spec/tasks/-
-  value:
-    name: sast-java-sec-check
-    runAfter:
-      - build-container
-    taskRef:
-      name: sast-java-sec-check
-    params:
-      - name: PATH_CONTEXT
-        value: $(params.path-context)
-    workspaces:
-    - name: workspace
-      workspace: workspace
-- op: add
-  path: /spec/tasks/-
-  value:
     name: sast-snyk-check
     runAfter:
       - clone-repository


### PR DESCRIPTION
We have made the decision to disable the SAST tasks (gosec and findsecbugs) temporarily becayse of infrastructure requirements. We will look into relying more on the Snyk task for the SAST functionality for the time being.

* Disable the sast-java-sec-check task in HACBS pipeline
* Disable the sast-go task in HACBS pipeline