### PR TITLE
STONEBLD-31: restrict hermetic build for FBC

### DIFF
--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -24,6 +24,8 @@
     value: $(params.path-context)
   - name: DOCKER_AUTH
     value: "$(tasks.init.results.container-registry-secret)"
+  - name: HERMETIC
+    value: "true"
 - op: add
   path: /spec/tasks/-
   value:

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -24,8 +24,6 @@ spec:
       if [ -z "${INPUT}" ]
       then
         echo "Build will be executed with network isolation, but no content was configured to be prefetched."
-        echo "This will likely result in a build failure."
-
         exit 0
       fi
 


### PR DESCRIPTION
Do not allow download external definitions in Dockerfile