### PR TITLE
STONEBLD-682: fix sed for new buildah image

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -102,7 +102,7 @@ spec:
       fi
 
 
-      sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
 
       # Setting new namespace to run buildah - 2^32-2
       echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid


### PR DESCRIPTION
Improve sed to match 'short-name-mode = xxx' and also 'short-name-mode=xxx'