### PR TITLE
feat(HACBS-1832): improve note in HACBS_TEST_OUTPUT

### DIFF
--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -9,19 +9,21 @@ metadata:
     tekton.dev/tags: "appstudio, hacbs"
   name: clair-scan
 spec:
+  description: >-
+    Scans image for vulnerabilities with Clair.
   params:
     - name: image-digest
-      description: Image digest to scan
+      description: Image digest to scan.
     - name: image-url
-      description: Url to image
+      description: Image URL.
     - name: docker-auth
-      description: folder with config.json for container auth
+      description: Folder where container authorization in config.json is stored.
       default: ""
   results:
     - name: HACBS_TEST_OUTPUT
-      description: test output
+      description: Tekton task test output.
     - name: CLAIR_SCAN_RESULT
-      description: clair scan result
+      description: Clair scan result.
   steps:
     - name: get-vulnerabilities
       image: quay.io/redhat-appstudio/clair-in-ci:latest  # explicit floating tag, daily updates
@@ -49,7 +51,7 @@ spec:
             - SETFCAP
       script: |
         if [ ! -s /tekton/home/clair-result.json ]; then
-          echo "Previous step [get-vulnerabilities] failed, /tekton/home/clair-result.json is empty."
+          echo "Previous step [get-vulnerabilities] failed: /tekton/home/clair-result.json is empty."
         else
           /usr/bin/conftest test --no-fail /tekton/home/clair-result.json \
           --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \
@@ -62,8 +64,9 @@ spec:
         . /utils.sh
 
         if [[ ! -f /tekton/home/clair-vulnerabilities.json ]] || [[ "$(jq '.[] | has("failures")' /tekton/home/clair-vulnerabilities.json)" == "false" ]]; then
-          HACBS_TEST_OUTPUT=$(make_result_json -r "ERROR" -t "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again")
-          echo "/tekton/home/clair-vulnerabilities.json is not generated correctly, please check again"
+          note="Task $(context.task.name) failed: /tekton/home/clair-vulnerabilities.json did not generate correctly. For details, check Tekton task log."
+          HACBS_TEST_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "/tekton/home/clair-vulnerabilities.json did not generate correctly. For details, check conftest command in Tekton task log."
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
           exit 0
         fi
@@ -76,5 +79,6 @@ spec:
               low: (.[] | .failures | map(select(.metadata.details.name=="clair_low_vulnerabilities")) | length)
             }}' /tekton/home/clair-vulnerabilities.json | tee $(results.CLAIR_SCAN_RESULT.path)
 
-        HACBS_TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "Please refer to result CLAIR_SCAN_RESULT for the vulnerabilities scanned by clair")
+        note="Task $(context.task.name) completed: Refer to Tekton task result CLAIR_SCAN_RESULT for vulnerabilities scanned by Clair."
+        HACBS_TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")
         echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -8,16 +8,18 @@ metadata:
     tekton.dev/tags: "virus, appstudio, hacbs"
   name: clamav-scan
 spec:
+  description: >-
+    Scans image for malware with ClamAV.
   results:
     - name: HACBS_TEST_OUTPUT
-      description: test output
+      description: Tekton task test output.
   params:
     - name: image-digest
-      description: Image digest to scan
+      description: Image digest to scan.
     - name: image-url
-      description: Url to image
+      description: Image URL.
     - name: docker-auth
-      description: secret with config.json for container auth
+      description: Folder where container authorization in config.json is stored.
 
   steps:
     - name: extract-and-scan-image
@@ -52,17 +54,17 @@ spec:
         # check if image is attestation one, skip the clamav scan in such case
         if [[ $imageanddigest == *.att ]]
         then
-            echo "$imageanddigest is an attestation image, skipping clamav scan"
+            echo "$imageanddigest is an attestation image. Skipping ClamAV scan."
             exit 0
         fi
         mkdir content
         cd content
-        echo Extracting image
+        echo Extracting image.
         if ! oc image extract $imageanddigest; then
-          echo "Unable to extract image! Skipping clamscan!"
+          echo "Unable to extract image. Skipping ClamAV scan!"
           exit 0
         fi
-        echo Extraction done
+        echo Extraction done.
         clamscan -ri --max-scansize=250M | tee /tekton/home/clamscan-result.log
         echo "Executed-on: Scan was executed on version - $(clamscan --version)" | tee -a /tekton/home/clamscan-result.log
       volumeMounts:
