### PR TITLE
PLNSRVCE-995: fix annotations for re-run

### DIFF
--- a/task/init/0.1/init.yaml
+++ b/task/init/0.1/init.yaml
@@ -44,6 +44,3 @@ spec:
         if ! oc get secret redhat-appstudio-registry-pull-secret &>/dev/null; then
           oc create secret generic redhat-appstudio-registry-pull-secret || true
         fi
-        if [ "$(params.skip-checks)" == "false" ]; then
-          oc annotate pipelinerun $(params.pipeline-run-name) 'appstudio.redhat.com/updateComponentOnSuccess=false'
-        fi

--- a/task/summary/0.1/summary.yaml
+++ b/task/summary/0.1/summary.yaml
@@ -28,8 +28,8 @@ spec:
         echo "Build repository: $(params.git-url)"
         echo "Generated Image is in : $(params.image-url)"
         echo
-        oc annotate pipelinerun $(params.pipeline-run-name) build.appstudio.openshift.io/repo=$(params.git-url)
-        oc annotate pipelinerun $(params.pipeline-run-name) build.appstudio.openshift.io/image=$(params.image-url)
+        oc annotate --overwrite pipelinerun $(params.pipeline-run-name) build.appstudio.openshift.io/repo=$(params.git-url)
+        oc annotate --overwrite pipelinerun $(params.pipeline-run-name) build.appstudio.openshift.io/image=$(params.image-url)
 
         echo "Output is in the following annotations:"
 


### PR DESCRIPTION
- appstudio.redhat.com/updateComponentOnSuccess is not used now PLNSRVCE-982
- updated annotation with --overwrite