### PR TITLE
Pin test team images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "tekton": {
+      "fileMatch": ["\\.yaml$", "\\.yml$"],
+      "includePaths": [".tekton/**", "task/**"]
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,11 @@
   "tekton": {
       "fileMatch": ["\\.yaml$", "\\.yml$"],
       "includePaths": [".tekton/**", "task/**"]
-  }
+  },
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "groupName": "all"
+    }
+  ]
 }

--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -36,7 +36,7 @@ spec:
 
         clair-action report --image-ref=$imageanddigest --db-path=/tmp/matcher.db --format=quay > /tekton/home/clair-result.json || true
     - name: conftest-vulnerabilities
-      image: quay.io/redhat-appstudio/hacbs-test:latest
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
       securityContext:
         capabilities:
           add:
@@ -50,7 +50,7 @@ spec:
           --output=json | tee /tekton/home/clair-vulnerabilities.json || true
         fi
     - name: test-format-result
-      image: quay.io/redhat-appstudio/hacbs-test:latest
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
       script: |
         #!/usr/bin/env bash
         . /utils.sh

--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -22,7 +22,8 @@ spec:
       description: test output
   steps:
     - name: get-vulnerabilities
-      image: quay.io/redhat-appstudio/clair-in-ci:latest
+      image: quay.io/redhat-appstudio/clair-in-ci:latest  # explicit floating tag, daily updates
+      imagePullPolicy: Always
       env:
         - name: DOCKER_CONFIG
           value: $(params.docker-auth)

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -118,7 +118,7 @@ spec:
         if __name__ == "__main__":
             main()
     - name: store-hacbs-test-output-result
-      image: quay.io/redhat-appstudio/hacbs-test:latest
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
       script: |
         #!/usr/bin/env bash
         source /utils.sh

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -140,7 +140,8 @@ spec:
   # provides latest virus database for clamscan only
   # does not execute anything
   sidecars:
-    - image: quay.io/redhat-appstudio/clamav-db:latest
+    - image: quay.io/redhat-appstudio/clamav-db:latest  # explicit floating tag, daily updates
+      imagePullPolicy: Always
       name: database
       script: |
         #!/usr/bin/env bash

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -21,7 +21,7 @@ spec:
 
   steps:
     - name: extract-and-scan-image
-      image: quay.io/redhat-appstudio/hacbs-test:v1.0.3
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
       workingDir: /work
       # need to change user since 'oc image extract' requires more privileges when running as root
       # https://bugzilla.redhat.com/show_bug.cgi?id=1969929
@@ -69,7 +69,7 @@ spec:
         - mountPath: /secrets/registry-auth
           name: registry-auth
     - name: modify-clam-output-to-json
-      image: quay.io/redhat-appstudio/hacbs-test:v1.0.3
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
       script: |
         #!/usr/bin/env python3.9
         import json

--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -46,7 +46,7 @@ spec:
 
     # Run the tests and save output
     - name: run-conftest
-      image: quay.io/redhat-appstudio/hacbs-test:latest
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
       script: |
         #!/usr/bin/env sh
         source /utils.sh

--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -27,7 +27,7 @@ spec:
   steps:
     # Download Pyxis metadata about the image
     - name: query-pyxis
-      image: registry.access.redhat.com/ubi8/ubi
+      image: registry.access.redhat.com/ubi8/ubi-minimal:8.7@sha256:65a240ad8bd3f2fff3e18a22ebadc40da0b145616231fc1e16251f3c6dee087a
       script: |
         #!/usr/bin/env bash
         readarray -t IMAGE_ARRAY < <(echo -n "$(params.BASE_IMAGES_DIGESTS)" | sed 's/\\n/\'$'\n''/g')

--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -14,7 +14,7 @@ spec:
     - name: workspace
   steps:
     - name: check-related-images
-      image: quay.io/redhat-appstudio/hacbs-test:latest
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       resources:
         limits:

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -19,7 +19,7 @@ spec:
     - name: workspace
   steps:
     - name: extract-and-check-binaries
-      image: quay.io/redhat-appstudio/hacbs-test:latest
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       securityContext:
         runAsUser: 0

--- a/task/sanity-inspect-image/0.1/sanity-inspect-image.yaml
+++ b/task/sanity-inspect-image/0.1/sanity-inspect-image.yaml
@@ -34,7 +34,7 @@ spec:
         optional: true
   steps:
   - name: inspect-image
-    image: quay.io/redhat-appstudio/hacbs-test:latest
+    image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
     workingDir: $(workspaces.source.path)/hacbs/$(context.task.name)
     securityContext:
       runAsUser: 0

--- a/task/sanity-label-check/0.1/sanity-label-check.yaml
+++ b/task/sanity-label-check/0.1/sanity-label-check.yaml
@@ -23,7 +23,7 @@ spec:
       name: HACBS_TEST_OUTPUT
   steps:
     - name: basic-sanity-checks-required-labels
-      image: quay.io/redhat-appstudio/hacbs-test:latest
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)-$(params.POLICY_NAMESPACE)
       securityContext:
         capabilities:

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -27,7 +27,7 @@ spec:
         optional: true
   steps:
     - name: sast-snyk-check
-      image: quay.io/redhat-appstudio/hacbs-test:latest
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       volumeMounts:
         - name: snyk-secret

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -19,7 +19,7 @@ spec:
       name: HACBS_TEST_OUTPUT
   steps:
   - name: sbom-json-check
-    image: quay.io/redhat-appstudio/hacbs-test:latest
+    image: quay.io/redhat-appstudio/hacbs-test:v1.0.9@sha256:e3714c1ec1bd7bc754a510cba6892052a74bf523a185cf75a59d84059375444f
     securityContext:
       runAsUser: 0
       capabilities:


### PR DESCRIPTION
Images should be pinned for stability

Last commit also contains configuration of renovate bot, which will be enabled after merging and do updates of images in tekton defintions