### PR TITLE
Remove trailing newline from BASE_IMAGE* results

### DIFF
--- a/task/sanity-inspect-image/0.1/sanity-inspect-image.yaml
+++ b/task/sanity-inspect-image/0.1/sanity-inspect-image.yaml
@@ -67,6 +67,7 @@ spec:
       BASE_IMAGE="${BASE_IMAGE_NAME%:*}@$BASE_IMAGE_DIGEST"
       echo "The base image is $BASE_IMAGE, get its manifest now"
       skopeo inspect --no-tags docker://$BASE_IMAGE  > $BASE_IMAGE_INSPECT || true
-      echo "$BASE_IMAGE" | tee $(results.BASE_IMAGE.path)
+      echo -n "$BASE_IMAGE" | tee $(results.BASE_IMAGE.path)
 
-      jq -r ".Name" $BASE_IMAGE_INSPECT | cut -d"/" -f2,3 | tee $(results.BASE_IMAGE_REPOSITORY.path)
+      BASE_IMAGE_REPOSITORY="$(jq -r '.Name | sub("[^/]+/"; "") | sub("[:@].*"; "")' "$BASE_IMAGE_INSPECT")"
+      echo -n "$BASE_IMAGE_REPOSITORY" | tee $(results.BASE_IMAGE_REPOSITORY.path)


### PR DESCRIPTION
In `sanity-inspect-image` the `BASE_IMAGE` and `BASE_IMAGE_REPOSITORY` result is set and later on used in the `deprecated-image-check`.

Currently it contains a trailing newline. The trailing newline ends up being passed literally to `curl` used in the `deprecated-image-check` as the URL is quoted there. This leads to curl failing with status `000`.

The `deprecated-image-check` Task doesn't fail, but the `HACBS_TEST_OUTPUT` results in an error.

No matter how hard I tried see where the issue was and where the newline was emitted from for the `BASE_IMAGE_REPOSITORY` result, i.e. was it from jq, cut or tee, it seemed to originate from none of those. That's why I ended up rewriting that in a single jq invocation and analogous to `BASE_IMAGE` passed via variable and echo to tee. Seems to have solved the issue.