### PR TITLE
fix: overriding pipeline bundle used in e2e

### DIFF
--- a/hack/util-install-bundle.sh
+++ b/hack/util-install-bundle.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e -o pipefail
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 BUNDLE=$1
@@ -23,7 +26,5 @@ spec:
         dockerfile: true
 EOF
 
-echo "Pipeline selectors configured to come from the namespace 'build-service':"
-oc get buildpipelineselector build-pipeline-selector -n build-service -o yaml | yq '.spec.selectors'
 echo "Overridden Pipeline selectors configured to come from the namespace '$NAMESPACE':"
 oc get buildpipelineselector build-pipeline-selector -n "$NAMESPACE" -o yaml | yq '.spec.selectors'


### PR DESCRIPTION
Since we've started using [build pipeline selector](https://github.com/redhat-appstudio/build-service/pull/84) instead of build-pipelines configmap, we need to update the logic in the pull request pipeline to install the custom build pipeline selector to `build-templates-e2e` namespace, where PR e2e tests are running.

Thanks to this we will be able to test changes to this repo per PR (again).