### PR TITLE
Create Tekton task and Pipeline for Tekton bundles

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -154,11 +154,11 @@ spec:
         taskSpec:
           steps:
             - name: fail-when-repo-is-missed
-              image: registry.redhat.io/openshift4/ose-cli:v4.11
+              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12
               workingDir: $(workspaces.source.path)
               script: |
                 #!/usr/bin/env bash
-                .tekton/scripts/check-task-pipeline-bundle-repos.sh
+                PULL_REQUEST=1 .tekton/scripts/check-task-pipeline-bundle-repos.sh
           workspaces:
             - name: source
         workspaces:

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -133,6 +133,22 @@ spec:
                     key: token
               - name: MY_GITHUB_ORG
                 value: redhat-appstudio-appdata
+      - name: check-task-pipeline-repo-existence
+        runAfter:
+          - build-bundles
+        taskSpec:
+          steps:
+            - name: fail-when-repo-is-missed
+              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12
+              workingDir: $(workspaces.source.path)
+              script: |
+                #!/usr/bin/env bash
+                PULL_REQUEST=1 .tekton/scripts/check-task-pipeline-bundle-repos.sh
+          workspaces:
+            - name: source
+        workspaces:
+          - name: source
+            workspace: workspace
     finally:
       - name: e2e-cleanup
         params:
@@ -150,20 +166,6 @@ spec:
                 # Perform cleanup of resources created by gitops service
                 oc delete --ignore-not-found deployment --all -n $(params.e2e_test_namespace)
                 oc delete --ignore-not-found eventlisteners --all -n $(params.e2e_test_namespace)
-      - name: check-task-pipeline-repo-existence
-        taskSpec:
-          steps:
-            - name: fail-when-repo-is-missed
-              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12
-              workingDir: $(workspaces.source.path)
-              script: |
-                #!/usr/bin/env bash
-                PULL_REQUEST=1 .tekton/scripts/check-task-pipeline-bundle-repos.sh
-          workspaces:
-            - name: source
-        workspaces:
-          - name: source
-            workspace: workspace
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/scripts/check-task-pipeline-bundle-repos.sh
+++ b/.tekton/scripts/check-task-pipeline-bundle-repos.sh
@@ -1,4 +1,8 @@
-#!/usr/bin/bash -e
+#!/usr/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPTDIR/../.."
@@ -6,8 +10,15 @@ cd "$SCRIPTDIR/../.."
 QUAY_ORG=redhat-appstudio-tekton-catalog
 
 locate_bundle_repo() {
-    local -r repo_name=$1
-    curl -I -s -L -w "%{http_code}\n" -o /dev/null "https://quay.io/api/v1/repository/${QUAY_ORG}/${repo_name}"
+    local -r type="$1"
+    local -r object="$2"
+    local -r version="${3}"
+
+    if [ "${PULL_REQUEST:-0}" -ne 1 ]; then
+        curl -I -s -L -w "%{http_code}\n" -o /dev/null "https://quay.io/v2/${QUAY_ORG}/${type}-${object}/manifests/${version}"
+    else
+        curl -I -s -L -w "%{http_code}\n" -o /dev/null "https://quay.io/v2/${QUAY_ORG}/pull-request-builds/manifests/${object}-${version}"
+    fi
 }
 
 has_missing_repo=
@@ -17,7 +28,9 @@ echo "Checking existence of task and pipeline bundle repositories ..."
 # tasks
 for task_file in task/*/*/*.yaml; do
     task_name=$(oc apply --dry-run=client -f "$task_file" -o jsonpath='{.metadata.name}')
-    found=$(locate_bundle_repo "task-$task_name")
+    dir=${task_file%/*}
+    version="${dir##*/}-$(git log -n 1 --pretty=format:%H -- "${task_file}")"
+    found=$(locate_bundle_repo task "$task_name" "${version}")
     if [ "$found" != "200" ]; then
         echo "Missing task bundle repo: task-$task_name"
         has_missing_repo=yes
