### PR TITLE
Add a prefetch step to the docker-container pipeline

### DIFF
--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -9,12 +9,12 @@
     "pipelines.openshift.io/runtime": "generic"
     "pipelines.openshift.io/strategy": "docker"
 - op: replace
-  path: /spec/tasks/3/taskRef
+  path: /spec/tasks/4/taskRef
   value:
     name: buildah
     version: "0.1"
 - op: add
-  path: /spec/tasks/3/params
+  path: /spec/tasks/4/params
   value:
   - name: IMAGE
     value: $(params.output-image)
@@ -26,6 +26,8 @@
     value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
   - name: PUSH_EXTRA_ARGS
     value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+  - name: HERMETIC_BUILD
+    value: "$(tasks.clone-repository.results.hermetic-build)"
 - op: add
   path: /spec/results/-
   value:

--- a/pipelines/java-builder/patch.yaml
+++ b/pipelines/java-builder/patch.yaml
@@ -9,12 +9,12 @@
     "pipelines.openshift.io/runtime": "java"
     "pipelines.openshift.io/strategy": "s2i"
 - op: replace
-  path: /spec/tasks/3/taskRef
+  path: /spec/tasks/4/taskRef
   value:
     name: s2i-java
     version: "0.1"
 - op: add
-  path: /spec/tasks/3/params
+  path: /spec/tasks/4/params
   value:
   - name: PATH_CONTEXT
     value: $(params.path-context)

--- a/pipelines/nodejs-builder/patch.yaml
+++ b/pipelines/nodejs-builder/patch.yaml
@@ -9,12 +9,12 @@
     "pipelines.openshift.io/runtime": "nodejs"
     "pipelines.openshift.io/strategy": "s2i"
 - op: replace
-  path: /spec/tasks/3/taskRef
+  path: /spec/tasks/4/taskRef
   value:
     name: s2i-nodejs
     version: "0.1"
 - op: add
-  path: /spec/tasks/3/params
+  path: /spec/tasks/4/params
   value:
   - name: PATH_CONTEXT
     value: $(params.path-context)

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -87,13 +87,31 @@ spec:
           workspace: workspace
         - name: registry-auth
           workspace: registry-auth
+    - name: prefetch-dependencies
+      when:
+      - input: $(tasks.clone-repository.results.hermetic-build)
+        operator: in
+        values: ["true"]
+      params:
+        - name: package-type
+          value: gomod
+        - name: package-path
+          value: "$(params.path-context)"
+      runAfter:
+        - appstudio-configure-build
+      taskRef:
+        name: prefetch-dependencies
+        version: "0.1"
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       when:
       - input: $(tasks.appstudio-init.results.build)
         operator: in
         values: ["true"]
       runAfter:
-        - appstudio-configure-build
+        - prefetch-dependencies
       taskRef:
         name: $REPLACE_ME
       workspaces:

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -42,6 +42,10 @@ spec:
     description: Extra parameters passed for the push command when pushing images.
     name: PUSH_EXTRA_ARGS
     type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC_BUILD
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -90,9 +94,21 @@ spec:
         sed -i -e 's|RUN mvn|RUN echo "<settings><mirrors><mirror><id>mirror.default</id><url>http://jvm-build-workspace-artifact-cache.$(context.taskRun.namespace).svc.cluster.local/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>" > /tmp/settings.yaml; mvn -s /tmp/settings.yaml|g' "$dockerfile_path"
         touch /var/lib/containers/java
       fi
+
       sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      if [ $(params.HERMETIC_BUILD) == "true" ];then
+        HERMETIC_BUILD_PARAMETERS="
+          --volume $(realpath ./cachi2/output):/cachi2/output:U \
+          --volume $(realpath ./cachi2/cachi2.env):/cachi2/cachi2.env:U \
+          --network none"
+
+        echo "Build will be executed with network isolation"
+      fi
+
       buildah bud \
         $(params.BUILD_EXTRA_ARGS) \
+        $HERMETIC_BUILD_PARAMETERS \
         --tls-verify=$(params.TLSVERIFY) --no-cache \
         --ulimit nofile=4096:4096 \
         -f "$dockerfile_path" -t $(params.IMAGE) $(params.CONTEXT)

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -81,6 +81,8 @@ spec:
     name: commit
   - description: The precise URL that was fetched by this Task.
     name: url