@@ -82,7 +84,7 @@ spec:
 
         clamscan_result = "/tekton/home/clamscan-result.log"
         if not os.path.exists(clamscan_result) or os.stat(clamscan_result).st_size == 0:
-            print("clamscan-result.log file is empty, meaning previous step didn't extracted the compiled code, skipping parsing.")
+            print("clamscan-result.log file is empty, so compiled code not extracted. Parsing skipped.")
             exit(0)
 
         with open(clamscan_result, "r") as file:
@@ -127,18 +129,23 @@ spec:
         #!/usr/bin/env bash
         source /utils.sh
 
-        HACBS_ERROR_OUTPUT=$(make_result_json -r "ERROR")
         if [ -f /tekton/home/clamscan-result.json ];
         then
           cat /tekton/home/clamscan-result.json
           INFECTED_FILES=$(jq -r '.infected_files' /tekton/home/clamscan-result.json || true )
           if [ -z "${INFECTED_FILES}" ]; then
-            echo "Failed to get number of infected files"
+            echo "Failed to get number of infected files."
+            note="Task $(context.task.name) failed: Unable to get number of infected files from /tekton/home/clamscan-result.json. For details, check Tekton task log."
           else
             if [[ "${INFECTED_FILES}" -gt 0 ]]; then RES="FAILURE"; else RES="SUCCESS"; fi
-            HACBS_TEST_OUTPUT=$(make_result_json -r "${RES}" -s 1 -f "${INFECTED_FILES}")
+            note="Task $(context.task.name) completed: Check result for antivirus scan result."
+            HACBS_TEST_OUTPUT=$(make_result_json -r "${RES}" -s 1 -f "${INFECTED_FILES}" -t "$note")
           fi
+        else
+          note="Task $(context.task.name) failed: /tekton/home/clamscan-result.json doesn't exist. For details, check Tekton task log."
         fi
+
+        HACBS_ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
         echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
   # sidecar is rebuilt daily(is meant to be updated daily), hence the usage of the tag instead of digest
   # provides latest virus database for clamscan only

--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -8,20 +8,22 @@ metadata:
     tekton.dev/tags: "appstudio, hacbs"
   name: deprecated-image-check
 spec:
+  description: >-
+    Checks whether base images are deprecated.
   params:
     - name: POLICY_DIR
-      description: "Path to the directory containing conftest policies"
+      description: Path to directory containing Conftest policies.
       default: "/project/repository/"
     - name: POLICY_NAMESPACE
-      description: "Namespace for the conftest policy"
+      description: Namespace for Conftest policy.
       default: "required_checks"
     - name: BASE_IMAGES_DIGESTS
-      description: Digests of the base images used for build
+      description: Digests of base build images.
 
   results:
     - name: PYXIS_HTTP_CODE
-      description: HTTP code returned by Pyxis API endpoint
-    - description: Test output
+      description: HTTP code returned by Pyxis API endpoint.
+    - description: Tekton task test output.
       name: HACBS_TEST_OUTPUT
 
   steps:
