### PR TITLE
fix: remove \n from image_url generated by build job

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -213,7 +213,7 @@ spec:
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
-      echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
+      echo -n "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
 
       # Create and push sbom image
       sbom_container=$(buildah from scratch)

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -235,7 +235,7 @@ spec:
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
-      echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
+      echo -n "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
 
       # Create and push sbom image
       sbom_container=$(buildah from scratch)

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -177,7 +177,7 @@ spec:
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
-      echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
+      echo -n "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
 
       # Create and push sbom image
       sbom_container=$(buildah from scratch)


### PR DESCRIPTION
I meet error as below in `sbom-json-check` task
```
failed to create task run pod "nodejs-builder-run-krzcv-sbom-json-check": Pod "nodejs-builder-run-krzcv-sbom-json-check-pod" is invalid: spec.containers[1].image: Invalid value: "quay.io/hongweiliu/single-nodejs-app:f623a43\n": must not have leading or trailing whitespace. Maybe missing or invalid Task default/sbom-json-check
```
This pr is to remove the  `\n` in `results.IMAGE_URL`.

Signed-off-by: Hongwei Liu hongliu@redhat.com