+  - description: Set to `true` if a hermetic build parameters file was found in the cloned repo.
+    name: hermetic-build
   steps:
   - env:
     - name: HOME
@@ -189,6 +191,9 @@ spec:
       fi
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+      if [ -e cachi2.params ]; then
+        printf "true" > "$(results.hermetic-build.path)"
+      fi
   workspaces:
   - description: The git repo will be cloned onto the volume backing this Workspace.
     name: output

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "image-build, hacbs"
+  name: prefetch-dependencies
+spec:
+  description: |-
+    Task that uses Cachi2 to prefetch build dependencies.
+  params:
+  - description: Package type
+    name: package-type
+  - description: Package path
+    name: package-path
+  - description: Flags
+    name: flags
+    default: ""
+  steps:
+  - image: quay.io/containerbuildsystem/cachi2:a4f1d24d4b9825d274353fba5c1921d7295c58ca
+    name: prefetch-dependencies
+    script: |
+      cachi2 fetch-deps \
+      --source=$(workspaces.source.path) \
+      --output=$(workspaces.source.path)/cachi2/output \
+      --package '{
+        "type": "$(params.package-type)",
+        "path": "$(params.package-path)"
+      }'
+
+      cachi2 generate-env $(workspaces.source.path)/cachi2/output \
+      --format env \
+      --for-output-dir=/cachi2/output \
+      --output $(workspaces.source.path)/cachi2/cachi2.env
+    volumeMounts:
+    - mountPath: /cachi2
+      name: prefetched-content
+  workspaces:
+  - name: source

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -34,8 +34,5 @@ spec:
       --format env \
       --for-output-dir=/cachi2/output \
       --output $(workspaces.source.path)/cachi2/cachi2.env
-    volumeMounts:
-    - mountPath: /cachi2
-      name: prefetched-content
   workspaces:
   - name: source

--- a/task/prefetch-dependencies/OWNERS
+++ b/task/prefetch-dependencies/OWNERS
@@ -1,0 +1,1 @@
+AppStudio/HACBS Team


### PR DESCRIPTION
Initital integration of Cachi2 into the pipelines to prefetch gomod dependencies and build the image with network isolation.

When a [cachi2-params](https://github.com/brunoapimentel/retrodep/commit/7e3edd8a0bcbf345e76ffc950ededa3c1b482282) file is found in the root of the target Git repository, the pipelineRun will:
- Execute the prefetch-dependencies task
- Apply the network isolation during the execution of `buildah bud` in the buildah task
- Mount the prefetched content at `/cachi2` during the execution of `buildah bud` in the buildah task

If the file is not present in the repository, the prefetch task will be skipped and the buildah bud command won't have the above mentioned changes.

In order to point the `go build` command to use the prefetched content, the Dockerfile needs to be modified to run `source /cachi2/cachi2.env && go build ...`.  See an example [here](https://github.com/brunoapimentel/retrodep/blob/hermetic-build/Dockerfile#L13).

Notice that the build might work even if the `go build` command tries do download content from the internet, because there's a bug in Buildah that affects the network isolation: https://github.com/containers/buildah/pull/4229.

CLOUDBLD-12412

## How to test this PR
- Connect to an Openshift cluster (4.11 was used for testing this PR)
- Install the Openshift Pipelines operator
- Apply the task and pipelines definition contained in this repository (can be achieved by running ./hack/test-builds.sh)
- Create a secret to allow the pipeline to have push access to quay.io and link it to the service account:
```
oc create secret docker-registry redhat-appstudio-staginguser-pull-secret --from-file=.dockerconfigjson=path/to/.docker/config.json

oc secrets link pipeline redhat-appstudio-staginguser-pull-secret --for=pull
```
- Run a hermetic build:

```
tkn pipeline start docker-build \
-w name=registry-auth,secret=redhat-appstudio-staginguser-pull-secret \
-w name=workspace,volumeClaimTemplateFile=./hack/test-build/workspace-template.yaml \
-p git-url="https://github.com/brunoapimentel/retrodep" \
-p output-image="quay.io/MY_QUAY_USER/retrodep:latest" \
-p revision="7e3edd8a0bcbf345e76ffc950ededa3c1b482282" \
-p is-hermetic="true" \
--use-param-defaults
```