@@ -41,9 +43,9 @@ spec:
           IMAGE_REGISTRY=${IMAGE_REGISTRY//registry.redhat.io/registry.access.redhat.com}
           export IMAGE_REPO_PATH=$(workspaces.sanity-ws.path)/${IMAGE_REPOSITORY}
           mkdir -p ${IMAGE_REPO_PATH}
-          echo "Querying Pyxis for $BASE_IMAGE..."
+          echo "Querying Pyxis for $BASE_IMAGE."
           http_code=$(curl -s -k -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY}/repository/${IMAGE_REPOSITORY}")
-          echo "Response code: $http_code"
+          echo "Response code: $http_code."
           echo $http_code $IMAGE_REGISTRY $IMAGE_REPOSITORY>> $(results.PYXIS_HTTP_CODE.path)
         done
 
@@ -71,7 +73,7 @@ spec:
           export IMAGE_REPO_PATH=$(workspaces.sanity-ws.path)/${IMAGE_REPOSITORY}
           if [ "$http_code" == "200" ];
           then
-            echo "Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace"
+            echo "Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace."
             /usr/bin/conftest test --no-fail ${IMAGE_REPO_PATH}/repository_data.json \
             --policy $POLICY_DIR --namespace $POLICY_NAMESPACE \
             --output=json 2> ${IMAGE_REPO_PATH}/stderr.txt | tee ${IMAGE_REPO_PATH}/deprecated_image_check_output.json
@@ -81,23 +83,25 @@ spec:
 
           elif [ "$http_code" == "404" ];
           then
-            echo "Registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} not found in Pyxis" >> $(workspaces.sanity-ws.path)/stderr.txt
+            echo "Registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} not found in Pyxis." >> $(workspaces.sanity-ws.path)/stderr.txt
             cat $(workspaces.sanity-ws.path)/stderr.txt
           else
-            echo "Unexpected error (HTTP code $http_code) occured for registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}" >> $(workspaces.sanity-ws.path)/stderr.txt
+            echo "Unexpected error HTTP code $http_code) occurred for registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}." >> $(workspaces.sanity-ws.path)/stderr.txt
             cat $(workspaces.sanity-ws.path)/stderr.txt
             error_counter=$((error_counter++))
             exit 0
           fi
         done < $(results.PYXIS_HTTP_CODE.path)
 
-        HACBS_ERROR_OUTPUT=$(make_result_json -r ERROR -n "$POLICY_NAMESPACE")
+        note="Task $(context.task.name) failed: Command conftest failed. For details, check Tekton task log."
+        HACBS_ERROR_OUTPUT=$(make_result_json -r ERROR -n "$POLICY_NAMESPACE" -t "$note")
         if [[ "$error_counter" == 0 && "$success_counter" > 0 ]];
         then
           if [[ "${failure_counter}" -gt 0 ]]; then RES="FAILURE"; else RES="SUCCESS"; fi
+          note="Task $(context.task.name) completed: Check result for task result."
           HACBS_TEST_OUTPUT=$(make_result_json \
             -r "${RES}" -n "$POLICY_NAMESPACE" \
-            -s "${success_counter}" -f "${failure_counter}")
+            -s "${success_counter}" -f "${failure_counter}" -t "$note")
         fi
         echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
 

--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -8,8 +8,11 @@ metadata:
     tekton.dev/tags: "appstudio, hacbs"
   name: fbc-related-image-check
 spec:
+  description: >-
+    Checks whether all images referenced in file-based catalog (FBC) are valid.
   results:
     - name: HACBS_TEST_OUTPUT
+      description: Tekton task test output.
   workspaces:
     - name: workspace
   steps:
@@ -38,28 +41,31 @@ spec:
         if [ $? -ne 0 ]; then
           relImgs="$(jq -r '.relatedImages[]?.image' $catalog)"
           if [ $? -ne 0 ]; then
-            echo "Could not get related images, make sure catalog.yaml exists in FBC fragment image and has valid yaml format."
-            HACBS_TEST_OUTPUT="$(make_result_json -r FAILURE -f 1)"
+            echo "Could not get related images. Make sure catalog.yaml exists in FBC fragment image and it is valid .yaml format."
+            note="Task $(context.task.name) failed: Could not fetch related images. Make sure you have catalog.yaml formatted correctly in your file-based catalog (FBC) fragment image."
+            HACBS_TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
             echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
           exit 0
           fi
         fi
 
