### PR TITLE
feat(HACBS-1509): Adding related image check

### DIFF
--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -45,6 +45,25 @@
     workspaces:
       - name: workspace
         workspace: workspace
+- op: add
+  path: /spec/tasks/-
+  value:
+    name: fbc-related-image-check
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+    runAfter:
+      - fbc-validate
+    taskRef:
+      name: fbc-related-image-check
+      version: "0.1"
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-container.results.IMAGE_URL)
+    workspaces:
+      - name: workspace
+        workspace: workspace
 - op: replace
   path: /spec/tasks/6/name
   value: fbc-label-check

--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio, hacbs"
+  name: fbc-related-image-check
+spec:
+  params:
+    - name: IMAGE_URL
+      description: the fully qualified image name
+  results:
+    - name: HACBS_TEST_OUTPUT
+  workspaces:
+    - name: workspace
+  steps:
+    - name: check-related-images
+      image: quay.io/redhat-appstudio/hacbs-test:latest
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      env:
+        - name: IMAGE_URL
+          value: $(params.IMAGE_URL)
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: 2
+        requests:
+          memory: 512Mi
+          cpu: 10m
+      script: |
+        #!/usr/bin/env bash
+        source /utils.sh
+        FAILEDIMAGES=""
+
+        relImgs=$(cat "$(workspaces.workspace.path)/hacbs/fbc-validation/confdir/catalog.yaml" | yq '.relatedImages[].image' | sed 's/---//')
+        echo -e "These are related images:\n $relImgs"
+        # cycle through those related images and show outputs
+        for i in ${relImgs// /}
+        do
+          if ! skopeo inspect --no-tags docker://"$i"; then
+            echo "Skopeo inspect failed on related image: $i"
+            FAILEDIMAGES+="$i, "
+          fi
+        done
+        if [ -z "$FAILEDIMAGES" ]; then
+          HACBS_TEST_OUTPUT="$(make_result_json -r SUCCESS -s 1)"
+          echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
+        else
+          echo "These images failed inspection: $FAILEDIMAGES"
+          HACBS_TEST_OUTPUT="$(make_result_json -r FAILURE -f 1)"
+          echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
+          exit 0
+        fi

--- a/task/fbc-related-image-check/OWNERS
+++ b/task/fbc-related-image-check/OWNERS
@@ -1,0 +1,1 @@
+Stonesoup Test Team

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -20,10 +20,7 @@ spec:
       image: quay.io/redhat-appstudio/hacbs-test:latest
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       securityContext:
-        runAsUser: 1000
-      env:
-        - name: HOME
-          value: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+        runAsUser: 0
       resources:
         limits:
           memory: 4Gi
@@ -38,7 +35,7 @@ spec:
         conffolder=$(cat ../sanity-inspect-image/image_inspect.json | jq -r '.Labels ."operators.operatorframework.io.index.configs.v1"')
 
         mkdir confdir
-        if ! oc image extract $(params.IMAGE_URL) --file /bin/opm --file /bin/grpc_health_probe --path $conffolder*:confdir/ ; then
+        if ! oc image extract $(params.IMAGE_URL) --file /bin/opm --file /bin/grpc_health_probe --path $conffolder/*:confdir/ ; then
         echo "Unable to extract image! Skipping checking binaries!"
           HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -f 1)"
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
@@ -67,9 +64,3 @@ spec:
           HACBS_TEST_OUTPUT="$(make_result_json -r SUCCESS -s 1)"
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
         fi
-      volumeMounts:
-        - mountPath: $(workspaces.workspace.path)/hacbs/$(context.task.name)
-          name: work
-  volumes:
-    - name: work
-      emptydir: {}


### PR DESCRIPTION
Adding related image check for FBC images:
Here is sample output:
```
Warning: the default reading order of registry auth file will be changed from "${HOME}/.docker/config.json" to podman registry config locations in the future version of oc. "${HOME}/.docker/config.json" is deprecated, but can still be used for storing credentials as a fallback. See https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md for the order of podman registry config locations.
These are related images: 
gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
quay.io/joelanford/example-operator-bundle:0.1.0
quay.io/joelanford/example-operator:0.1.0

gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
quay.io/joelanford/example-operator-bundle:0.2.0
quay.io/joelanford/example-operator:0.2.0
{
    "Name": "gcr.io/kubebuilder/kube-rbac-proxy",
    "Digest": "sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c",
    "RepoTags": [],
    "Created": "2020-11-04T16:21:57.356969476Z",
    "DockerVersion": "18.06.0-ce",
    "Labels": null,
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:5c7fe08dec514a5105d43dfcae1a5a45be002bcd3251dd178ced702aecfb7531",
        "sha256:a5b8859cca0e318e4b64257c9bff72f7a22c42fe7b2a1eae97d4c005bfb9652b"
    ],
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
    ]
}
{
    "Name": "quay.io/joelanford/example-operator-bundle",
    "Digest": "sha256:56eff01efa996db4d25050c5d6eab7eed83a171e138175c735442761e330748d",
    "RepoTags": [],
    "Created": "2021-12-18T04:19:28.000503732Z",
    "DockerVersion": "20.10.12",
    "Labels": {
        "operators.operatorframework.io.bundle.channels.v1": "alpha",
        "operators.operatorframework.io.bundle.manifests.v1": "manifests/",
        "operators.operatorframework.io.bundle.mediatype.v1": "registry+v1",
        "operators.operatorframework.io.bundle.metadata.v1": "metadata/",
        "operators.operatorframework.io.bundle.package.v1": "example-operator",
        "operators.operatorframework.io.metrics.builder": "operator-sdk-v1.11.0+git",
        "operators.operatorframework.io.metrics.mediatype.v1": "metrics+v1",
        "operators.operatorframework.io.metrics.project_layout": "go.kubebuilder.io/v3",
        "operators.operatorframework.io.test.config.v1": "tests/scorecard/",
        "operators.operatorframework.io.test.mediatype.v1": "scorecard+v1"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:791f7562a10d20bcc0723254b3cf1b389fedd6146ee772fe9c7af6ebbd298400",
        "sha256:5bb2da43d50ef25b72e69376759268be0c559c7def4560e27a58b4850e48a510",
        "sha256:47805382cf9b72813cf3d5622174f0f74717a02cf10fc5a25986e75c7e28282f"
    ],
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ]
}
{
    "Name": "quay.io/joelanford/example-operator",
    "Digest": "sha256:18386c91cead79b3db2001a8a8d46a4d5992aae800d2cbcf4afd708acb2bb3ba",
    "RepoTags": [],
    "Created": "2021-12-18T03:36:01.65274211Z",
    "DockerVersion": "20.10.12",
    "Labels": null,
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:0d7d70899875b098ace120b574f57b39e91415ceaf9b348d6abe168537509f5a",
        "sha256:7ea343377a86d359cd35da7808f84c7acd24ffb9a70e0c9d1d734d675a6bf205"
    ],
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
    ]
}
{
    "Name": "gcr.io/kubebuilder/kube-rbac-proxy",
    "Digest": "sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c",
    "RepoTags": [],
    "Created": "2020-11-04T16:21:57.356969476Z",
    "DockerVersion": "18.06.0-ce",
    "Labels": null,
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:5c7fe08dec514a5105d43dfcae1a5a45be002bcd3251dd178ced702aecfb7531",
        "sha256:a5b8859cca0e318e4b64257c9bff72f7a22c42fe7b2a1eae97d4c005bfb9652b"
    ],
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
    ]
}
{
    "Name": "quay.io/joelanford/example-operator-bundle",
    "Digest": "sha256:0ffdcfa405d2761025bf2b0e8463f1b9ed39def92bab3fc4278b2f303c7d20a8",
    "RepoTags": [],
    "Created": "2021-12-18T04:36:47.000084945Z",
    "DockerVersion": "20.10.12",
    "Labels": {
        "operators.operatorframework.io.bundle.channels.v1": "alpha",
        "operators.operatorframework.io.bundle.manifests.v1": "manifests/",
        "operators.operatorframework.io.bundle.mediatype.v1": "registry+v1",
        "operators.operatorframework.io.bundle.metadata.v1": "metadata/",
        "operators.operatorframework.io.bundle.package.v1": "example-operator",
        "operators.operatorframework.io.metrics.builder": "operator-sdk-v1.11.0+git",
        "operators.operatorframework.io.metrics.mediatype.v1": "metrics+v1",
        "operators.operatorframework.io.metrics.project_layout": "go.kubebuilder.io/v3",
        "operators.operatorframework.io.test.config.v1": "tests/scorecard/",
        "operators.operatorframework.io.test.mediatype.v1": "scorecard+v1"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:468bdfc07e2eee106615eba8c2edc01f19ca7dfc37f80425f666dc6f206d93fa",
        "sha256:90ece14121d0ba0ba5567a913cd91ef4f49899c7b9b03b762cccc9f8a499b07b",
        "sha256:cdfd2f39dd8a668da1a38a2a84de9e418c741d4922c0334ccd4b881016a64988"
    ],
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ]
}
{
    "Name": "quay.io/joelanford/example-operator",
    "Digest": "sha256:f68ec59375459865cc3e5dd4ff51273947a1883d3743e6a6844dd91e66a0ea89",
    "RepoTags": [],
    "Created": "2021-12-18T04:32:41.013764284Z",
    "DockerVersion": "20.10.12",
    "Labels": null,
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:0d7d70899875b098ace120b574f57b39e91415ceaf9b348d6abe168537509f5a",
        "sha256:bf3b7d93a0b3a82016b4c5d1d364ed2bddea5876d0d17de520e1cc3c62cc0f04"
    ],
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
    ]
}
{"result":"SUCCESS","timestamp":"1675120230","note":"For more details please visit the logs in workspace of Tekton tasks.","namespace":"default","successes":1,"failures":0,"warnings":0}```