@@ -25,10 +38,11 @@ for task_file in task/*/*/*.yaml; do
 done
 
 # pipelines
+version="$(git rev-parse HEAD)"
 for pl_name in $(oc kustomize pipelines/ | oc apply --dry-run=client -f - -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'); do
-    found=$(locate_bundle_repo "pipeline-$pl_name")
+    found=$(locate_bundle_repo pipeline "$pl_name" "${version}")
     if [ "$found" != "200" ]; then
-        echo "Missing pipeline bundle repo: pipeline-$pl_name"
+        echo "Missing pipeline bundle repo: pipeline-$pl_name ${version}"
         has_missing_repo=yes
     fi
 done

--- a/pipelines/kustomization.yaml
+++ b/pipelines/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - nodejs-builder
 - enterprise-contract.yaml
 - fbc-builder
+- tekton-bundle-builder

--- a/pipelines/tekton-bundle-builder/kustomization.yaml
+++ b/pipelines/tekton-bundle-builder/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../template-build
+
+patches:
+# Use the template-build as a template replacing the Pipeline name and the
+# `build-container` step's task reference
+- patch: |-
+    - op: replace
+      path: /metadata/name
+      value: tekton-bundle-builder
+    - op: replace
+      path: /spec/tasks/4/taskRef
+      value:
+        name: tkn-bundle
+        version: "0.1"
+  target:
+    kind: Pipeline
+    name: template-build

--- a/task/tkn-bundle/0.1/.shellspec
+++ b/task/tkn-bundle/0.1/.shellspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/task/tkn-bundle/0.1/README.md
+++ b/task/tkn-bundle/0.1/README.md
@@ -1,0 +1,50 @@
+# tkn-bundle - Tekton Task to push a Tekton Bundle to an image registry
+
+Tekton Task to build and push Tekton Bundles (OCI images) which contain
+definitions of Tekton objects, most commonly Task and Pipeline objects.
+
+Task finds all `*.yaml` or `*.yml` files within `CONTEXT`, packages and pushes
+them as a Tekton Bundle to the image repository, name and tag specified by the
+`IMAGE` parameter.
+
+## Input Parameters
+
+The task supports the following input parameters.
+
+| Name    | Example                 | Description                              |
+|---------|-------------------------|------------------------------------------|
+| IMAGE   | registry.io/my-task:tag | Reference of the image task will produce |
+| CONTEXT | my-task/0.1             | Paths to include in the bundle image     |
+
+`CONTEXT` can include multiple directories or files separated by comma or space.
+Paths can be negated with exclamation mark to prevent inclusion of certain
+directories or files. Negated paths are best placed at the end as they operate
+on collected paths preceeding them. For example if `CONTEXT` is set to
+`"0.1,!0.1/spec"` for this tree:
+
+    .
+    ├── 0.1
+    │   ├── README.md
+    │   ├── spec
+    │   │   ├── spec_helper.sh
+    │   │   ├── support
+    │   │   │   ├── jq_matcher.sh
+    │   │   │   └── task_run_subject.sh
+    │   │   ├── test1.yaml
+    │   │   ├── test2.yml
+    │   │   ├── test3.yaml
+    │   │   └── tkn-bundle_spec.sh
+    │   ├── TESTING.md
+    │   └── tkn-bundle.yaml
+    └── OWNERS
+
+Only the `0.1/tkn-bundle.yaml` file will be included in the bundle.
+
+## Results
+
+The task emits the following results.
+
+| Name         | Example                           | Description                                       |
+|--------------|-----------------------------------|---------------------------------------------------|
+| IMAGE_URL    | registry.io/my-task@sha256-abc... | Image repository where the built image was pushed |
+| IMAGE_DIGEST | abc...                            | Digest of the image just built                    |

--- a/task/tkn-bundle/0.1/TESTING.md
+++ b/task/tkn-bundle/0.1/TESTING.md
@@ -1,0 +1,37 @@
+# Testing tkn-bundle Tekton Task
+
+Make sure you have shellspec installed[1]. The test setup script will bring up a
+kind[2] cluster and installs Tekton Pipeline. The source is provided via the
+`source-pvc` PersistantVolumeClaim and prepopulated with the test?.y*ml files in
+order to not necesate the need for source checkout.
+
+For second and subsequent invocations the setup is quicker as it only applies
+any changes to already started and setup cluster. To delete the cluster and
+start afresh run: `kind delete cluster --name=test-tkn-bundle`.
+
+To run the tests run `shellspec` from this directory.
+
+## Example of a testing setup and session
+
+```shell
+$ pwd
+.../build-definitions/task/tkn-bundle/0.1
+$ shellspec --jobs 5
+Running: /bin/sh [bash 5.2.15(1)-release]
+namespace/tekton-pipelines created
+clusterrole.rbac.authorization.k8s.io/tekton-pipelines-controller-cluster-access created
+...
+pod "setup-1674815473" deleted
+deployment.apps/registry created
+service/registry created
+deployment.apps/registry condition met
+deployment.apps/tekton-pipelines-controller condition met
+deployment.apps/tekton-pipelines-webhook condition met
+.....
+
+Finished in 119.59 seconds (user 7.37 seconds, sys 4.03 seconds)
+2 examples, 0 failures
+```
+
+[1] https://shellspec.info/
+[2] https://kind.sigs.k8s.io/

--- a/task/tkn-bundle/0.1/spec/spec_helper.sh
+++ b/task/tkn-bundle/0.1/spec/spec_helper.sh
@@ -1,0 +1,10 @@
+#!/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+spec_helper_configure() {
+  import 'support/task_run_subject'
+  import 'support/jq_matcher'
+}