-        echo -e "These are related images:\n$relImgs"
+        echo -e "These are related images:\n$relImgs."
         # cycle through those related images and show outputs
         for i in ${relImgs// /}
         do
           if ! skopeo inspect --no-tags "docker://${i}"; then
-            echo "Skopeo inspect failed on related image: $i"
+            echo "Skopeo inspect failed on related image: $i."
             FAILEDIMAGES+="$i, "
           fi
         done
         if [ -z "$FAILEDIMAGES" ]; then
-          HACBS_TEST_OUTPUT="$(make_result_json -r SUCCESS -s 1)"
+          note="Task $(context.task.name) succeeded: For details, check Tekton task result HACBS_TEST_OUTPUT."
+          HACBS_TEST_OUTPUT=$(make_result_json -r SUCCESS -s 1 -t "$note")
           echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
         else
-          echo "These images failed inspection: $FAILEDIMAGES"
-          HACBS_TEST_OUTPUT="$(make_result_json -r FAILURE -f 1)"
+          echo "These images failed inspection: $FAILEDIMAGES."
+          note="Task $(context.task.name) failed: Command skopeo inspect could not inspect images. For details, check Tekton task log."
+          HACBS_TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
           echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
           exit 0
         fi

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -8,13 +8,16 @@ metadata:
     tekton.dev/tags: "appstudio, hacbs"
   name: fbc-validation
 spec:
+  description: >-
+    Validates file-based catalog (FBC) image with opm command.
   params:
     - name: IMAGE_URL
-      description: the fully qualified image name
+      description: Fully qualified image name.
     - name: IMAGE_DIGEST
-      description: image digest
+      description: Image digest.
   results:
     - name: HACBS_TEST_OUTPUT
+      description: Tekton task test output.
   workspaces:
     - name: workspace
   steps:
@@ -45,15 +48,16 @@ spec:
 
         ### Try to extract binaries with configs > check binaries functionality > check opm validate ###
         if [ ! -s ../sanity-inspect-image/image_inspect.json ]; then
-          echo "File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image"
-          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image!')"
+          echo "File $(workspaces.source.path)/hacbs/sanity-inspect-image/image_inspect.json did not generate correctly. Check sanity-inspect-image task log."
+          note="Task $(context.task.name) failed: $(workspaces.source.path)/hacbs/sanity-inspect-image/image_inspect.json did not generate correctly. For details, check Tekton task result HACBS_TEST_OUTPUT in task sanity-inspect-image."
+          HACBS_TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
           exit 0
         fi
 
         conffolder=$(cat ../sanity-inspect-image/image_inspect.json | jq -r '.Labels ."operators.operatorframework.io.index.configs.v1"')
         if [ $? -ne 0 ]; then
-          echo "Could not get labels from sanity-inspect-image/image_inspect.json, make sure the file exists and contains this label: operators.operatorframework.io.index.configs.v1."
+          echo "Could not get labels from sanity-inspect-image/image_inspect.json. Make sure file exists and it contains this label: operators.operatorframework.io.index.configs.v1."
           HACBS_TEST_OUTPUT="$(make_result_json -r ERROR)"
           echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
           exit 0
@@ -63,15 +67,16 @@ spec:
         image_with_digest="${IMAGE_URL}@${IMAGE_DIGEST}"
 
         if ! oc image extract "${image_with_digest}" ; then
-          echo "Unable to extract image! Skipping checking binaries!"
-          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'Unable to extract image! Skipping checking binaries!')"
+          echo "Unable to extract or validate extracted binaries."
+          note="Task $(context.task.name) failed: Failed to extract image with oc extract command, so it cannot validate extracted binaries. For details, check Tekton task log."
+          HACBS_ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
           popd
           exit 0
         fi
 
         if [ -z "$(ls -A .$conffolder)" ]; then
-          echo "$conffolder is empty, missing catalog file."
+          echo "$conffolder is missing catalog file."
           HACBS_TEST_OUTPUT="$(make_result_json -r ERROR)"
           echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
           popd
@@ -86,30 +91,31 @@ spec:
         TESTPASSED=true
 
         if [[ ! $(find . -name "opm") ]]; then
-          echo "!FAILURE! - opm binary presence check failed"
+          echo "!FAILURE! - opm binary presence check failed."
           failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
         if [[ ! $(find . -name "grpc_health_probe") ]]; then
-          echo "!FAILURE! - grpc_health_probe binary presence check failed"
+          echo "!FAILURE! - grpc_health_probe binary presence check failed."
           failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
         if ! opm validate ."${conffolder}"; then
-          echo "!FAILURE! - opm validate check has failed"
+          echo "!FAILURE! - opm validate check failed."
           failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
         if ! opm render ."${conffolder}" | jq -en 'reduce (inputs | select(.schema == "olm.package")) as $obj (0; .+1) == 1'; then
-          echo "!FAILURE! - more than one olm.packages are not permitted in a FBC fragment"
+          echo "!FAILURE! - More than one olm.packages is not permitted in a FBC fragment."
           failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
+        note="Task $(context.task.name) completed: Check result for task result."
         if [ $TESTPASSED == false ]; then
-          HACBS_ERROR_OUTPUT="$(make_result_json -r FAILURE -f $failure_num -s `expr $check_num - $failure_num`)"
+          HACBS_ERROR_OUTPUT=$(make_result_json -r FAILURE -f $failure_num -s `expr $check_num - $failure_num` -t "$note")
           echo "${HACBS_ERROR_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
         else
-          HACBS_TEST_OUTPUT="$(make_result_json -r SUCCESS -s $check_num)"
+          HACBS_TEST_OUTPUT=$(make_result_json -r SUCCESS -s $check_num -t "$note")
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
         fi
         popd

--- a/task/sanity-inspect-image/0.1/sanity-inspect-image.yaml
+++ b/task/sanity-inspect-image/0.1/sanity-inspect-image.yaml
@@ -10,22 +10,22 @@ metadata:
   name: sanity-inspect-image
 spec:
   description: >-
