### PR TITLE
fix: e2e: use pre-kcp image tag

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -111,7 +111,7 @@ spec:
               type: string
           steps:
             - name: e2e-test
-              image: quay.io/redhat-appstudio/e2e-tests:latest
+              image: quay.io/redhat-appstudio/e2e-tests:pre-kcp
               imagePullPolicy: Always
               args: [
                 "--ginkgo.label-filter=build-templates-e2e",


### PR DESCRIPTION
follow-up on https://github.com/redhat-appstudio/e2e-tests/pull/219/files

https://quay.io/repository/redhat-appstudio/e2e-tests?tab=tags