### PR TITLE
use DOCKER_CONFIG env for auth files and push sbom via cosign

### DIFF
--- a/.tekton/tasks/buildah.yaml
+++ b/.tekton/tasks/buildah.yaml
@@ -37,14 +37,6 @@ spec:
     description: The format of the built container, oci or docker
     name: FORMAT
     type: string
-  - default: ""
-    description: Extra parameters passed for the build command when building images.
-    name: BUILD_EXTRA_ARGS
-    type: string
-  - default: ""
-    description: Extra parameters passed for the push command when pushing images.
-    name: PUSH_EXTRA_ARGS
-    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -62,7 +54,7 @@ spec:
         cpu: 10m
     script: |
       buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
-        $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
+        --format=$(params.FORMAT) \
         --tls-verify=$(params.TLSVERIFY) --no-cache \
         -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
     securityContext:
@@ -78,7 +70,7 @@ spec:
     resources: {}
     script: |
       buildah --storage-driver=$(params.STORAGE_DRIVER) push \
-        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --tls-verify=$(params.TLSVERIFY) \
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
     volumeMounts:

--- a/hack/test-build.sh
+++ b/hack/test-build.sh
@@ -30,7 +30,7 @@ else
      # Ensure that the pipeline service account has access to the secret. Although the
      # secret is mounted directly on the pipeline, Tekton Chains needs this linkage so
      # it can push the image signature and attestation to the same OCI repository.
-     oc secrets link pipeline redhat-appstudio-staginguser-pull-secret --for=pull
+     oc secrets link pipeline redhat-appstudio-staginguser-pull-secret
   else
      echo "Secret redhat-appstudio-staginguser-pull-secret is not created, can be created by:"
      echo "Docker:"
@@ -39,7 +39,7 @@ else
      echo "  oc create secret docker-registry redhat-appstudio-staginguser-pull-secret --from-file=.dockerconfigjson=${XDG_RUNTIME_DIR}/containers/auth.json"
      echo "(Note: it will upload all login credentials, make sure that you are not logged into sensitive registries, or create the particular secret manually!)"
      echo "and link it to the pipeline ServiceAccount:"
-     echo "  oc secrets link pipeline redhat-appstudio-staginguser-pull-secret --for=pull"
+     echo "  oc secrets link pipeline redhat-appstudio-staginguser-pull-secret"
      echo ""
   fi
   IMG=quay.io/$MY_QUAY_USER/$APPNAME:$IMAGE_SHORT_TAG

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -22,10 +22,8 @@
     value: $(params.dockerfile)
   - name: CONTEXT
     value: $(params.path-context)
-  - name: BUILD_EXTRA_ARGS
-    value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
-  - name: PUSH_EXTRA_ARGS
-    value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+  - name: DOCKER_AUTH
+    value: "$(tasks.appstudio-configure-build.results.docker-auth)"
   - name: HERMETIC
     value: "$(params.hermetic)"
   - name: PREFETCH_INPUT

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -22,10 +22,8 @@
     value: $(params.dockerfile)
   - name: CONTEXT
     value: $(params.path-context)
-  - name: BUILD_EXTRA_ARGS
-    value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
-  - name: PUSH_EXTRA_ARGS
-    value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+  - name: DOCKER_AUTH
+    value: "$(tasks.appstudio-configure-build.results.docker-auth)"
 - op: add
   path: /spec/tasks/-
   value:

--- a/pipelines/java-builder/patch.yaml
+++ b/pipelines/java-builder/patch.yaml
@@ -20,8 +20,8 @@
     value: $(params.path-context)
   - name: IMAGE
     value: "$(params.output-image)"
-  - name: PUSH_EXTRA_ARGS
-    value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+  - name: DOCKER_AUTH
+    value: "$(tasks.appstudio-configure-build.results.docker-auth)"
   - name: SKIP_CHECKS
     value: "$(params.skip-checks)"
 - op: add

--- a/pipelines/nodejs-builder/patch.yaml
+++ b/pipelines/nodejs-builder/patch.yaml
@@ -20,5 +20,5 @@
     value: $(params.path-context)
   - name: IMAGE
     value: "$(params.output-image)"
-  - name: PUSH_EXTRA_ARGS
-    value: "$(tasks.appstudio-configure-build.results.buildah-auth-param)"
+  - name: DOCKER_AUTH
+    value: "$(tasks.appstudio-configure-build.results.docker-auth)"

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -258,16 +258,6 @@ spec:
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
 
