### PR TITLE
fix(HACBS-1778): Add the snyk-secret parameter

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -46,6 +46,10 @@ spec:
       name: java
       type: string
       default: "false"
+    - description: Snyk Token Secret Name
+      name: snyk-secret
+      type: string
+      default: ""
   tasks:
     - name: appstudio-init
       params:
@@ -202,11 +206,17 @@ spec:
       - input: $(params.skip-checks)
         operator: in
         values: ["false"]
+      - input: $(params.snyk-secret)
+        operator: notin
+        values: [""]
       runAfter:
         - clone-repository
       taskRef:
         name: sast-snyk-check
         version: "0.1"
+      params:
+        - name: SNYK_SECRET
+          value: $(params.snyk-secret)
       workspaces:
       - name: workspace
         workspace: workspace

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -14,8 +14,8 @@ spec:
     - description: Test output
       name: HACBS_TEST_OUTPUT
   params:
-    - name: SHARED_SECRET
-      default: snyk-shared-secret
+    - name: SNYK_SECRET
+      default: ""
     - name: ARGS
       type: string
       description: extra args needs to append
@@ -23,7 +23,7 @@ spec:
   volumes:
     - name: snyk-secret
       secret:
-        secretName: $(params.SHARED_SECRET)
+        secretName: $(params.SNYK_SECRET)
         optional: true
   steps:
     - name: sast-snyk-check
@@ -38,7 +38,7 @@ spec:
         . /utils.sh
         SNYK_TOKEN="$(cat /etc/secrets/snyk_token)"
         if [[ -z $SNYK_TOKEN ]]; then
-          echo "SNYK_TOKEN is empty and please set params.SHARED_SECRET" | tee stdout.txt
+          echo "SNYK_TOKEN is not defined, please create the $(params.SNYK_SECRET) secret with the snyk_token key containing the Snyk token." | tee stdout.txt
           make_result_json -r SKIPPED -t "Check skipped: SNYK_TOKEN is empty"
           exit 0
         fi


### PR DESCRIPTION
* Add the snyk-secret parameter to build pipeline
* Skip the sast-snyk-check task if snyk-secret is empty
* Refactor the warning message in sast-snyk-check