### PR TITLE
Run the git-clone task as root

### DIFF
--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -128,6 +128,8 @@ spec:
     image: $(params.gitInitImage)
     name: clone
     resources: {}
+    securityContext:
+      runAsUser: 0
     script: |
       #!/usr/bin/env sh
       set -eu


### PR DESCRIPTION
Currently, other tasks in the pipeline assume that the source was cloned as root. Make sure the step will indeed run as root even if the default USER in the git-init image is non-root.

Otherwise, for example the prefetch-dependencies task (which runs as root) may fail to fetch git tags when processing Go modules:

    cmdline: git fetch -v --force --tags origin
    stderr: 'fatal: detected dubious ownership in repository at '/workspace/source''

Signed-off-by: Adam Cmiel <acmiel@redhat.com>