### PR TITLE
STONEBLD-884: Quick fix for running on Openshift 1.9

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -79,6 +79,7 @@ spec:
         memory: 512Mi
         cpu: 10m
     script: |
+      touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
       if [ -e "$(params.CONTEXT)/$(params.DOCKERFILE)" ]; then
         dockerfile_path=$(params.CONTEXT)/$(params.DOCKERFILE)
       elif [ -e "$(params.DOCKERFILE)" ]; then

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -61,6 +61,7 @@ spec:
   steps:
   - args:
     - |-
+      touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
       echo "MAVEN_CLEAR_REPO=true" > env-file
       [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] &&
         echo "MAVEN_MIRROR_URL=http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/" >> env-file


### PR DESCRIPTION
Fixing issue `invalid pipelineresults [JAVA_COMMUNITY_DEPENDENCIES], the referred results don't exist`

There is still issue with java pipelines with JVM build service enabled.