### PR TITLE
Update cachi2 image to fix env vars used for build

### DIFF
--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -19,7 +19,7 @@ spec:
     name: flags
     default: ""
   steps:
-  - image: quay.io/containerbuildsystem/cachi2@sha256:6aaecb3fa76d3b3d2417ecbf13de2d77b258cd1085823288d49cc5139ad36a5f
+  - image: quay.io/containerbuildsystem/cachi2@sha256:febe4e3e8ac01063c2f7319c43a60ab13e4cd2a9124500b0f8c53311a7e26d0f
     name: prefetch-dependencies
     script: |
       cachi2 fetch-deps \


### PR DESCRIPTION
The currently used cachi2 image has a bug ([cachi2#45](https://github.com/containerbuildsystem/cachi2/pull/45)) where it will never generate any environment variables for the build. That means the GOMODCACHE environment variable won't be set => the build will not use the pre-fetched dependencies and will instead (try to) download them again.

Update to a fixed version.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>