### PR TITLE
STONEBLD-884: fix  missmatched Types on Openshift Pipelines 1.9

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -54,6 +54,7 @@ spec:
     name: BASE_IMAGES_DIGESTS
   - name: SBOM_JAVA_COMPONENTS_COUNT
     description: The counting of Java components by publisher in JSON format
+    type: string
   - name: JAVA_COMMUNITY_DEPENDENCIES
     description: The Java dependencies that came from community sources such as Maven central.
   stepTemplate:
@@ -160,6 +161,7 @@ spec:
     script: |
       if [ -f /var/lib/containers/java ]; then
         /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /workspace/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
       fi
     volumeMounts:
     - mountPath: /var/lib/containers

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -48,6 +48,7 @@ spec:
     name: BASE_IMAGES_DIGESTS
   - name: SBOM_JAVA_COMPONENTS_COUNT
     description: The counting of Java components by publisher in JSON format
+    type: string
   - name: JAVA_COMMUNITY_DEPENDENCIES
     description: The Java dependencies that came from community sources such as Maven central.
   stepTemplate:
@@ -134,6 +135,7 @@ spec:
     script: |
       if [ -f /var/lib/containers/java ]; then
         /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /workspace/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
       fi
     volumeMounts:
     - mountPath: /var/lib/containers


### PR DESCRIPTION
The issue:  missmatched Types for these results, map[SBOM_JAVA_COMPONENTS_COUNT:[string]] Reported as SRVKP-2875, this is workaround