### PR TITLE
STONEBLD-694: Add e2e test to verify cachi2 pip support

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -124,7 +124,7 @@ spec:
               - name: APP_SUFFIX
                 value: "{{ pull_request_number }}"
               - name: COMPONENT_REPO_URLS
-                value: "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic,https://github.com/redhat-appstudio-qe/retrodep"
+                value: "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic,https://github.com/redhat-appstudio-qe/retrodep,https://github.com/cachito-testing/pip-e2e-test"
               - name: QUAY_E2E_ORGANIZATION
                 value: redhat-appstudio
               - name: E2E_APPLICATIONS_NAMESPACE

--- a/hack/util-install-bundle.sh
+++ b/hack/util-install-bundle.sh
@@ -18,7 +18,7 @@ metadata:
   name: build-pipeline-selector
 spec:
   selectors:
-    - name: Hermetic build (docker)
+    - name: Hermetic build - golang
       pipelineParams:
         - name: hermetic
           value: "true"
@@ -30,6 +30,19 @@ spec:
       when:
         dockerfile: true
         language: Go
+        projectType: test-hermetic-build
+    - name: Hermetic build - python
+      pipelineParams:
+        - name: hermetic
+          value: "true"
+        - name: prefetch-input
+          value: "pip"
+      pipelineRef:
+        name: docker-build
+        bundle: ${BUNDLE}
+      when:
+        dockerfile: true
+        language: Python
         projectType: test-hermetic-build
     - name: Docker build
       pipelineRef:


### PR DESCRIPTION
Use https://github.com/cachito-testing/pip-e2e-test for testing hermetic build with pip.