--- a/task/tkn-bundle/0.1/spec/support/jq_matcher.sh
+++ b/task/tkn-bundle/0.1/spec/support/jq_matcher.sh
@@ -1,0 +1,30 @@
+#!/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+shellspec_syntax 'shellspec_matcher_jq'
+
+shellspec_matcher_jq() {
+  shellspec_matcher__match() {
+    SHELLSPEC_EXPECT="$1"
+    [ "${SHELLSPEC_SUBJECT+x}" ] || return 1
+    echo "${SHELLSPEC_SUBJECT}" | jq --exit-status "${SHELLSPEC_EXPECT}" > /dev/null || return 1
+    return 0
+  }
+
+  # Message when the matcher fails with "should"
+  shellspec_matcher__failure_message() {
+    shellspec_putsn "expected: JSON $1 should evaluate with success against jq expression: $2"
+  }
+
+  # Message when the matcher fails with "should not"
+  shellspec_matcher__failure_message_when_negated() {
+    shellspec_putsn "expected: JSON $1 should not evaluate with success against jq expression: $2"
+  }
+
+  # checking for parameter count
+  shellspec_syntax_param count [ $# -eq 1 ] || return 0
+  shellspec_matcher_do_match "$@"
+}

--- a/task/tkn-bundle/0.1/spec/support/task_run_subject.sh
+++ b/task/tkn-bundle/0.1/spec/support/task_run_subject.sh
@@ -1,0 +1,26 @@
+#!/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+shellspec_syntax 'shellspec_subject_taskrun'
+
+shellspec_subject_taskrun() {
+  # shellcheck disable=SC2034
+  SHELLSPEC_META='text'
+  shellspec_readfile_once SHELLSPEC_STDOUT "$SHELLSPEC_STDOUT_FILE"
+  if [ ${SHELLSPEC_STDOUT+x} ]; then
+    # shellcheck disable=SC2034
+    LINES=(${SHELLSPEC_STDOUT[@]})
+    TASK_RUN_NAME="${LINES[2]}" # "TaskRun(0) started:(1) tkn-bundle-run-ndjfb(2)
+    SHELLSPEC_SUBJECT="$(tkn tr describe "${TASK_RUN_NAME}" -o json)"
+    shellspec_chomp SHELLSPEC_SUBJECT
+  else
+    unset SHELLSPEC_SUBJECT ||:
+  fi
+
+  shellspec_off UNHANDLED_STDOUT
+
+  eval shellspec_syntax_dispatch modifier ${1+'"$@"'}
+}

--- a/task/tkn-bundle/0.1/spec/test1.yaml
+++ b/task/tkn-bundle/0.1/spec/test1.yaml
@@ -1,0 +1,4 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test1

--- a/task/tkn-bundle/0.1/spec/test2.yml
+++ b/task/tkn-bundle/0.1/spec/test2.yml
@@ -1,0 +1,4 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test2

--- a/task/tkn-bundle/0.1/spec/test3.yaml
+++ b/task/tkn-bundle/0.1/spec/test3.yaml
@@ -1,0 +1,4 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test3

--- a/task/tkn-bundle/0.1/spec/tkn-bundle_spec.sh
+++ b/task/tkn-bundle/0.1/spec/tkn-bundle_spec.sh
@@ -1,0 +1,140 @@
+#!/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+eval "$(shellspec - -c) exit 1"
+
+Describe "tkn-bundle task"
+  setup() {
+    # Create Kind cluster if it doesn't exist already
+    CLUSTER_NAME="test-tkn-bundle"
+    kind get clusters -q | grep -q "${CLUSTER_NAME}" || kind create cluster -q --name="${CLUSTER_NAME}"
+
+    # Install Tekton Pipeline, proceed with the rest of the test of the setup
+    kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.42.0/release.yaml
+
+    # Create the test namespace
+    kubectl create namespace test --dry-run=client -o yaml | kubectl apply -f -
+    kubectl config set-context --current --namespace=test
+    while ! kubectl get serviceaccount default 2> /dev/null
+    do
+      sleep 1
+    done
+
+    # Create the tkn-bundle Task
+    kubectl apply -f tkn-bundle.yaml
+
+    # Copy the task's YAML file to the persistent volume mounted as source for
+    # running the task via a setup Pod
+
+    # Create the PersistentVolumeClaim
+    echo 'apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: source-pvc
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi
+' | kubectl apply -f -
+
+    # Image to run the setup pod with, taken from the Task definition
+    IMAGE="$(kubectl get task tkn-bundle -o=jsonpath='{.spec.steps[0].image}')"
+    # Semi-random name for the setup Pod
+    SETUP_POD="setup-$(date +%s)"
+    # Run the pod with the volume mounted at /source, the container is blocking
+    # until "/stop" file is created
+    kubectl run "${SETUP_POD}" \
+        --restart=Never \
+        --image="${IMAGE}" \
+        --override-type=json \
+        --overrides='[
+            {"op":"add","path":"/spec/containers/0/volumeMounts","value":[{"name":"source","mountPath":"/source"}]},
+            {"op":"add","path":"/spec/volumes","value":[{"name":"source","persistentVolumeClaim":{"claimName":"source-pvc"}}]}]' \
+        --command -- bash -c 'while [ ! -f /tmp/stop ]; do sleep 1; done'
+    # Wait for the Pod to be ready
+    kubectl wait --for=condition=Ready "pod/${SETUP_POD}" --timeout=3m
+
+    # Clean the volume before proceeding
+    kubectl exec "${SETUP_POD}" -- sh -c 'rm -rf /source/*'
+
+    # Copy the files over
+    setup_file() {
+      source="$1"
+      dest="$2"
+
+      kubectl exec -i "${SETUP_POD}" -- sh -c "mkdir -p \"$(dirname "${dest}")\"; cat > ${dest}" < "${source}"
+    }
+    setup_file spec/test1.yaml /source/test1.yaml
+    setup_file spec/test2.yml /source/test2.yml
+    setup_file spec/test3.yaml /source/sub/test3.yaml
+
+    # Trigger the termination and delete the Pod
+    kubectl exec "${SETUP_POD}" -- touch /tmp/stop
+    kubectl delete pod "${SETUP_POD}"
+
+    # Deploy an image registry and expose it via a Service
+    kubectl create deployment registry --image=docker.io/registry:2.8.1 --port=5000 --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create service clusterip registry --tcp=5000:5000 --dry-run=client -o yaml | kubectl apply -f -
+    kubectl wait deployment registry --for=condition=Available --timeout=3m
+
+    # Finally wait for Tekton Pipeline to be available
+    kubectl -n tekton-pipelines wait deployment -l "app.kubernetes.io/part-of=tekton-pipelines" --for=condition=Available --timeout=3m
+  }
+  BeforeAll 'setup'
+
+  It 'creates Tekton bundles'
+    When call tkn task start tkn-bundle -p IMAGE=registry:5000/bundle:tag --use-param-defaults --timeout 1m --showlog -w name=source,claimName=source-pvc
+    The output should include 'Added Task: test1 to image'
+    The output should include 'Added Task: test2 to image'
+    The output should include 'Added Task: test3 to image'
+    The output should include 'Pushed Tekton Bundle to registry:5000/bundle'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("sha256:[a-z0-9]+")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("registry:5000/bundle@sha256:[a-z0-9]+")'
+  End
+
+  It 'creates Tekton bundles from specific context'
+    When call tkn task start tkn-bundle -p IMAGE=registry:5000/sub:tag -p CONTEXT=sub --timeout 1m --showlog -w name=source,claimName=source-pvc
+    The output should not include 'Added Task: test1 to image'
+    The output should not include 'Added Task: test2 to image'
+    The output should include 'Added Task: test3 to image'
+    The output should include 'Pushed Tekton Bundle to registry:5000/sub'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("sha256:[a-z0-9]+")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("registry:5000/sub@sha256:[a-z0-9]+")'
+  End
+
+  It 'creates Tekton bundles when context points to a file'
+    When call tkn task start tkn-bundle -p IMAGE=registry:5000/file:tag -p CONTEXT=test2.yml --timeout 1m --showlog -w name=source,claimName=source-pvc
+    The output should not include 'Added Task: test1 to image'
+    The output should not include 'Added Task: test3 to image'
+    The output should include 'Added Task: test2 to image'
+    The output should include 'Pushed Tekton Bundle to registry:5000/file'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("sha256:[a-z0-9]+")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("registry:5000/file@sha256:[a-z0-9]+")'
+  End
+
+  It 'creates Tekton bundles when context points to a file and a directory'
+    When call tkn task start tkn-bundle -p IMAGE=registry:5000/mix:tag -p CONTEXT=test2.yml,sub --timeout 1m --showlog -w name=source,claimName=source-pvc
+    The output should not include 'Added Task: test1 to image'
+    The output should include 'Added Task: test2 to image'
+    The output should include 'Added Task: test3 to image'
+    The output should include 'Pushed Tekton Bundle to registry:5000/mix'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("sha256:[a-z0-9]+")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("registry:5000/mix@sha256:[a-z0-9]+")'
+  End
+
+  It 'creates Tekton bundles when using negation'
+    When call tkn task start tkn-bundle -p IMAGE=registry:5000/neg:tag -p CONTEXT=!sub --timeout 1m --showlog -w name=source,claimName=source-pvc
+    The output should not include 'Added Task: test3 to image'
+    The output should include 'Added Task: test1 to image'
+    The output should include 'Added Task: test2 to image'
+    The output should include 'Pushed Tekton Bundle to registry:5000/neg'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("sha256:[a-z0-9]+")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("registry:5000/neg@sha256:[a-z0-9]+")'
+  End
+End

