### PR TITLE
init: Allow to fail creation of secret

### DIFF
--- a/task/init/0.1/init.yaml
+++ b/task/init/0.1/init.yaml
@@ -42,7 +42,7 @@ spec:
       script: |
         # Create empty secret which is now hardcoded in PaC Pipelinerun template
         if ! oc get secret redhat-appstudio-registry-pull-secret &>/dev/null; then
-          oc create secret generic redhat-appstudio-registry-pull-secret
+          oc create secret generic redhat-appstudio-registry-pull-secret || true
         fi
         if [ "$(params.hacbs)" == "true" ]; then
           oc annotate pipelinerun $(params.pipeline-run-name) 'appstudio.redhat.com/updateComponentOnSuccess="false"'


### PR DESCRIPTION
When multiple pipelineRuns are created at the same time it could happen that the secret will be created by another PipelineRun.