### PR TITLE
fix(HACBS-1821-2):return confdir for rel-img-check

### DIFF
--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -28,8 +28,9 @@ spec:
         set -o pipefail
         source /utils.sh
         FAILEDIMAGES=""
+        catalog="$(find $(workspaces.workspace.path)/hacbs/fbc-validation/ -name catalog.yaml)"
 
-        relImgs=$(cat "$(workspaces.workspace.path)/hacbs/fbc-validation/confdir/catalog.yaml" | yq -r '.relatedImages[].image' | sed 's/---//')
+        relImgs="$(yq -r '.relatedImages[]?.image' $catalog)"
         if [ $? -ne 0 ]; then
           echo "Could not get related images, make sure catalog.yaml exists in FBC fragment image and has valid yaml format."
           HACBS_TEST_OUTPUT="$(make_result_json -r FAILURE -f 1)"

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -53,7 +53,7 @@ spec:
           echo "${HACBS_TEST_OUTPUT}" | tee "$(results.HACBS_TEST_OUTPUT.path)"
           exit 0
         fi
-        mkdir -p /tmp/image-content
+        mkdir -p /tmp/image-content confdir
         pushd /tmp/image-content
         image_with_digest="$(params.IMAGE_URL)@$(params.IMAGE_DIGEST)"
 
@@ -72,18 +72,20 @@ spec:
           popd
           exit 0
         fi
+        # copy content of conffolder to confdir - will be used in next task - related image check
+        cp -r .$conffolder/* $(workspaces.workspace.path)/hacbs/$(context.task.name)/confdir
 
         # We have totally 4 checks here currently
         check_num=4
         failure_num=0
         TESTPASSED=true
 
-        if [ ! $(find . -name "opm") ]; then
+        if [[ ! $(find . -name "opm") ]]; then
           echo "!FAILURE! - opm binary presence check failed"
           failure_num=`expr $failure_num + 1`
           TESTPASSED=false
         fi
-        if [ ! $(find . -name grpc_health_probe ) ]; then
+        if [[ ! $(find . -name "grpc_health_probe") ]]; then
           echo "!FAILURE! - grpc_health_probe binary presence check failed"
           failure_num=`expr $failure_num + 1`
           TESTPASSED=false


### PR DESCRIPTION
This will fix following errors in pipeline:

```
/tmp/image-content /workspace/workspace/hacbs/fbc-validation
Warning: the default reading order of registry auth file will be changed from "${HOME}/.docker/config.json" to podman registry config locations in the future version of oc. "${HOME}/.docker/config.json" is deprecated, but can still be used for storing credentials as a fallback. See https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md for the order of podman registry config locations.
/tekton/scripts/script-0-xf56w: line 45: [: ./usr/bin/opm: unary operator expected
true
{"result":"SUCCESS","timestamp":"1677596444","note":"For more details please visit the logs in workspace of Tekton tasks.","namespace":"default","successes":4,"failures":0,"warnings":0}
/workspace/workspace/hacbs/fbc-validation
(https://redhat-internal.slack.com/archives/D03Q4SZ2BHQ/p1677596586642549)
STEP-CHECK-RELATED-IMAGES
cat: /workspace/workspace/hacbs/fbc-validation/confdir/catalog.yaml: No such file or directory
Could not get related images, make sure catalog.yaml exists in FBC fragment image and has valid yaml format.
{"result":"FAILURE","timestamp":"1677596453","note":"For more details please visit the logs in workspace of Tekton tasks.","namespace":"default","successes":0,"failures":1,"warnings":0}
```