### PR TITLE
PLNSRVCE-968: Remove registry-auth

### DIFF
--- a/hack/test-build.sh
+++ b/hack/test-build.sh
@@ -27,7 +27,6 @@ if [ -z "$MY_QUAY_USER" ]; then
   echo MY_QUAY_USER env variable is not set, pushing to $IMG
 else
   if oc get secret redhat-appstudio-staginguser-pull-secret &>/dev/null; then
-     PUSH_WORKSPACE="-w name=registry-auth,secret=redhat-appstudio-staginguser-pull-secret"
      # Ensure that the pipeline service account has access to the secret. Although the
      # secret is mounted directly on the pipeline, Tekton Chains needs this linkage so
      # it can push the image signature and attestation to the same OCI repository.
@@ -46,4 +45,4 @@ if [ "$SKIP_CHECKS" == "1" ]; then
   SKIP_CHECKS_PARAM="-p skip-checks=true"
 fi
 
-tkn pipeline start $PIPELINE_NAME -w name=workspace,volumeClaimTemplateFile=$SCRIPTDIR/test-build/workspace-template.yaml $PUSH_WORKSPACE $SKIP_CHECKS_PARAM -p git-url=$GITREPO -p output-image=$IMG --use-param-defaults
+tkn pipeline start $PIPELINE_NAME -w name=workspace,volumeClaimTemplateFile=$SCRIPTDIR/test-build/workspace-template.yaml $SKIP_CHECKS_PARAM -p git-url=$GITREPO -p output-image=$IMG --use-param-defaults

--- a/pipelines/prototypes/noop.yaml
+++ b/pipelines/prototypes/noop.yaml
@@ -115,7 +115,5 @@ spec:
           workspace: workspace
   workspaces:
     - name: workspace
-    - name: registry-auth
-      optional: true
     - name: git-auth
       optional: true

--- a/pipelines/prototypes/prototype-build-compliance.yaml
+++ b/pipelines/prototypes/prototype-build-compliance.yaml
@@ -62,8 +62,6 @@ spec:
       workspaces:
         - name: source
           workspace: workspace
-        - name: registry-auth
-          workspace: registry-auth
     - name: secret-detection-detect-secrets
       taskRef:
         name: utils-task
@@ -413,7 +411,5 @@ spec:
           echo "This is a placeholder for message-slack-summary"
   workspaces:
     - name: workspace
-    - name: registry-auth
-      optional: true
     - name: git-auth
       optional: true

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -85,8 +85,6 @@ spec:
       workspaces:
         - name: source
           workspace: workspace
-        - name: registry-auth
-          workspace: registry-auth
     - name: prefetch-dependencies
       when:
       - input: $(tasks.clone-repository.results.hermetic-build)
@@ -191,9 +189,6 @@ spec:
         value: $(tasks.build-container.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)
-      workspaces:
-      - name: registry-auth
-        workspace: registry-auth
     - name: sast-snyk-check
       when:
       - input: $(params.skip-checks)
@@ -222,9 +217,6 @@ spec:
         value: $(tasks.build-container.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)
-      workspaces:
-      - name: registry-auth
-        workspace: registry-auth
     - name: sbom-json-check
       when:
       - input: $(params.skip-checks)
@@ -265,7 +257,5 @@ spec:
       value: "$(tasks.clone-repository.results.commit)"
   workspaces:
     - name: workspace
-    - name: registry-auth
-      optional: true
     - name: git-auth
       optional: true

--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -27,9 +27,7 @@ spec:
         # strip new-line escape symbol from parameter and save it to variable
         imageanddigest=$(echo $imagewithouttag@'$(params.image-digest)')
 
-        [ -f /workspace/registry-auth/.dockerconfigjson ] && REGISTRY_ARGS="/workspace/registry-auth/"
-
-        clair-action report --image-ref=$imageanddigest --db-path=/tmp/matcher.db --format=quay --docker-config-dir=$REGISTRY_ARGS > /tekton/home/clair-result.json
+        clair-action report --image-ref=$imageanddigest --db-path=/tmp/matcher.db --format=quay --docker-config-dir=~/.docker/config.json > /tekton/home/clair-result.json
     - name: conftest-vulnerabilities
       image: quay.io/redhat-appstudio/hacbs-test:latest
       securityContext:
@@ -50,6 +48,3 @@ spec:
         parse_hacbs_test_output $(context.task.name) conftest /tekton/home/clair-vulnerabilities.json
 
         echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
-  workspaces:
-    - name: registry-auth
-      optional: true

--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -27,8 +27,6 @@ spec:
         # strip new-line escape symbol from parameter and save it to variable
         imageanddigest=$(echo $imagewithouttag@'$(params.image-digest)')
 
