### PR TITLE
Fully integrate Cachi2 into the build pipelines

### DIFF
--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -26,8 +26,10 @@
     value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
   - name: PUSH_EXTRA_ARGS
     value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
-  - name: HERMETIC_BUILD
-    value: "$(tasks.clone-repository.results.hermetic-build)"
+  - name: HERMETIC
+    value: "$(params.hermetic)"
+  - name: PREFETCH_INPUT
+    value: "$(params.prefetch-input)"
 - op: add
   path: /spec/results/-
   value:

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -34,6 +34,14 @@ spec:
       name: skip-checks
       type: string
       default: "false"
+    - description: Execute the build with network isolation
+      name: hermetic
+      type: string
+      default: "false"
+    - description: Build dependencies to be prefetched by Cachi2
+      name: prefetch-input
+      type: string
+      default: ""
     - description: Java build
       name: java
       type: string
@@ -89,14 +97,12 @@ spec:
           workspace: registry-auth
     - name: prefetch-dependencies
       when:
-      - input: $(tasks.clone-repository.results.hermetic-build)
+      - input: $(params.hermetic)
         operator: in
         values: ["true"]
       params:
-        - name: package-type
-          value: gomod
-        - name: package-path
-          value: "$(params.path-context)"
+        - name: input
+          value: $(params.prefetch-input)
       runAfter:
         - appstudio-configure-build
       taskRef:

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -44,7 +44,11 @@ spec:
     type: string
   - default: "false"
     description: Determines if build will be executed without network access.
-    name: HERMETIC_BUILD
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available to the build.
+    name: PREFETCH_INPUT
     type: string
   results:
   - description: Digest of the image just built
@@ -63,6 +67,10 @@ spec:
       value: oci
     - name: STORAGE_DRIVER
       value: vfs
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: PREFETCH_INPUT
+      value: $(params.PREFETCH_INPUT)
   steps:
   - image: $(params.BUILDER_IMAGE)
     name: build
@@ -98,18 +106,23 @@ spec:
 
       sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
 
-      if [ $(params.HERMETIC_BUILD) == "true" ];then
-        HERMETIC_BUILD_PARAMETERS="
-          --volume $(realpath ./cachi2/output):/cachi2/output:U \
-          --volume $(realpath ./cachi2/cachi2.env):/cachi2/cachi2.env:U \
-          --network none"
-
+      if [ "${HERMETIC}" == "true" ]; then
+        NETWORK="--network none"
         echo "Build will be executed with network isolation"
+      fi
+
+      if [ ! -z "${PREFETCH_INPUT}" ]; then
+        VOLUME_MOUNTS="
+          --volume $(realpath ./cachi2/output):/cachi2/output:U \
+          --volume $(realpath ./cachi2/cachi2.env):/cachi2/cachi2.env:U"
+
+        echo "Prefetched content will be made available"
       fi
 
       buildah bud \
         $(params.BUILD_EXTRA_ARGS) \
-        $HERMETIC_BUILD_PARAMETERS \
+        $NETWORK \
+        $VOLUME_MOUNTS \
         --tls-verify=$(params.TLSVERIFY) --no-cache \
         --ulimit nofile=4096:4096 \
         -f "$dockerfile_path" -t $(params.IMAGE) $(params.CONTEXT)

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -81,8 +81,6 @@ spec:
     name: commit
   - description: The precise URL that was fetched by this Task.
     name: url
-  - description: Set to `true` if a hermetic build parameters file was found in the cloned repo.
-    name: hermetic-build
   steps:
   - env:
     - name: HOME
@@ -193,11 +191,6 @@ spec:
       fi
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
-      if [ -e cachi2.params ]; then
-        printf "true" > "$(results.hermetic-build.path)"
-      else
-        printf "false" > "$(results.hermetic-build.path)"
-      fi
   workspaces:
   - description: The git repo will be cloned onto the volume backing this Workspace.
     name: output

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -10,25 +10,29 @@ metadata:
 spec:
   description: |-
     Task that uses Cachi2 to prefetch build dependencies.
+    See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
   params:
-  - description: Package type
-    name: package-type
-  - description: Package path
-    name: package-path
-  - description: Flags
-    name: flags
-    default: ""
+  - description: Configures project packages that will have their dependencies prefetched.
+    name: input
   steps:
   - image: quay.io/containerbuildsystem/cachi2@sha256:febe4e3e8ac01063c2f7319c43a60ab13e4cd2a9124500b0f8c53311a7e26d0f
     name: prefetch-dependencies
+    env:
+    - name: INPUT
+      value: $(params.input)
     script: |
+      if [ -z "${INPUT}" ]
+      then
+        echo "Build will be executed with network isolation, but no content was configured to be prefetched."
+        echo "This will likely result in a build failure."
+
+        exit 0
+      fi
+
       cachi2 fetch-deps \
       --source=$(workspaces.source.path) \
       --output=$(workspaces.source.path)/cachi2/output \
-      --package '{
-        "type": "$(params.package-type)",
-        "path": "$(params.package-path)"
-      }'
+      "${INPUT}"
 
       cachi2 generate-env $(workspaces.source.path)/cachi2/output \
       --format env \

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -15,7 +15,7 @@ spec:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
   steps:
-  - image: quay.io/containerbuildsystem/cachi2@sha256:febe4e3e8ac01063c2f7319c43a60ab13e4cd2a9124500b0f8c53311a7e26d0f
+  - image: quay.io/containerbuildsystem/cachi2@sha256:784c5a89682df877379ccb4b7afa19930d6f6f3e9b8fef2f48f060f35a8b5d0d
     name: prefetch-dependencies
     env:
     - name: INPUT


### PR DESCRIPTION
With the current integration, Cachi2 was limited to Go repositories that had the main module defined in the root of the repository. It was also dependent on the existence of a cachi2.params file that lived in the root of the repository.

Considering the addition of new package manager support to Cachi2 and the discouraging of having additional configuration files in the user's repository, this PR improves the current integration so that:

- The user can pass all configuration needed to Cachi2 using the `prefetch-input` pipeline parameter
- The preftech step no longer relies on the existence of a cachi2.params file
- The user can configure the network isolation using the `hermetic` parameter

### How to test this PR

```
tkn pipeline start docker-build \
-w name=workspace,volumeClaimTemplateFile=workspace-template.yaml \
-w name=registry-auth,secret=redhat-appstudio-staginguser-pull-secret \
-p revision="3c2735a005453932ececda0a17cfe13ef4a9c03d" \
-p git-url="https://github.com/chmeliik/dashdotdb"  \
-p output-image=quay.io/myuser/dashdotdb \
-p hermetic=true \
-p prefetch-input='[{"type":"pip"}]' \
--use-param-defaults
```