-    Get manifest data for the source image and its base image to workspace
+    Get manifest data for source and base images and save them to workspace.
   params:
     - name: IMAGE_URL
-      description: the fully qualified image name
+      description: Fully qualified image name.
     - name: IMAGE_DIGEST
-      description: image digest
+      description: Image digest.
       type: string
     - name: DOCKER_AUTH
-      description: secret with config.json for container auth
+      description: Secret with config.json for container auth.
       type: string
   results:
-    - description: Base image the source image is built from
+    - description: Base image source image is built from.
       name: BASE_IMAGE
-    - description: Base image repository URL
+    - description: Base image repository URL.
       name: BASE_IMAGE_REPOSITORY
-    - description: Test output
+    - description: Tekton task test output.
       name: HACBS_TEST_OUTPUT
   workspaces:
     - name: source
@@ -69,41 +69,43 @@ spec:
       if [[ "${IMAGE_URL}" == *":"*"@"* ]]; then
         IMAGE_URL="${IMAGE_URL/:*@/@}"
       fi
-      echo "Inspecting manifest for source image ${IMAGE_URL}"
+      echo "Inspecting manifest for source image ${IMAGE_URL}."
       skopeo inspect --no-tags docker://"${IMAGE_URL}" > $IMAGE_INSPECT 2> stderr.txt || true
       skopeo inspect --no-tags --raw docker://"${IMAGE_URL}" > $RAW_IMAGE_INSPECT 2>> stderr.txt || true
 
       if [ ! -z $(cat stderr.txt) ]; then
-        echo "skopeo inspect fails, the sanity-inspect-image test meets the following error:"
+        echo "Skopeo inspect failed, sanity-inspect-image test encountered the following error:"
         cat stderr.txt
-        HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'skopeo inspect meets errors')"
+        note="Task $(context.task.name) failed: Encountered errors while inspecting image. For details, check Tekton task log."
+        HACBS_TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
         echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
         exit 0
       fi
-      echo "Getting base image manifest for source image ${IMAGE_URL}"
+      echo "Getting base image manifest for source image ${IMAGE_URL}."
       BASE_IMAGE_NAME="$(jq -r ".annotations.\"org.opencontainers.image.base.name\"" $RAW_IMAGE_INSPECT)"
       BASE_IMAGE_DIGEST="$(jq -r ".annotations.\"org.opencontainers.image.base.digest\"" $RAW_IMAGE_INSPECT)"
       if [ $BASE_IMAGE_NAME == 'null' ]; then
-        echo "Cannot get base image info from 'annotations'"
-        echo "Trying to get base image info from 'Labels'"
+        echo "Cannot get base image info from annotations."
+        echo "Cannot get base image info from Labels. For details, check source image ${IMAGE_URL}."
         BASE_IMAGE_NAME="$(jq -r ".Labels.\"org.opencontainers.image.base.name\"" $IMAGE_INSPECT)"
         BASE_IMAGE_DIGEST="$(jq -r ".annotations.\"org.opencontainers.image.base.digest\"" $IMAGE_INSPECT)"
         if [ "$BASE_IMAGE_NAME" == 'null' ]; then
-          echo "Cannot get base image info from 'Labels', please check the source image ${IMAGE_URL}"
+          echo "Cannot get base image info from Labels. For details, check source image ${IMAGE_URL}."
           exit 0
         fi
       fi
       if [ -z "$BASE_IMAGE_NAME" ]; then
-        echo "Source image ${IMAGE_URL} is built from scratch, so there is no base image"
+        echo "Source image ${IMAGE_URL} is built from scratch, so there is no base image."
         exit 0
       fi
       BASE_IMAGE="${BASE_IMAGE_NAME%:*}@$BASE_IMAGE_DIGEST"
-      echo "The base image is $BASE_IMAGE, get its manifest now"
+      echo "The base image is $BASE_IMAGE. Fetch its manifest."
       skopeo inspect --no-tags docker://$BASE_IMAGE  > $BASE_IMAGE_INSPECT || true
       echo -n "$BASE_IMAGE" | tee $(results.BASE_IMAGE.path)
 
       BASE_IMAGE_REPOSITORY="$(jq -r '.Name | sub("[^/]+/"; "") | sub("[:@].*"; "")' "$BASE_IMAGE_INSPECT")"
       echo -n "$BASE_IMAGE_REPOSITORY" | tee $(results.BASE_IMAGE_REPOSITORY.path)
 