-      # Create and push sbom image
-      sbom_container=$(buildah from scratch)
-      sbom_container_mountpath=$(buildah mount $sbom_container)
-      cp sbom-cyclonedx.json sbom-purl.json $sbom_container_mountpath
-      buildah umount $sbom_container
-      buildah commit working-container $(params.IMAGE).sbom
-      buildah push \
-        --tls-verify=$(params.TLSVERIFY) \
-        $(params.IMAGE).sbom
-
     securityContext:
       runAsUser: 0
       capabilities:
@@ -276,6 +266,18 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+
+  - name: upload-sbom
+    image: quay.io/redhat-appstudio/cosign:v1.13.1
+    args:
+      - attach
+      - sbom
+      - --sbom
+      - sbom-cyclonedx.json
+      - --type
+      - cyclonedx
+      - $(params.IMAGE)
     workingDir: $(workspaces.source.path)
 
   volumes:

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -35,12 +35,8 @@ spec:
     name: TLSVERIFY
     type: string
   - default: ""
-    description: Extra parameters passed for the build command when building images.
-    name: BUILD_EXTRA_ARGS
-    type: string
-  - default: ""
-    description: Extra parameters passed for the push command when pushing images.
-    name: PUSH_EXTRA_ARGS
+    description: folder with config.json for container auth
+    name: DOCKER_AUTH
     type: string
   - default: "false"
     description: Determines if build will be executed without network access.
@@ -71,6 +67,8 @@ spec:
       value: $(params.HERMETIC)
     - name: PREFETCH_INPUT
       value: $(params.PREFETCH_INPUT)
+    - name: DOCKER_CONFIG
+      value: $(params.DOCKER_AUTH)
   steps:
   - image: $(params.BUILDER_IMAGE)
     name: build
@@ -120,7 +118,6 @@ spec:
       fi
 
       buildah bud \
-        $(params.BUILD_EXTRA_ARGS) \
         $NETWORK \
         $VOLUME_MOUNTS \
         --tls-verify=$(params.TLSVERIFY) --no-cache \
@@ -255,7 +252,7 @@ spec:
       buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
       buildah commit $container $(params.IMAGE)
       buildah push \
-        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --tls-verify=$(params.TLSVERIFY) \
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
@@ -268,7 +265,7 @@ spec:
       buildah umount $sbom_container
       buildah commit working-container $(params.IMAGE).sbom
       buildah push \
-        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --tls-verify=$(params.TLSVERIFY) \
         $(params.IMAGE).sbom
 
     securityContext:

--- a/task/configure-build/0.1/configure-build.yaml
+++ b/task/configure-build/0.1/configure-build.yaml
@@ -14,8 +14,8 @@ spec:
     - name: shared-secret
       default: redhat-appstudio-user-workload
   results:
-    - name: buildah-auth-param
-      description: pass this to the build optional params to configure secrets
+    - name: docker-auth
+      description: pass composed docker auth file
   workspaces:
     - name: source
   volumes:
@@ -34,8 +34,8 @@ spec:
       script: |
         #!/usr/bin/env bash
         echo "App Studio Configure Build"
-
-        DEST=/workspace/source/.dockerconfigjson
+        mkdir /workspace/source/.docker
+        DEST=/workspace/source/.docker/config.json
         SHARED=/secret/default-push-secret/.dockerconfigjson
         if [ -f $SHARED ]; then
            jq -M -s '.[0] * .[1]' $SHARED ~/.docker/config.json > $DEST
@@ -43,4 +43,4 @@ spec:
            cp ~/.docker/config.json $DEST
         fi
         chmod 644 $DEST
-        echo -n "--authfile $DEST"  >  /tekton/results/buildah-auth-param
+        echo -n /workspace/source/.docker > /tekton/results/docker-auth

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -35,10 +35,9 @@ spec:
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
-  # Additional parameter for auth configuration
   - default: ""
-    description: Extra parameters passed for the push command when pushing images.
-    name: PUSH_EXTRA_ARGS
+    description: folder with config.json for container auth
+    name: DOCKER_AUTH
     type: string
   results:
   - description: Digest of the image just built
