### PR TITLE
feat(HACBS-1423): add FBC validation task

### DIFF
--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -26,3 +26,30 @@
     value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
   - name: PUSH_EXTRA_ARGS
     value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+- op: add
+  path: /spec/tasks/-
+  value:
+    name: fbc-validate
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+    runAfter:
+      - fbc-label-check
+    taskRef:
+      name: fbc-validation
+      version: "0.1"
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-container.results.IMAGE_URL)
+    workspaces:
+      - name: workspace
+        workspace: workspace
+- op: replace
+  path: /spec/tasks/6/name
+  value: fbc-label-check
+- op: add
+  path: /spec/tasks/6/params
+  value:
+  - name: POLICY_NAMESPACE
+    value: fbc_checks

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -1,0 +1,76 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio, hacbs"
+  name: fbc-validation
+spec:
+  params:
+    - name: IMAGE_URL
+      description: the fully qualified image name
+  results:
+    - name: HACBS_TEST_OUTPUT
+  workspaces:
+    - name: workspace
+  steps:
+    - name: extract-and-check-binaries
+      image: quay.io/redhat-appstudio/hacbs-test:latest
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      securityContext:
+        runAsUser: 1000
+      env:
+        - name: HOME
+          value: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: 2
+        requests:
+          memory: 512Mi
+          cpu: 10m
+      script: |
+        ### Try to extract binaries with configs > check binaries functionality > check opm validate ###
+        conffolder=$(cat ../sanity-inspect-image/image_inspect.json | jq -r '.Labels ."operators.operatorframework.io.index.configs.v1"')
+
+        mkdir confdir
+        if ! oc image extract $(params.IMAGE_URL) --file /bin/opm --file /bin/grpc_health_probe --path $conffolder*:confdir/ ; then
+        echo "Unable to extract image! Skipping checking binaries!"
+          HACBS_ERROR_OUTPUT=$(jq -rc --arg date $(date +%s) --null-input \
+          '{result: "ERROR", timestamp: $date, successes: 0, failures: 1}')
+          echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
+          exit 0
+        fi
+
+        TESTPASSED=true
+        chmod +x opm grpc_health_probe
+
+        if ! ./opm version; then
+        echo "!FAILURE! - opm binary check failed"
+          TESTPASSED=false
+        fi
+        if [ ! -f "grpc_health_probe" ]; then
+        echo "!FAILURE! - grpc_health_probe binary check failed"
+          TESTPASSED=false
+        fi
+        if ! ./opm validate confdir; then
+        echo "!FAILURE! - opm validate check has failed"
+          TESTPASSED=false
+        fi
+        if [ $TESTPASSED == false ]; then
+          HACBS_ERROR_OUTPUT=$(jq -rc --arg date $(date +%s) --null-input \
+          '{result: "FAILURE", timestamp: $date, successes: 0, failures: 1}')
+          echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
+        else
+          HACBS_TEST_OUTPUT=$(jq -rc --arg date $(date +%s) --null-input \
+          '{result: "SUCCESS",timestamp: $date, namespace: "default", successes: 1, failures: 0}')
+          echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
+        fi
+      volumeMounts:
+        - mountPath: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+          name: work
+  volumes:
+    - name: work
+      emptydir: {}

--- a/task/fbc-validation/OWNERS
+++ b/task/fbc-validation/OWNERS
@@ -1,0 +1,1 @@
+AppStudio/HACBS Team


### PR DESCRIPTION
Signed-off-by: Jiri Sztuka <jsztuka@ovpn-194-168.brq.redhat.com>

This PR can be pushed only after https://github.com/redhat-appstudio/build-definitions/pull/249
Task is doing following:

- Checks existence of label: **operators.operatorframework.io.index.configs.v1** within a tested image
- Extracts binaries (opm, grpc_health_probe) together with configs folder found in previous step
- Checks binaries (opm version, existence of grpc_health_probe)
- Runs **opm validate** on configs folder
- Return report accordingly