-      HACBS_TEST_OUTPUT="$(make_result_json -r SUCCESS -s 1)"
+      note="Task $(context.task.name) completed: Check inspected JSON files under $(workspaces.source.path)/hacbs/$(context.task.name)."
+      HACBS_TEST_OUTPUT=$(make_result_json -r SUCCESS -s 1 -t "$note")
       echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)

--- a/task/sanity-label-check/0.1/sanity-label-check.yaml
+++ b/task/sanity-label-check/0.1/sanity-label-check.yaml
@@ -9,17 +9,19 @@ metadata:
     tekton.dev/tags: "appstudio, hacbs"
   name: sanity-label-check
 spec:
+  description: >-
+    Checks that image carries best practice labels.
   params:
     - name: POLICY_DIR
-      description: "Path to the directory containing conftest policies"
+      description: Path to directory containing Conftest policies.
       default: "/project/image/"
     - name: POLICY_NAMESPACE
-      description: "Namespace for the conftest policy"
+      description: Namespace for Conftest policy.
       default: "required_checks"
   workspaces:
     - name: workspace
   results:
-    - description: Test output
+    - description: Tekton task test output.
       name: HACBS_TEST_OUTPUT
   steps:
     - name: basic-sanity-checks-required-labels
@@ -39,8 +41,9 @@ spec:
 
         . /utils.sh
         if [ ! -s ../sanity-inspect-image/image_inspect.json ]; then
-          echo "File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image"
-          HACBS_TEST_OUTPUT="$(make_result_json -r ERROR -t 'File ../sanity-inspect-image/image_inspect.json is not generated correctly, please check HACBS_TEST_OUTPUT of task sanity-inspect-image!')"
+          echo "File $(workspaces.source.path)/hacbs/sanity-inspect-image/image_inspect.json did not generate correctly. Check task sanity-inspect-image log."
+          note="Task $(context.task.name) failed: $(workspaces.source.path)/hacbs/sanity-inspect-image/image_inspect.json did not generate correctly. For details, check Tekton task result HACBS_TEST_OUTPUT in task sanity-inspect-image."
+          HACBS_TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
           echo "${HACBS_TEST_OUTPUT}" | tee $(results.HACBS_TEST_OUTPUT.path)
           exit 0
         fi
@@ -50,16 +53,17 @@ spec:
           CONFTEST_OPTIONS="-d=../sanity-inspect-image/base_image_inspect.json"
         fi
 
-        echo "Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace"
+        echo "Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace."
         /usr/bin/conftest test --no-fail ../sanity-inspect-image/image_inspect.json "${CONFTEST_OPTIONS}" \
         --policy $POLICY_DIR --namespace $POLICY_NAMESPACE \
         --output=json 2> stderr.txt | tee sanity_label_check_output.json
 
         if [ ! -z $(cat stderr.txt) ]; then
-          echo "The sanity-label-check test meets the following error:"
+          echo "sanity-label-check test encountered the following error:"
           cat stderr.txt
+          note="Task $(context.task.name) failed: Command conftest failed. For details, check Tekton task log."
+          HACBS_ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
         fi
-        HACBS_ERROR_OUTPUT=$(make_result_json -r "ERROR")
 
         HACBS_TEST_OUTPUT=
         parse_hacbs_test_output $(context.task.name) conftest sanity_label_check_output.json || true

--- a/task/sast-go/0.1/sast-go.yaml
+++ b/task/sast-go/0.1/sast-go.yaml
@@ -9,10 +9,12 @@ metadata:
     tekton.dev/tags: "appstudio, hacbs"
   name: sast-go
 spec:
+  description: >-
+    Static application security testing for Go code.
   workspaces:
     - name: workspace
   results:
-    - description: Test output
+    - description: Tekton task test output.
       name: HACBS_TEST_OUTPUT
   steps:
     - name: sast-go
@@ -42,10 +44,10 @@ spec:
         grep -q "$SKIP_MSG$" gosec_output.txt || test_not_skipped=$?
 
         HACBS_ERROR_OUTPUT=$(jq -rc --arg date $(date +%s) --arg tmp_not_skipped $test_not_skipped \
-                              --arg SKIP_MESSAGE "${SKIP_MSG} --null-input \
+                               --null-input \
             '{result: (if $tmp_not_skipped=="0" then "SKIPPED" else "ERROR" end),
               timestamp: $date,
-              note: (if $tmp_not_skipped=="0" then "Test is skipped" else "" end)
+              note: (if $tmp_not_skipped=="0" then "Task sast-go skipped: No packages found." else "Task sast-go failed: For details, check Tekton task log." end)
               }')
 
         if [ -f gosec_output.json ];

