### PR TITLE
PLNSRVCE-970: disable setting of jvm cache

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -90,10 +90,6 @@ spec:
         echo "Cannot find Dockerfile $(params.DOCKERFILE)"
         exit 1
       fi
-      if [ "$(params.SKIP_CHECKS)" == "false" ] && grep -q '^RUN mvn' "$dockerfile_path"; then
-        sed -i -e 's|RUN mvn|RUN echo "<settings><mirrors><mirror><id>mirror.default</id><url>http://jvm-build-workspace-artifact-cache.$(context.taskRun.namespace).svc.cluster.local/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>" > /tmp/settings.yaml; mvn -s /tmp/settings.yaml|g' "$dockerfile_path"
-        touch /var/lib/containers/java
-      fi
 
       sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
 

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -62,9 +62,6 @@ spec:
     - |-
       echo "MAVEN_CLEAR_REPO=true" > env-file
 
-      [[ '$(params.SKIP_CHECKS)' == "false" ]] &&
-        echo "MAVEN_MIRROR_URL=http://jvm-build-workspace-artifact-cache.$(context.taskRun.namespace).svc.cluster.local/v1/cache/default/0/" >> env-file
-
       echo "Generated Env file"
       echo "------------------------------"
       cat env-file


### PR DESCRIPTION
JVM cache deployment is not set in the pipeline so it's pointing to non-existent cache.