### PR TITLE
Fixes to the tekton-bundle-builder pipeline

### DIFF
--- a/pipelines/tekton-bundle-builder/kustomization.yaml
+++ b/pipelines/tekton-bundle-builder/kustomization.yaml
@@ -15,6 +15,18 @@ patches:
       value:
         name: tkn-bundle
         version: "0.1"
+    - op: add
+      path: /spec/tasks/4/params
+      value:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: CONTEXT
+        value: $(params.path-context)
+    # Remove tasks that assume a binary image
+    - op: remove
+      path: /spec/tasks/12  # sbom-json-check
+    - op: remove
+      path: /spec/tasks/8  # deprecated-base-image-check
   target:
     kind: Pipeline
     name: template-build

--- a/task/tkn-bundle/0.1/README.md
+++ b/task/tkn-bundle/0.1/README.md
@@ -15,6 +15,7 @@ The task supports the following input parameters.
 |---------|-------------------------|------------------------------------------|
 | IMAGE   | registry.io/my-task:tag | Reference of the image task will produce |
 | CONTEXT | my-task/0.1             | Paths to include in the bundle image     |
+| HOME    | /tekton/home            | Value for the HOME environment variable  |
 
 `CONTEXT` can include multiple directories or files separated by comma or space.
 Paths can be negated with exclamation mark to prevent inclusion of certain
@@ -44,7 +45,7 @@ Only the `0.1/tkn-bundle.yaml` file will be included in the bundle.
 
 The task emits the following results.
 
-| Name         | Example                           | Description                                       |
-|--------------|-----------------------------------|---------------------------------------------------|
-| IMAGE_URL    | registry.io/my-task@sha256-abc... | Image repository where the built image was pushed |
-| IMAGE_DIGEST | abc...                            | Digest of the image just built                    |
+| Name         | Example                 | Description                                                     |
+|--------------|-------------------------|-----------------------------------------------------------------|
+| IMAGE_URL    | registry.io/my-task:tag | Image repository where the built image was pushed with tag only |
+| IMAGE_DIGEST | abc...                  | Digest of the image just built                                  |

--- a/task/tkn-bundle/0.1/spec/tkn-bundle_spec.sh
+++ b/task/tkn-bundle/0.1/spec/tkn-bundle_spec.sh
@@ -94,47 +94,63 @@ spec:
     The output should include 'Added Task: test2 to image'
     The output should include 'Added Task: test3 to image'
     The output should include 'Pushed Tekton Bundle to registry:5000/bundle'
-    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("sha256:[a-z0-9]+")'
-    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("registry:5000/bundle@sha256:[a-z0-9]+")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("\\Asha256:[a-z0-9]+\\z")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("\\Aregistry:5000/bundle:tag\\z")'
+    The taskrun should jq '.status.taskSpec.stepTemplate.env[] | select(.name == "HOME").value | test("\\A/tekton/home\\z")'
   End
 
   It 'creates Tekton bundles from specific context'
-    When call tkn task start tkn-bundle -p IMAGE=registry:5000/sub:tag -p CONTEXT=sub --timeout 1m --showlog -w name=source,claimName=source-pvc
+    When call tkn task start tkn-bundle -p IMAGE=registry:5000/sub:tag -p CONTEXT=sub --use-param-defaults --timeout 1m --showlog -w name=source,claimName=source-pvc
     The output should not include 'Added Task: test1 to image'
     The output should not include 'Added Task: test2 to image'
     The output should include 'Added Task: test3 to image'
     The output should include 'Pushed Tekton Bundle to registry:5000/sub'
-    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("sha256:[a-z0-9]+")'
-    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("registry:5000/sub@sha256:[a-z0-9]+")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("\\Asha256:[a-z0-9]+\\z")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("\\Aregistry:5000/sub:tag\\z")'
+    The taskrun should jq '.status.taskSpec.stepTemplate.env[] | select(.name == "HOME").value | test("\\A/tekton/home\\z")'
   End
 
   It 'creates Tekton bundles when context points to a file'
-    When call tkn task start tkn-bundle -p IMAGE=registry:5000/file:tag -p CONTEXT=test2.yml --timeout 1m --showlog -w name=source,claimName=source-pvc
+    When call tkn task start tkn-bundle -p IMAGE=registry:5000/file:tag -p CONTEXT=test2.yml --use-param-defaults --timeout 1m --showlog -w name=source,claimName=source-pvc
     The output should not include 'Added Task: test1 to image'
     The output should not include 'Added Task: test3 to image'
     The output should include 'Added Task: test2 to image'
     The output should include 'Pushed Tekton Bundle to registry:5000/file'
-    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("sha256:[a-z0-9]+")'
-    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("registry:5000/file@sha256:[a-z0-9]+")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("\\Asha256:[a-z0-9]+\\z")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("\\Aregistry:5000/file:tag\\z")'
+    The taskrun should jq '.status.taskSpec.stepTemplate.env[] | select(.name == "HOME").value | test("\\A/tekton/home\\z")'
   End
 
   It 'creates Tekton bundles when context points to a file and a directory'