-        [ -f /workspace/registry-auth/.dockerconfigjson ] && REGISTRY_ARGS="/workspace/registry-auth/"
-
         clair-action report --image-ref=$imageanddigest --db-path=/tmp/matcher.db --format=quay --docker-config-dir=~/.docker/config.json > /tekton/home/clair-result.json || true
     - name: conftest-vulnerabilities
       image: quay.io/redhat-appstudio/hacbs-test:latest

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -46,11 +46,10 @@ spec:
             echo "$imageanddigest is an attestation image, skipping clamav scan"
             exit 0
         fi
-        [ -f /workspace/registry-auth/.dockerconfigjson ] && REGISTRY_ARGS="-a /workspace/registry-auth/.dockerconfigjson"
         mkdir content
         cd content
         echo Extracting image
-        if ! oc image extract $REGISTRY_ARGS $imageanddigest; then
+        if ! oc image extract $imageanddigest; then
           echo "Unable to extract image! Skipping clamscan!"
           exit 0
         fi
@@ -144,6 +143,3 @@ spec:
       emptydir: {}
     - name: work
       emptydir: {}
-  workspaces:
-    - name: registry-auth
-      optional: true

--- a/task/configure-build/0.1/configure-build.yaml
+++ b/task/configure-build/0.1/configure-build.yaml
@@ -14,14 +14,10 @@ spec:
     - name: shared-secret
       default: redhat-appstudio-user-workload
   results:
-    - name: registry-auth
-      description: docker config location
     - name: buildah-auth-param
       description: pass this to the build optional params to configure secrets
   workspaces:
     - name: source
-    - name: registry-auth
-      optional: true
   volumes:
     - name: default-push-secret
       csi:
@@ -40,35 +36,11 @@ spec:
         echo "App Studio Configure Build"
 
         DEST=/workspace/source/.dockerconfigjson
-        DEF=/secret/default-push-secret/.dockerconfigjson
-        AUTH=/workspace/registry-auth/.dockerconfigjson
-        TMP=$(mktemp)
-        echo '{}' > $DEST
-        # Set lowest priority on default shared secret
-        FILES="$DEF"
-        # Use secrets from serviceAccount
-        cd /tekton/creds-secrets
-        for file in $(ls); do
-          if [ -f "$file/.dockerconfigjson" ]; then
-            FILES="$FILES $file/.dockerconfigjson"
-          elif [ -f "$file/.dockercfg" ]; then
-            # convert format from .dockercfg to .dockerconfigjson
-            newformat=$(mktemp)
-            jq '{"auths": .}' $file/.dockercfg > $newformat
-            FILES="$FILES $newformat"
-          fi
-        done
-        # set highest priority on registry-auth workspace
-        FILES="$FILES $AUTH"
-        echo "Looking for Registry Auth Configs"
-        # Merge secrets into one file
-        for file in $FILES; do
-          if [ -f "$file" ]; then
-            echo "$file found"
-            jq -M -s '.[0] * .[1]' $DEST $file > $TMP
-            mv $TMP $DEST
-          fi
-        done
+        SHARED=/secret/default-push-secret/.dockerconfigjson
+        if [ -f $SHARED ]; then
+           jq -M -s '.[0] * .[1]' $SHARED ~/.docker/config.json > $DEST
+        else
+           cp ~/.docker/config.json $DEST
+        fi
         chmod 644 $DEST
-        echo -n $DEST > /tekton/results/registry-auth
         echo -n "--authfile $DEST"  >  /tekton/results/buildah-auth-param

--- a/task/init/0.1/init.yaml
+++ b/task/init/0.1/init.yaml
@@ -23,7 +23,7 @@ spec:
   results:
     - name: build
   steps:
-    - name: appstudio-init
+    - name: init
       image: registry.access.redhat.com/ubi9/skopeo:9.1.0-5@sha256:6ebbdfce633f9915a6a99d8ee035d9fd258121aa1acf944229e90696eb353549
       script: |
         #!/bin/bash
@@ -35,12 +35,4 @@ spec:
           echo -n "true" > $(results.build.path)
         else
           echo -n "false" > $(results.build.path)
-        fi
-
-    - name: hacbs-init
-      image: registry.redhat.io/openshift4/ose-cli:v4.11
-      script: |
-        # Create empty secret which is now hardcoded in PaC Pipelinerun template
-        if ! oc get secret redhat-appstudio-registry-pull-secret &>/dev/null; then
-          oc create secret generic redhat-appstudio-registry-pull-secret || true
         fi


### PR DESCRIPTION
Registry auth removal since the secrets should be linked to service account to be possible to use them by chains.

Updated secret merge logic to use tekton feature which creates ~/.docker/config.json file based on secrets attached to ServiceAccount  (which was done manually).
https://tekton.dev/vault/pipelines-v0.15.2/auth/#kubernetess-docker-registrys-secret