### PR TITLE
Fix missing chains results

### DIFF
--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -27,7 +27,7 @@
   - name: PUSH_EXTRA_ARGS
     value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
 - op: add
-  path: /spec/results
+  path: /spec/results/-
   value:
-    - name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
+    name: JAVA_COMMUNITY_DEPENDENCIES
+    value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)

--- a/pipelines/java-builder/patch.yaml
+++ b/pipelines/java-builder/patch.yaml
@@ -25,7 +25,7 @@
   - name: HACBS
     value: "$(params.hacbs)"
 - op: add
-  path: /spec/results
+  path: /spec/results/-
   value:
-  - name: JAVA_COMMUNITY_DEPENDENCIES
+    name: JAVA_COMMUNITY_DEPENDENCIES
     value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)


### PR DESCRIPTION
Previously, the patch was overwriting the results from the template-build pipeline. This change makes it so results are appended to the list of existing results.

Before this change:
```
🐚 oc kustomize pipelines | yq -P .spec.results
- name: JAVA_COMMUNITY_DEPENDENCIES
  value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
---
null
---
- name: REPORT
  value: $(tasks.verify.results.REPORT)
---
- name: JAVA_COMMUNITY_DEPENDENCIES
  value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
---
- name: IMAGE_URL
  value: $(tasks.build-container.results.IMAGE_URL)
- name: IMAGE_DIGEST
  value: $(tasks.build-container.results.IMAGE_DIGEST)
- name: CHAINS-GIT_URL
  value: $(tasks.clone-repository.results.url)
- name: CHAINS-GIT_COMMIT
  value: $(tasks.clone-repository.results.commit)

```

After this change:
```
🐚 oc kustomize pipelines | yq -P .spec.results
- name: IMAGE_URL
  value: $(tasks.build-container.results.IMAGE_URL)
- name: IMAGE_DIGEST
  value: $(tasks.build-container.results.IMAGE_DIGEST)
- name: CHAINS-GIT_URL
  value: $(tasks.clone-repository.results.url)
- name: CHAINS-GIT_COMMIT
  value: $(tasks.clone-repository.results.commit)
- name: JAVA_COMMUNITY_DEPENDENCIES
  value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
---
null
---
- name: REPORT
  value: $(tasks.verify.results.REPORT)
---
- name: IMAGE_URL
  value: $(tasks.build-container.results.IMAGE_URL)
- name: IMAGE_DIGEST
  value: $(tasks.build-container.results.IMAGE_DIGEST)
- name: CHAINS-GIT_URL
  value: $(tasks.clone-repository.results.url)
- name: CHAINS-GIT_COMMIT
  value: $(tasks.clone-repository.results.commit)
- name: JAVA_COMMUNITY_DEPENDENCIES
  value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
---
- name: IMAGE_URL
  value: $(tasks.build-container.results.IMAGE_URL)
- name: IMAGE_DIGEST
  value: $(tasks.build-container.results.IMAGE_DIGEST)
- name: CHAINS-GIT_URL
  value: $(tasks.clone-repository.results.url)
- name: CHAINS-GIT_COMMIT
  value: $(tasks.clone-repository.results.commit)
```

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>