### PR TITLE
Set pipefail for build-and-push.sh

### DIFF
--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -e -o pipefail
 
 QUAY_ORG=redhat-appstudio-tekton-catalog
 # local dev build script


### PR DESCRIPTION
`tkn bundle push' runs as the first command in the shell pipeline to push task and pipeline bundles. A few reason may fail the command and no bundle image information is got from the registry. So, fail the push pipeline immediately when something is wrong with the push operation.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>