### PR TITLE
Fix the build pipeline

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -129,7 +129,7 @@ spec:
         version: "0.1"
       params:
       - name: IMAGE_URL
-        value: $(params.output-image)
+        value: "$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)"
       workspaces:
       - name: workspace
         workspace: workspace
@@ -270,9 +270,9 @@ spec:
       - name: pipeline-run-name
         value: "$(context.pipelineRun.name)"
       - name: git-url
-        value: "$(params.git-url)"
+        value: "$(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)"
       - name: image-url
-        value: $(params.output-image)
+        value: "$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)"
   results:
     - name: IMAGE_URL
       value: "$(tasks.build-container.results.IMAGE_URL)"

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -193,6 +193,8 @@ spec:
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
       if [ -e cachi2.params ]; then
         printf "true" > "$(results.hermetic-build.path)"
+      else
+        printf "false" > "$(results.hermetic-build.path)"
       fi
   workspaces:
   - description: The git repo will be cloned onto the volume backing this Workspace.

--- a/task/sanity-inspect-image/0.1/sanity-inspect-image.yaml
+++ b/task/sanity-inspect-image/0.1/sanity-inspect-image.yaml
@@ -36,11 +36,18 @@ spec:
       BASE_IMAGE_INSPECT=base_image_inspect.json
       RAW_IMAGE_INSPECT=raw_image_inspect.json
 
-      echo "Inspecting manifest for source image $(params.IMAGE_URL)"
-      skopeo inspect --no-tags docker://$(params.IMAGE_URL) > $IMAGE_INSPECT
-      skopeo inspect --no-tags --raw docker://$(params.IMAGE_URL) > $RAW_IMAGE_INSPECT
+      IMAGE_URL="$(params.IMAGE_URL)"
+      # Given a tag and a the digest in the IMAGE_URL we opt to use the digest alone
+      # this is because containers/image currently doesn't support image references
+      # that contain both. See https://github.com/containers/image/issues/1736
+      if [[ "${IMAGE_URL}" == *":"*"@"* ]]; then
+        IMAGE_URL="${IMAGE_URL/:*@/@}"
+      fi
+      echo "Inspecting manifest for source image ${IMAGE_URL}"
+      skopeo inspect --no-tags docker://"${IMAGE_URL}" > $IMAGE_INSPECT
+      skopeo inspect --no-tags --raw docker://"${IMAGE_URL}" > $RAW_IMAGE_INSPECT
 
-      echo "Getting base image manifest for source image $(params.IMAGE_URL)"
+      echo "Getting base image manifest for source image ${IMAGE_URL}"
       BASE_IMAGE_NAME="$(jq -r ".annotations.\"org.opencontainers.image.base.name\"" $RAW_IMAGE_INSPECT)"
       BASE_IMAGE_DIGEST="$(jq -r ".annotations.\"org.opencontainers.image.base.digest\"" $RAW_IMAGE_INSPECT)"
       if [ $BASE_IMAGE_NAME == 'null' ]; then
@@ -49,12 +56,12 @@ spec:
         BASE_IMAGE_NAME="$(jq -r ".Labels.\"org.opencontainers.image.base.name\"" $IMAGE_INSPECT)"
         BASE_IMAGE_DIGEST="$(jq -r ".annotations.\"org.opencontainers.image.base.digest\"" $IMAGE_INSPECT)"
         if [ "$BASE_IMAGE_NAME" == 'null' ]; then
-          echo "Cannot get base image info from 'Labels', please check the source image $(params.IMAGE_URL)"
+          echo "Cannot get base image info from 'Labels', please check the source image ${IMAGE_URL}"
           exit 0
         fi
       fi
       if [ -z "$BASE_IMAGE_NAME" ]; then
-        echo "Source image $(params.IMAGE_URL) is built from scratch, so there is no base image"
+        echo "Source image ${IMAGE_URL} is built from scratch, so there is no base image"
         exit 0
       fi
       BASE_IMAGE="${BASE_IMAGE_NAME%:*}@$BASE_IMAGE_DIGEST"


### PR DESCRIPTION
[Make sure hermetic-build result is produced](https://github.com/redhat-appstudio/build-definitions/commit/dd729340099ee5440bc05f3a95d6a9088bd9f465)

If the Tekton Task result is not produced any when expression using that result will evaluate to `false`. The `hermetic-build` result of the `git-clone` Task would be set to `true` if and only if the `cachi2.params` exists in the workspace, if the file does not exist it will not be set.
The current default is that a when expression evaluating to false skips the task where the when expression is defined, but also all tasks that `runAfter` it. See[1],`scope-when-expressions-to-task` feature flag[2] and TEP-0059[3].
Without the `cachi2.params` file in the workspace, the when condition on the `prefetch-dependencies` would evaluate to false, and the `build-container` step that has `runAfter: prefetch-dependencies` would be skipped as well, cascading to every other step in the pipeline other than `show-summary` and `sast-snyk-check` tasks.
With this change the `hermetic-build` result is always set to either `"true"` or `"false"`.

[1] https://tekton.dev/docs/pipelines/pipelines/#guard-task-execution-using-when-expressions
[2] https://tekton.dev/docs/operator/tektonpipeline/
[3] https://github.com/tektoncd/community/blob/main/teps/0059-skipping-strategies.md

[Use resource dependencies](https://github.com/redhat-appstudio/build-definitions/commit/b238b09f1ec6258d11d3d3e30075ffaff9d5006e)

The parameters git and image URLs should be taken from the `clone-repository` and `build-container` tasks not from the user input.

This creates a resource dependency between the `sanity-inspect-image` task and the `build-container` task, so if the `build-container` task is skipped the `sanity-inspect-image` task will not be run. Not creating a resource dependency leads to `sanity-inspect-image` task running with an image reference pointing to an image that could not have been built in the pipeline when the `build-container` task is skipped.

Similarly for the `show-summary` task, as it now depends on `clone-repository` and `build-container` tasks running. And in addition to that the `show-summary` now includes git revision that was cloned, and since the image SHA-256 digest is passed the exact image that was built.

[1] https://tekton.dev/docs/pipelines/pipelines/#guard-task-execution-using-when-expressions