### PR TITLE
fix(HACBS-1787): report failures correctly

### DIFF
--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -25,10 +25,18 @@ spec:
           cpu: 10m
       script: |
         #!/usr/bin/env bash
+        set -o pipefail
         source /utils.sh
         FAILEDIMAGES=""
 
         relImgs=$(cat "$(workspaces.workspace.path)/hacbs/fbc-validation/confdir/catalog.yaml" | yq -r '.relatedImages[].image' | sed 's/---//')
+        if [ $? -ne 0 ]; then
+          echo "Could not get related images, make sure catalog.yaml exists in FBC fragment image and has valid yaml format."
+          HACBS_TEST_OUTPUT="$(make_result_json -r FAILURE -f 1)"
+          echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
+          exit 0
+        fi
+
         echo -e "These are related images:\n$relImgs"
         # cycle through those related images and show outputs
         for i in ${relImgs// /}


### PR DESCRIPTION
FBC-related image check was incorrectly setting result to **success** when catalog was not existing/ containing incorrect data. This changes fixes that issue.