### PR TITLE
fix: e2e: update github org env var

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -131,7 +131,7 @@ spec:
                   secretKeyRef:
                     name: github
                     key: token
-              - name: GITHUB_E2E_ORGANIZATION
+              - name: MY_GITHUB_ORG
                 value: redhat-appstudio-appdata
     finally:
       - name: e2e-cleanup


### PR DESCRIPTION
the env var name for github org used for creating an application repo [has changed recently](https://github.com/redhat-appstudio/e2e-tests/blame/3148530edcd1b80f604490344d9852b18971ecf9/pkg/constants/constants.go#L9)