-    When call tkn task start tkn-bundle -p IMAGE=registry:5000/mix:tag -p CONTEXT=test2.yml,sub --timeout 1m --showlog -w name=source,claimName=source-pvc
+    When call tkn task start tkn-bundle -p IMAGE=registry:5000/mix:tag -p CONTEXT=test2.yml,sub --use-param-defaults --timeout 1m --showlog -w name=source,claimName=source-pvc
     The output should not include 'Added Task: test1 to image'
     The output should include 'Added Task: test2 to image'
     The output should include 'Added Task: test3 to image'
     The output should include 'Pushed Tekton Bundle to registry:5000/mix'
-    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("sha256:[a-z0-9]+")'
-    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("registry:5000/mix@sha256:[a-z0-9]+")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("\\Asha256:[a-z0-9]+\\z")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("\\Aregistry:5000/mix:tag\\z")'
+    The taskrun should jq '.status.taskSpec.stepTemplate.env[] | select(.name == "HOME").value | test("\\A/tekton/home\\z")'
   End
 
   It 'creates Tekton bundles when using negation'
-    When call tkn task start tkn-bundle -p IMAGE=registry:5000/neg:tag -p CONTEXT=!sub --timeout 1m --showlog -w name=source,claimName=source-pvc
+    When call tkn task start tkn-bundle -p IMAGE=registry:5000/neg:tag -p CONTEXT=!sub --use-param-defaults --timeout 1m --showlog -w name=source,claimName=source-pvc
     The output should not include 'Added Task: test3 to image'
     The output should include 'Added Task: test1 to image'
     The output should include 'Added Task: test2 to image'
     The output should include 'Pushed Tekton Bundle to registry:5000/neg'
-    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("sha256:[a-z0-9]+")'
-    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("registry:5000/neg@sha256:[a-z0-9]+")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("\\Asha256:[a-z0-9]+\\z")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("\\Aregistry:5000/neg:tag\\z")'
+    The taskrun should jq '.status.taskSpec.stepTemplate.env[] | select(.name == "HOME").value | test("\\A/tekton/home\\z")'
+  End
+
+  It 'allows overriding HOME environment variable'
+    When call tkn task start tkn-bundle -p IMAGE=registry:5000/bundle:summer-home -p HOME=/tekton/summer-home --use-param-defaults --timeout 1m --showlog -w name=source,claimName=source-pvc
+    The output should include 'Added Task: test1 to image'
+    The output should include 'Added Task: test2 to image'
+    The output should include 'Added Task: test3 to image'
+    The output should include 'Pushed Tekton Bundle to registry:5000/bundle'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_DIGEST").value | test("\\Asha256:[a-z0-9]+\\z")'
+    The taskrun should jq '.status.taskResults[] | select(.name=="IMAGE_URL").value | test("\\Aregistry:5000/bundle:summer-home\\z")'
+    The taskrun should jq '.status.taskSpec.stepTemplate.env[] | select(.name == "HOME").value | test("\\A/tekton/summer-home\\z")'
   End
 End

--- a/task/tkn-bundle/0.1/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.1/tkn-bundle.yaml
@@ -18,11 +18,19 @@ spec:
     description: Path to the directory to use as context.
     name: CONTEXT
     type: string
+  - name: HOME
+    type: string
+    description: Value for the HOME environment variable.
+    default: /tekton/home
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
-  - description: Image repository where the built image was pushed
+  - description: Image repository where the built image was pushed with tag only
     name: IMAGE_URL
+  stepTemplate:
+    env:
+    - name: HOME
+      value: "$(params.HOME)"
   steps:
   - image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:1.9
     name: build
@@ -89,8 +97,8 @@ spec:
       OUT="$(tkn bundle push "$(params.IMAGE)" \
         $(printf ' -f %s' "${FILES[@]}") \
         |tee /proc/self/fd/3)"
-      echo "${OUT#*Pushed Tekton Bundle to }" > $(results.IMAGE_URL.path)
-      echo "${OUT#*Pushed Tekton Bundle to *@}" > $(results.IMAGE_DIGEST.path)
+      echo -n "$(params.IMAGE)" > $(results.IMAGE_URL.path)
+      echo -n "${OUT#*Pushed Tekton Bundle to *@}" > $(results.IMAGE_DIGEST.path)
     workingDir: $(workspaces.source.path)
   workspaces:
   - name: source


### PR DESCRIPTION
This commit includes various small fixes that are essential for executing the tekton-bundle-builder pipeline:

1. Pass the pipeline path-context parameter to the CONTEXT parameter of the tkn-bundle task.
2. Pass the pipeline output-image parameter to the IMAGE parameter of the tkn-bundle task.
3. Remove certain tasks from the pipeline that assume the built image is binary. Tekton bundles are not.
4. Add new HOME parameter to the tkn-bundle task to avoid permission issues when mounting linked secrets. For details, see: https://access.redhat.com/solutions/6956010
5. Change the IMAGE_URL result from the tkn-bundle task to not include the digest. Other tasks, assume this value does not have a digest, and blindly add the IMAGE_DIGEST to it which creates an image reference that contains the digest twice.
6. Change the IMAGE_URL result from the tkn-bundle task to include the tag of the image. This matches the current behavior of the other build tasks.
7. Change the IMAGE_URL and IMAGE_DIGEST results from the tkn-bundle task to no longer include an unexpected trailing new-line. Update tests to catch this in the future.

Required for https://issues.redhat.com/browse/HACBS-1557

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>