### PR TITLE
fix: fix syntax issue in sanity-label-check

### DIFF
--- a/task/sanity-label-check/0.1/sanity-label-check.yaml
+++ b/task/sanity-label-check/0.1/sanity-label-check.yaml
@@ -33,7 +33,7 @@ spec:
         #!/usr/bin/env bash
 
         . /utils.sh
-        if [ ! -f ../sanity-inspect-image/image_inspect.json ] || [ -z $(cat ../sanity-inspect-image/image_inspect.json) ]; then
+        if [ ! -s ../sanity-inspect-image/image_inspect.json ]; then
           echo "File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image"
           HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image!')"
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)


### PR DESCRIPTION
Fix error 'line 6: [: too many arguments' in `[ ! -f ../sanity-inspect-image/image_inspect.json ] || [ -z $(cat ../sanity-inspect-image/image_inspect.json) ]`