### PR TITLE
fix(HACBS-1786): handle exception in task sanity-inspect-image

### DIFF
--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -34,6 +34,13 @@ spec:
         #!/usr/bin/env bash
         source /utils.sh
         ### Try to extract binaries with configs > check binaries functionality > check opm validate ###
+        if [ ! -f ../sanity-inspect-image/image_inspect.json ] || [ -z $(cat ../sanity-inspect-image/image_inspect.json) ]; then
+          echo "File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image"
+          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image!')"
+          echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
+          exit 0
+        fi
+
         conffolder=$(cat ../sanity-inspect-image/image_inspect.json | jq -r '.Labels ."operators.operatorframework.io.index.configs.v1"')
 
         image_with_digest="$(params.IMAGE_URL)@$(params.IMAGE_DIGEST)"
@@ -41,7 +48,7 @@ spec:
         mkdir confdir
         if ! oc image extract "${image_with_digest}" --file /bin/opm --file /bin/grpc_health_probe --path $conffolder/*:confdir/ ; then
           echo "Unable to extract image! Skipping checking binaries!"
-          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -f 1 -t 'Unable to extract image! Skipping checking binaries!')"
+          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'Unable to extract image! Skipping checking binaries!')"
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
           exit 0
         fi

--- a/task/sanity-inspect-image/0.1/sanity-inspect-image.yaml
+++ b/task/sanity-inspect-image/0.1/sanity-inspect-image.yaml
@@ -25,6 +25,8 @@ spec:
       name: BASE_IMAGE
     - description: Base image repository URL
       name: BASE_IMAGE_REPOSITORY
+    - description: Test output
+      name: HACBS_TEST_OUTPUT
   workspaces:
     - name: source
   volumes:
@@ -49,6 +51,8 @@ spec:
         name: registry-auth
 
     script: |
+      #!/usr/bin/env bash
+      source /utils.sh
       IMAGE_INSPECT=image_inspect.json
       BASE_IMAGE_INSPECT=base_image_inspect.json
       RAW_IMAGE_INSPECT=raw_image_inspect.json
@@ -61,9 +65,16 @@ spec:
         IMAGE_URL="${IMAGE_URL/:*@/@}"
       fi
       echo "Inspecting manifest for source image ${IMAGE_URL}"
-      skopeo inspect --no-tags docker://"${IMAGE_URL}" > $IMAGE_INSPECT
-      skopeo inspect --no-tags --raw docker://"${IMAGE_URL}" > $RAW_IMAGE_INSPECT
+      skopeo inspect --no-tags docker://"${IMAGE_URL}" > $IMAGE_INSPECT 2> stderr.txt || true
+      skopeo inspect --no-tags --raw docker://"${IMAGE_URL}" > $RAW_IMAGE_INSPECT 2>> stderr.txt || true
 
+      if [ ! -z $(cat stderr.txt) ]; then
+        echo "skopeo inspect fails, the sanity-inspect-image test meets the following error:"
+        cat stderr.txt
+        HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'skopeo inspect meets errors')"
+        echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
+        exit 0
+      fi
       echo "Getting base image manifest for source image ${IMAGE_URL}"
       BASE_IMAGE_NAME="$(jq -r ".annotations.\"org.opencontainers.image.base.name\"" $RAW_IMAGE_INSPECT)"
       BASE_IMAGE_DIGEST="$(jq -r ".annotations.\"org.opencontainers.image.base.digest\"" $RAW_IMAGE_INSPECT)"
@@ -88,3 +99,6 @@ spec:
 
       BASE_IMAGE_REPOSITORY="$(jq -r '.Name | sub("[^/]+/"; "") | sub("[:@].*"; "")' "$BASE_IMAGE_INSPECT")"
       echo -n "$BASE_IMAGE_REPOSITORY" | tee $(results.BASE_IMAGE_REPOSITORY.path)
+
+      HACBS_TEST_OUTPUT="$(make_result_json -r SUCCESS -s 1)"
+      echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)

--- a/task/sanity-label-check/0.1/sanity-label-check.yaml
+++ b/task/sanity-label-check/0.1/sanity-label-check.yaml
@@ -33,6 +33,13 @@ spec:
         #!/usr/bin/env bash
 
         . /utils.sh
+        if [ ! -f ../sanity-inspect-image/image_inspect.json ] || [ -z $(cat ../sanity-inspect-image/image_inspect.json) ]; then
+          echo "File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image"
+          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image!')"
+          echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
+          exit 0
+        fi
+
         CONFTEST_OPTIONS=""
         if [ -s "../sanity-inspect-image/base_image_inspect.json" ]; then
           CONFTEST_OPTIONS="-d=../sanity-inspect-image/base_image_inspect.json"


### PR DESCRIPTION
* The exception in comamnd skopeo inspect should not break pipeline
* The error message in command skopeo will be logged out in task log and result HACBS_TEST_OUTPUT

Signed-off-by: Hongwei Liu hongliu@redhat.com