--- a/task/sast-java-sec-check/0.1/sast-java-sec-check.yaml
+++ b/task/sast-java-sec-check/0.1/sast-java-sec-check.yaml
@@ -9,28 +9,30 @@ metadata:
     tekton.dev/tags: "appstudio, hacbs, java"
   name: sast-java-sec-check
 spec:
+  description: >-
+    Static application security testing for Java.
   workspaces:
     - name: workspace
   results:
-    - description: Test output
+    - description: Tekton task test output.
       name: HACBS_TEST_OUTPUT
   params:
     - name: PATH_CONTEXT
-      description: The path to your source code
+      description: Path to your source code.
       type: string
       default: .
     - name: OUTPUT_FORMAT
-      description: the format of findsecbugs output
+      description: Format of findsecbugs output.
       type: string
       default: "sarif"
     - name: OUTPUT_ONLY_ANALYZE
       description: |
-        only analyze given classes and packages;
-        end with .* to indicate classes in a package, .- to indicate a package prefix
+        Analyze only given classes and packages;
+        Ending with .* to indicate classes in a package, .- to indicate a package prefix.
       type: string
       default: ""
     - name: OPTIONAL_ARGS
-      description: optional parameters to run findsecbugs
+      description: Optional parameters to run findsecbugs.
       type: string
       default: ""
   steps:
@@ -61,7 +63,7 @@ spec:
         if [ -f "$PATH_CONTEXT/pom.xml" ]; then
           mvn package -f $PATH_CONTEXT/
         else
-          echo "pom.xml file doesn't exist in $(workspaces.workspace.path)/$PATH_CONTEXT"
+          echo "pom.xml file doesn't exist in $(workspaces.workspace.path)/$PATH_CONTEXT."
         fi
         popd
 
@@ -72,12 +74,12 @@ spec:
           cat sast_java_sec_output.json
           test_skipped=0
         else
-          echo "jar file $JAR_PATH doesn't exist" > stderr.txt
+          echo "jar file $JAR_PATH doesn't exist." > stderr.txt
           test_skipped=1
         fi
 
         if [ ! -z $(cat stderr.txt) ]; then
-          echo "The sast-java-sec-check test meets the following error:"
+          echo "sast-java-sec-check test encountered the following error:"
           cat stderr.txt
         fi
 
@@ -85,7 +87,7 @@ spec:
                               --arg test_skipped $test_skipped --null-input \
             '{result: (if $test_skipped=="1" then "SKIPPED" else "ERROR" end),
               timestamp: $date,
-              note: (if $test_skipped=="1" then "Test is skipped" else "" end)
+              note: (if $test_skipped=="1" then "Task sast-java-sec-check skipped: .jar file does not exist. For details, check Tekton task log." else "Task sast-java-sec-check failed: For details, check Tekton task log." end)
               }')
         HACBS_TEST_OUTPUT=
         parse_hacbs_test_output $(context.task.name) sarif sast_java_sec_output.json

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -9,16 +9,17 @@ metadata:
   name: sast-snyk-check
 spec:
   description: >-
-    Static code security test with snyk
+    Static application security testing with Snyk.
   results:
-    - description: Test output
+    - description: Tekton task test output.
       name: HACBS_TEST_OUTPUT
   params:
     - name: SNYK_SECRET
+      description: Name of secret which contains Snyk token.
       default: ""
     - name: ARGS
       type: string
-      description: extra args needs to append
+      description: Append arguments.
       default: "--all-projects --exclude=test*,vendor,deps"
   volumes:
     - name: snyk-secret
@@ -43,8 +44,9 @@ spec:
         . /utils.sh
         SNYK_TOKEN="$(cat /etc/secrets/snyk_token)"
         if [[ -z $SNYK_TOKEN ]]; then
-          echo "SNYK_TOKEN is not defined, please create the $SNYK_SECRET secret with the snyk_token key containing the Snyk token." | tee stdout.txt
-          make_result_json -r SKIPPED -t "Check skipped: SNYK_TOKEN is empty"
+          echo "SNYK_TOKEN not defined. Create $SNYK_SECRET secret with key containing Snyk token." | tee stdout.txt
+          note="Task $(context.task.name) skipped: SNYK_TOKEN is empty."
+          HACBS_TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
           exit 0
         fi
         export SNYK_TOKEN
