### PR TITLE
fix: avoid failing dotnet

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -124,7 +124,7 @@ spec:
         echo "Prefetched content will be made available"
       fi
 
-      unshare -Ufp $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah bud \
+      unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah bud \
         $VOLUME_MOUNTS \
         $BUILDAH_ARGS \
         --tls-verify=$(params.TLSVERIFY) --no-cache \


### PR DESCRIPTION
Dotnet component was failing on:
```
Unhandled exception. System.ComponentModel.Win32Exception (2):
Unable to retrieve the specified information about the process or thread.
It may have exited or may be privileged
```
Removing '-p/--pid' is fixing the problem.