### PR TITLE
feat(HACBS-1510): add check to allow only one package in FBC fragment

### DIFF
--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -36,31 +36,42 @@ spec:
 
         mkdir confdir
         if ! oc image extract $(params.IMAGE_URL) --file /bin/opm --file /bin/grpc_health_probe --path $conffolder/*:confdir/ ; then
-        echo "Unable to extract image! Skipping checking binaries!"
-          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -f 1)"
+          echo "Unable to extract image! Skipping checking binaries!"
+          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -f 1 -t 'Unable to extract image! Skipping checking binaries!')"
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
           exit 0
         fi
 
+        # We have totally 4 checks here currently
+        check_num=4
+        failure_num=0
         TESTPASSED=true
         chmod +x opm grpc_health_probe
 
         if ! ./opm version; then
-        echo "!FAILURE! - opm binary check failed"
+          echo "!FAILURE! - opm binary check failed"
+          failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
         if [ ! -f "grpc_health_probe" ]; then
-        echo "!FAILURE! - grpc_health_probe binary check failed"
+          echo "!FAILURE! - grpc_health_probe binary check failed"
+          failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
         if ! ./opm validate confdir; then
-        echo "!FAILURE! - opm validate check has failed"
+          echo "!FAILURE! - opm validate check has failed"
+          failure_num=`expr $failure_num + 1`
+          TESTPASSED=false
+        fi
+        if ! ./opm render confdir | jq -en 'reduce (inputs | select(.schema == "olm.package")) as $obj (0; .+1) == 1'; then
+          echo "!FAILURE! - more than one olm.packages are not permitted in a FBC fragment"
+          failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
         if [ $TESTPASSED == false ]; then
-          HACBS_ERROR_OUTPUT="$(make_result_json -r FAILURE -f 1)"
-          echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
+          HACBS_ERROR_OUTPUT="$(make_result_json -r FAILURE -f $failure_num -s `expr $check_num - $failure_num`)"
+          echo "${HACBS_ERROR_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
         else
-          HACBS_TEST_OUTPUT="$(make_result_json -r SUCCESS -s 1)"
+          HACBS_TEST_OUTPUT="$(make_result_json -r SUCCESS -s $check_num)"
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
         fi


### PR DESCRIPTION
We allow only one olm.package in a FBC fragment

The result is like below
```
!FAILURE! - more than one olm.packages are not permitted in a FBC fragment
{"result":"FAILURE","timestamp":"1675243411","note":"For more details please visit the logs in workspace of Tekton tasks.","namespace":"default","successes":3,"failures":1,"warnings":0}
```

Signed-off-by: Hongwei Liu <hongliu@redhat.com>