### PR TITLE
Updates the Cachi2 image version

### DIFF
--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -19,7 +19,7 @@ spec:
     name: flags
     default: ""
   steps:
-  - image: quay.io/containerbuildsystem/cachi2:a4f1d24d4b9825d274353fba5c1921d7295c58ca
+  - image: quay.io/containerbuildsystem/cachi2@sha256:6aaecb3fa76d3b3d2417ecbf13de2d77b258cd1085823288d49cc5139ad36a5f
     name: prefetch-dependencies
     script: |
       cachi2 fetch-deps \


### PR DESCRIPTION
This image is used in the prefetch task. The newer version properly sets the GOPROXY variable, which fixes the slowness issues that were happening.

CLOUDBLD-12647