@@ -57,6 +56,8 @@ spec:
       value: oci
     - name: STORAGE_DRIVER
       value: vfs
+    - name: DOCKER_CONFIG
+      value: $(params.DOCKER_AUTH)
   steps:
   - args:
     - |-
@@ -230,7 +231,7 @@ spec:
       buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
       buildah commit $container $(params.IMAGE)
       buildah push \
-        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --tls-verify=$(params.TLSVERIFY) \
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
@@ -243,7 +244,7 @@ spec:
       buildah umount $sbom_container
       buildah commit working-container $(params.IMAGE).sbom
       buildah push \
-        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --tls-verify=$(params.TLSVERIFY) \
         $(params.IMAGE).sbom
     securityContext:
       runAsUser: 0

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -237,15 +237,6 @@ spec:
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
 
-      # Create and push sbom image
-      sbom_container=$(buildah from scratch)
-      sbom_container_mountpath=$(buildah mount $sbom_container)
-      cp sbom-cyclonedx.json sbom-purl.json $sbom_container_mountpath
-      buildah umount $sbom_container
-      buildah commit working-container $(params.IMAGE).sbom
-      buildah push \
-        --tls-verify=$(params.TLSVERIFY) \
-        $(params.IMAGE).sbom
     securityContext:
       runAsUser: 0
       capabilities:
@@ -254,6 +245,18 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+
+  - name: upload-sbom
+    image: quay.io/redhat-appstudio/cosign:v1.13.1
+    args:
+      - attach
+      - sbom
+      - --sbom
+      - sbom-cyclonedx.json
+      - --type
+      - cyclonedx
+      - $(params.IMAGE)
     workingDir: $(workspaces.source.path)
 
   volumes:

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -180,15 +180,6 @@ spec:
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
 
-      # Create and push sbom image
-      sbom_container=$(buildah from scratch)
-      sbom_container_mountpath=$(buildah mount $sbom_container)
-      cp sbom-cyclonedx.json sbom-purl.json $sbom_container_mountpath
-      buildah umount $sbom_container
-      buildah commit working-container $(params.IMAGE).sbom
-      buildah push \
-        --tls-verify=$(params.TLSVERIFY) \
-        $(params.IMAGE).sbom
     securityContext:
       runAsUser: 0
       capabilities:
@@ -197,6 +188,18 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+
+  - name: upload-sbom
+    image: quay.io/redhat-appstudio/cosign:v1.13.1
+    args:
+      - attach
+      - sbom
+      - --sbom
+      - sbom-cyclonedx.json
+      - --type
+      - cyclonedx
+      - $(params.IMAGE)
     workingDir: $(workspaces.source.path)
 
   volumes:

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -30,10 +30,9 @@ spec:
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
-  # Additional parameter for auth configuration
   - default: ""
-    description: Extra parameters passed for the push command when pushing images.
-    name: PUSH_EXTRA_ARGS
+    description: folder with config.json for container auth
+    name: DOCKER_AUTH
     type: string
   # Unused only as placeholder
   - default: ""
@@ -45,6 +44,8 @@ spec:
       value: oci
     - name: STORAGE_DRIVER
       value: vfs
+    - name: DOCKER_CONFIG
+      value: $(params.DOCKER_AUTH)
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -173,7 +174,7 @@ spec:
       buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
       buildah commit $container $(params.IMAGE)
       buildah push \
-        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --tls-verify=$(params.TLSVERIFY) \
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
@@ -186,7 +187,7 @@ spec:
       buildah umount $sbom_container
       buildah commit working-container $(params.IMAGE).sbom
       buildah push \
-        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --tls-verify=$(params.TLSVERIFY) \
         $(params.IMAGE).sbom
     securityContext:
       runAsUser: 0


### PR DESCRIPTION
DOCKER_CONFIG env provides way how to globally set container registries auth - podman, buildah, docker, cosign are using it. For cosign it's only way how to configure auth. The auth file is composed in configure-build step which is taking secrets from serviceaccount and merge them with shared secret. So when shared secret will be removed we can just remove the task and use only secrets provided by serviceaccount (handled by tekton).

Instead of manual creation of sbom image use cosign to upload sbom - in future it could be function of tekton-chains. To receive the sbom `cosign download sbom $IMAGE` eg. `cosign download sbom quay.io/mkovarik/single-container-app:62c06bf`