### PR TITLE
Run the show-summary task always

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -272,7 +272,7 @@ spec:
       - name: git-url
         value: "$(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)"
       - name: image-url
-        value: "$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)"
+        value: $(params.output-image)
   results:
     - name: IMAGE_URL
       value: "$(tasks.build-container.results.IMAGE_URL)"


### PR DESCRIPTION
This removes the resource dependency on the `build-container` task from the `show-summary` task. This way the `show-summary` task will be run regardless of the `build-container` task running, i.e. always.

Note that the resource dependency on the `clone-repository` task remains. Since `clone-repository` task will not be skipped, like the `build-container` task might, this is not an issue.