### PR TITLE
Persist old sha256 of images which were overriden

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -36,6 +36,8 @@ spec:
             value: $(params.repo_url)
           - name: revision
             value: $(params.revision)
+          - name: depth
+            value: "0"
       - name: yaml-lint-check
         runAfter:
           - fetch-repository

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -29,6 +29,8 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: "$(params.revision)"
+          - name: depth
+            value: "0"
         taskRef:
           name: git-clone
         workspaces:

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -87,6 +87,11 @@ do
     echo "$output"
     task_bundle_with_digest="${output##*$'\n'}"
 
+    # copy task to new tag pointing to commit where the file was changed lastly, so that image persists
+    # even when original tag is updated
+    task_file_git_sha=$(git log -n 1 --pretty=format:%H -- ${task_file})
+    skopeo copy "docker://${task_bundle}" "docker://${task_bundle}-${task_file_git_sha}"
+
     # version placeholder is removed naturally by the substitution.
     real_task_name=$(yq e '.metadata.name' "$prepared_task_file")
     sub_expr_1="


### PR DESCRIPTION
Tag tasks with last github git commit id which modified the file so they are persisted after update.