### PR TITLE
Use older e2e-test image to fix e2e-tests issue

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -124,7 +124,7 @@ spec:
               type: string
           steps:
             - name: e2e-test
-              image: quay.io/redhat-appstudio/e2e-tests:main
+              image: quay.io/redhat-appstudio/e2e-tests:16e830d2ba3e8208208a7524fa9c3cec4e520a77
               imagePullPolicy: Always
               args: [
                 "--ginkgo.label-filter=build-templates-e2e",


### PR DESCRIPTION
using older e2e-tests image which does not include https://github.com/redhat-appstudio/e2e-tests/blob/266c7898952a16e22471f0b928ddb3fed71ec0f8/pkg/framework/framework.go#L40