### PR TITLE
Run Shellspec tests via GitHub Actions

### DIFF
--- a/.github/workflows/shellspec.yaml
+++ b/.github/workflows/shellspec.yaml
@@ -1,0 +1,24 @@
+---
+name: Shellspec Tests
+
+"on":
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  Shellspec:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: jerop/tkn@v0.1.0
+
+      - name: Shellspec
+        run: hack/test-shellspec.sh

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ For quick local innerloop style task development, you may install new Tasks in y
 
 There is a container which is used to support multiple set of tasks called `quay.io/redhat-appstudio/appstudio-utils:GIT_SHA` , which is a single container which is used by multiple tasks. Tasks may also be in their own container as well however many simple tasks are utilities and will be packaged for app studio in a single container. Tasks can rely on other tasks in the system which are co-packed in a container allowing combined tasks (build-only vs build-deploy) which use the same core implementations.
 
+Shellspec tests can be run by invoking `hack/test-shellspec.sh`.
+
 ## Release
 
 Release is done by setting env variable `MY_QUAY_USER=redhat-appstudio`, `BUILD_TAG=$(git rev-parse HEAD)` and running `hack/build-and-push.sh`.

--- a/hack/shellspec/github_formatter.sh
+++ b/hack/shellspec/github_formatter.sh
@@ -1,0 +1,21 @@
+#shellcheck shell=bash disable=SC2154
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+print_error() {
+    message="${field_note}${field_note:+: }${field_message}%0A${field_failure_message//$'\n'/%0A}"
+    printf "::error file=%s,line=%d,endLine=%d,title=%s::%s%%0A" "${field_specfile}" "${field_lineno%-*}" "${field_lineno#*-}" "${field_message}" "${message}"
+}
+
+github_each() {
+    case "${field_type}" in
+        statement)
+            [[ "$field_fail" ]] && print_error
+            ;;
+        error)
+            print_error
+            ;;
+    esac
+}

--- a/hack/test-shellspec.sh
+++ b/hack/test-shellspec.sh
@@ -1,0 +1,39 @@
+#!/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Run tests only for changed
+INCREMENTAL=${INCREMENTAL:-1}
+
+readarray SPEC_DIRS < <(find "${ROOT}" -name spec -type d -print0)
+
+REF=main
+if ! git rev-parse --verify main 2>/dev/null; then
+    REF=$(openssl rand -base64 12)
+fi
+git fetch origin "main:${REF}"
+readarray CHANGED_FILES < <(git diff .."${REF}" --name-only; git status --porcelain=v1 | cut -c 4-)
+
+for CHANGED in "${CHANGED_FILES[@]}"; do
+    CHANGED_DIR="${ROOT}/$(dirname "${CHANGED}")"
+    for SPEC_DIR in "${SPEC_DIRS[@]}"; do
+        # If the changed file is within the `spec` directory or the directory
+        # above it
+        if [[ "${CHANGED_DIR}" == "${SPEC_DIR}" || "${CHANGED_DIR}/spec" == "${SPEC_DIR}" ]]; then
+            SPEC_DIRS=("${SPEC_DIRS[@]/${SPEC_DIR}}")
+            [[ -n "${GITHUB_ACTIONS:-}" ]] && echo "::group::Shellspec test in ${SPEC_DIR}"
+            echo -e "Detected changes in \033[1m${CHANGED_DIR}\033[0m, running tests"
+            PARAMS=(--chdir "${SPEC_DIR}" --shell /usr/bin/bash)
+            [[ -n "${GITHUB_ACTIONS:-}" ]] && PARAMS+=(--format github -I "${ROOT}/hack/shellspec")
+            if ! command -v shellspec &> /dev/null; then
+                curl -fsSL https://git.io/shellspec | sh -s -- --yes
+            fi
+            shellspec "${PARAMS[@]}"
+            [[ -n "${GITHUB_ACTIONS:-}" ]] && echo '::endgroup::'
+        fi
+    done
+done

--- a/task/tkn-bundle/0.1/spec/support/task_run_subject.sh
+++ b/task/tkn-bundle/0.1/spec/support/task_run_subject.sh
@@ -9,11 +9,11 @@ shellspec_syntax 'shellspec_subject_taskrun'
 shellspec_subject_taskrun() {
   # shellcheck disable=SC2034
   SHELLSPEC_META='text'
-  shellspec_readfile_once SHELLSPEC_STDOUT "$SHELLSPEC_STDOUT_FILE"
+  SHELLSPEC_STDOUT=$(<"${SHELLSPEC_STDOUT_FILE}")
   if [ ${SHELLSPEC_STDOUT+x} ]; then
-    # shellcheck disable=SC2034
-    LINES=(${SHELLSPEC_STDOUT[@]})
+    IFS=" " read -r -a LINES <<< "${SHELLSPEC_STDOUT}"
     TASK_RUN_NAME="${LINES[2]}" # "TaskRun(0) started:(1) tkn-bundle-run-ndjfb(2)
+    # shellcheck disable=SC2034
     SHELLSPEC_SUBJECT="$(tkn tr describe "${TASK_RUN_NAME}" -o json)"
     shellspec_chomp SHELLSPEC_SUBJECT
   else


### PR DESCRIPTION
The test we have in `task/tkn-bundle/0.1/spec` is now exercised on
GitHub Actions by running `hack/test-shellspec.sh`. There is support for
GitHub reporting via annotations and incremental test runs -- i.e. skip
running change-unrelated tests.

Ref. https://issues.redhat.com/browse/HACBS-1740