@@ -54,8 +56,6 @@ spec:
         SKIP_MSG="We found 0 supported files"
         grep -q "$SKIP_MSG" stdout.txt || test_not_skipped=$?
 
-        HACBS_ERROR_OUTPUT=$(make_result_json -r ERROR)
-
         if [[ "$SNYK_EXIT_CODE" -eq 0 ]] || [[ "$SNYK_EXIT_CODE" -eq 1 ]]; then
           cat sast_snyk_check_out.json
           HACBS_TEST_OUTPUT=
@@ -63,10 +63,13 @@ spec:
 
         # When the test is skipped, the "SNYK_EXIT_CODE" is 3 and it can also be 3 in some other situation
         elif [[ "$test_not_skipped" -eq 0 ]]; then
-          HACBS_ERROR_OUTPUT=$(make_result_json -r SKIPPED -t "$SKIP_MSG")
+          note="Task $(context.task.name) skipped: Snyk code test found zero supported files."
+          HACBS_ERROR_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
         else
-          echo "The sast-snyk-check test has failed with the following issues:"
+          echo "sast-snyk-check test failed because of the following issues:"
           cat stdout.txt
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          HACBS_ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
         echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
   workspaces:

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -5,17 +5,16 @@ metadata:
   name: sbom-json-check
 spec:
   description: >-
-    Check the syntax of the sbom-cyclonedx.json file which should be found
-    in the /root/buildinfo/content_manifests/ directory
+    Check syntax of sbom-cyclonedx.json file in /root/buildinfo/content_manifests/.
   params:
     - name: IMAGE_URL
-      description: the fully qualified image name to be verified
+      description: Fully qualified image name to verify.
       type: string
     - name: IMAGE_DIGEST
-      description: image digest
+      description: Image digest.
       type: string
   results:
-    - description: Test output
+    - description: Tekton task test output.
       name: HACBS_TEST_OUTPUT
   steps:
   - name: sbom-json-check
@@ -42,7 +41,9 @@ spec:
       image_with_digest="${IMAGE_URL}@${IMAGE_DIGEST}"
 
       if ! oc image extract "${image_with_digest}" --path '/root/buildinfo/content_manifests/*:/manifests/'; then
-        echo "Failed to extract manifests from image ${image_with_digest}"
+        echo "Failed to extract manifests from image ${image_with_digest}."
+        note="Task $(context.task.name) failed: Failed to extract manifests from image ${image_with_digest} with oc extract. For details, check Tekton task log."
+        HACBS_ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
       fi
 
       touch fail_result.txt
@@ -54,16 +55,18 @@ spec:
           echo "sbom-cyclonedx.json: $result" > fail_result.txt
         fi
       else
-        echo "cannot access 'sbom-cyclonedx.json': No such file or directory" > fail_result.txt
+        echo "Cannot access sbom-cyclonedx.json: No such file or directory exists." > fail_result.txt
       fi
 
       FAIL_RESULTS="$(cat fail_result.txt)"
       if [[ -z $FAIL_RESULTS ]]
       then
-        HACBS_TEST_OUTPUT=$(make_result_json -r "SUCCESS" -s 1)
+        note="Task $(context.task.name) completed: Check result for JSON check result."
+        HACBS_TEST_OUTPUT=$(make_result_json -r "SUCCESS" -s 1 -t "$note")
       else
-        echo "Fail to verify sbom-cyclonedx.json for image $IMAGE_URL with reason: $FAIL_RESULTS"
-        HACBS_ERROR_OUTPUT=$(make_result_json -r "FAILURE" -f 1)
+        echo "Failed to verify sbom-cyclonedx.json for image $IMAGE_URL with reason: $FAIL_RESULTS."
+        note="Task $(context.task.name) failed: Failed to verify SBOM for image $IMAGE_URL."
+        HACBS_ERROR_OUTPUT=$(make_result_json -r "FAILURE" -f 1 -t "$note")
       fi
 
       echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)


### PR DESCRIPTION
- Add more more meaningful note to HACBS_TEST_OUTPUT
- Add description to task

Example:
The note in clamav-scan task is like below when it meet error: 
`Task clamav-scan failed: Unable to get number of infected files from /tekton/home/clamscan-result.json. For details, check Tekton task log.`
`Task clamav-scan failed: /tekton/home/clamscan-result.json doesn't exist. For details, check Tekton task log.`
The note for the completed task: `Task clamav-scan completed: Check result for antivirus scan result.`


Signed-off-by: Hongwei Liu hongliu@redhat.com