### PR TITLE
chore(images): use no-auth registry for ubi images

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -166,7 +166,7 @@ spec:
     securityContext:
       runAsUser: 0
   - name: merge-sboms
-    image: registry.redhat.io/ubi9/python-39:1-90.1669637098
+    image: registry.access.redhat.com/ubi9/python-39:1-90.1669637098
     script: |
       #!/bin/python3
       import json

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -139,7 +139,7 @@ spec:
       name: varlibcontainers
     securityContext:
       runAsUser: 0
-  - image: registry.redhat.io/ubi8/python-39:1-87.1669838026
+  - image: registry.access.redhat.com/ubi8/python-39:1-87.1669838026
     name: merge-sboms
     script: |
       #!/bin/python3

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -111,7 +111,7 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
-  - image: registry.redhat.io/ubi9/python-39:1-90.1669637098
+  - image: registry.access.redhat.com/ubi9/python-39:1-90.1669637098
     name: merge-sboms
     script: |
       #!/bin/python3


### PR DESCRIPTION
UBI images are availble without authentication. This will allow renovatebot to track updates.