### PR TITLE
fix(STONE-355): clair-scan must not fail the pipelinerun

### DIFF
--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -29,7 +29,7 @@ spec:
 
         [ -f /workspace/registry-auth/.dockerconfigjson ] && REGISTRY_ARGS="/workspace/registry-auth/"
 
-        clair-action report --image-ref=$imageanddigest --db-path=/tmp/matcher.db --format=quay --docker-config-dir=$REGISTRY_ARGS > /tekton/home/clair-result.json
+        clair-action report --image-ref=$imageanddigest --db-path=/tmp/matcher.db --format=quay --docker-config-dir=$REGISTRY_ARGS > /tekton/home/clair-result.json || true
     - name: conftest-vulnerabilities
       image: quay.io/redhat-appstudio/hacbs-test:latest
       securityContext:
@@ -37,9 +37,13 @@ spec:
           add:
             - SETFCAP
       script: |
-        /usr/bin/conftest test --no-fail /tekton/home/clair-result.json \
-        --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \
-        --output=json | tee /tekton/home/clair-vulnerabilities.json
+        if [ ! -s /tekton/home/clair-result.json ]; then
+          echo "Previous step [get-vulnerabilities] failed, /tekton/home/clair-result.json is empty."
+        else
+          /usr/bin/conftest test --no-fail /tekton/home/clair-result.json \
+          --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \
+          --output=json | tee /tekton/home/clair-vulnerabilities.json || true
+        fi
     - name: test-format-result
       image: quay.io/redhat-appstudio/hacbs-test:latest
       script: |


### PR DESCRIPTION
As Title clarifies, preventing both clair steps from failing.