### PR TITLE
fix: CI: remove reference to e2e-ec pipeline

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -113,7 +113,7 @@ spec:
               type: string
           steps:
             - name: e2e-test
-              image: quay.io/redhat-appstudio/e2e-tests:pre-kcp
+              image: quay.io/redhat-appstudio/e2e-tests:main
               imagePullPolicy: Always
               args: [
                 "--ginkgo.label-filter=build-templates-e2e",

--- a/pipelines/kustomization.yaml
+++ b/pipelines/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
 - java-builder
 - nodejs-builder
 - enterprise-contract.yaml
-- e2e-ec.yaml


### PR DESCRIPTION
Follow-up on https://github.com/redhat-appstudio/build-definitions/pull/242

Fixes an error seen in CI
```
Error: accumulating resources: accumulation err='accumulating resources from 'e2e-ec.yaml': evalsymlink failure on '/workspace/source/pipelines/e2e-ec.yaml' : lstat /workspace/source/pipelines/e2e-ec.yaml: no such file or directory': evalsymlink failure on '/workspace/source/pipelines/e2e-ec.yaml' : lstat /workspace/source/pipelines/e2e-ec.yaml: no such file or directory
```