### PR TITLE
fix: check prod repositories on pull-request

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -143,7 +143,7 @@ spec:
               workingDir: $(workspaces.source.path)
               script: |
                 #!/usr/bin/env bash
-                PULL_REQUEST=1 .tekton/scripts/check-task-pipeline-bundle-repos.sh
+                .tekton/scripts/check-task-pipeline-bundle-repos.sh
           workspaces:
             - name: source
         workspaces:

--- a/.tekton/scripts/check-task-pipeline-bundle-repos.sh
+++ b/.tekton/scripts/check-task-pipeline-bundle-repos.sh
@@ -12,13 +12,8 @@ QUAY_ORG=redhat-appstudio-tekton-catalog
 locate_bundle_repo() {
     local -r type="$1"
     local -r object="$2"
-    local -r version="${3}"
 
-    if [ "${PULL_REQUEST:-0}" -ne 1 ]; then
-        curl -I -s -L -w "%{http_code}\n" -o /dev/null "https://quay.io/v2/${QUAY_ORG}/${type}-${object}/manifests/${version}"
-    else
-        curl -I -s -L -w "%{http_code}\n" -o /dev/null "https://quay.io/v2/${QUAY_ORG}/pull-request-builds/manifests/${object}-${version}"
-    fi
+    curl -I -s -L -w "%{http_code}\n" -o /dev/null "https://quay.io/v2/${QUAY_ORG}/${type}-${object}/tags/list"
 }
 
 has_missing_repo=
@@ -29,8 +24,7 @@ echo "Checking existence of task and pipeline bundle repositories ..."
 for task_file in task/*/*/*.yaml; do
     task_name=$(oc apply --dry-run=client -f "$task_file" -o jsonpath='{.metadata.name}')
     dir=${task_file%/*}
-    version="${dir##*/}-$(git log -n 1 --pretty=format:%H -- "${task_file}")"
-    found=$(locate_bundle_repo task "$task_name" "${version}")
+    found=$(locate_bundle_repo task "$task_name")
     if [ "$found" != "200" ]; then
         echo "Missing task bundle repo: task-$task_name"
         has_missing_repo=yes
@@ -38,16 +32,16 @@ for task_file in task/*/*/*.yaml; do
 done
 
 # pipelines
-version="$(git rev-parse HEAD)"
 for pl_name in $(oc kustomize pipelines/ | oc apply --dry-run=client -f - -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'); do
-    found=$(locate_bundle_repo pipeline "$pl_name" "${version}")
+    found=$(locate_bundle_repo pipeline "$pl_name")
     if [ "$found" != "200" ]; then
-        echo "Missing pipeline bundle repo: pipeline-$pl_name ${version}"
+        echo "Missing pipeline bundle repo: pipeline-$pl_name"
         has_missing_repo=yes
     fi
 done
 
 if [ -n "$has_missing_repo" ]; then
+    echo "Please contact Build team - #forum-stonesoup-build that the missing repos should be created in https://quay.io/organization/redhat-appstudio-tekton-catalog"
     exit 1
 else
     echo "Done"


### PR DESCRIPTION
During Pull-request check we should check production repositories so then we can reveal that some repository is missing before merging.