--- a/task/tkn-bundle/0.1/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.1/tkn-bundle.yaml
@@ -1,0 +1,96 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "image-build, appstudio, hacbs"
+  name: tkn-bundle
+spec:
+  description: |-
+    Creates and pushes a Tekton bundle containing the specified Tekton YAML files.
+  params:
+  - description: Reference of the image task will produce.
+    name: IMAGE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository where the built image was pushed
+    name: IMAGE_URL
+  steps:
+  - image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:1.9
+    name: build
+    script: |
+      #!/bin/env bash
+
+      set -o errexit
+      set -o pipefail
+      set -o nounset
+
+      # expand '**', and don't return glob expression when no matches found
+      shopt -s globstar nullglob
+
+      # read params.CONTEXT as an array split by comma or space into PATHS
+      IFS=', ' read -r -a PATHS <<< "$(params.CONTEXT)"
+      FILES=()
+      for path in "${PATHS[@]}"; do
+        # keeps current path expanded
+        paths=()
+        # are we negating the current path
+        neg=0
+        if [[ "${path}" == \!* ]]; then
+          neg=1
+          path="${path#\!}"
+        fi
+        if [[ -d "$(workspaces.source.path)/${path}" ]]; then
+          # for directories look for any .yaml or .yml files
+          paths+=(
+            $(workspaces.source.path)/${path}/**/*.yaml
+            $(workspaces.source.path)/${path}/**/*.yml
+          )
+        else
+          # for files add the file to the collected paths
+          paths+=("${path}")
+        fi
+        if [[ $neg == 0 ]]; then
+          # collect curent paths to FILES
+          FILES+=("${paths[@]}")
+        else
+          if [[ ${#PATHS[@]} -eq 1 ]]; then
+            # single negative path provided, first include everything then
+            # subtract the negative elements
+            FILES=(
+              $(workspaces.source.path)/**/*.yaml
+              $(workspaces.source.path)/**/*.yml
+            )
+          fi
+          for p in "${paths[@]}"; do
+            # remove any collected paths from FILES, leaves blank elements in place
+            FILES=("${FILES[@]/$p/}")
+          done
+          # remove blank elements
+          TMP=("${FILES[@]}")
+          FILES=()
+          for p in "${TMP[@]}"; do
+            [[ -n "${p}" ]] && FILES+=("${p}")
+          done
+        fi
+      done
+      [[ ${#FILES[@]} -eq 0 ]] \
+        && echo 'No YAML files matched by "$(params.CONTEXT)" in "$(workspaces.source.path)", aborting the build' \
+        && exit 1
+      exec 3>&1;
+      OUT="$(tkn bundle push "$(params.IMAGE)" \
+        $(printf ' -f %s' "${FILES[@]}") \
+        |tee /proc/self/fd/3)"
+      echo "${OUT#*Pushed Tekton Bundle to }" > $(results.IMAGE_URL.path)
+      echo "${OUT#*Pushed Tekton Bundle to *@}" > $(results.IMAGE_DIGEST.path)
+    workingDir: $(workspaces.source.path)
+  workspaces:
+  - name: source

--- a/task/tkn-bundle/OWNERS
+++ b/task/tkn-bundle/OWNERS
@@ -1,0 +1,1 @@
+Stonesoup Enterprise Contract Team


### PR DESCRIPTION
This adds `tkn-bundle` Tekton Task that simply finds all *.yaml or *.yml files in the current `params.CONTEXT` directory and creates a Tekton Bundle by pushing it to `params.IMAGE`. The result of the task are `IMAGE_URL` image reference with digest (no tag) and `IMAGE_DIGEST` containing the image digest.

Also adds `tekton-bundle-builder` builder pipeline that uses the `tkn-bundle` task for the `build` step.

Tests are provided.

Ref. https://issues.redhat.com/browse/HACBS-1675