### PR TITLE
Adapts the incremental support for GitHub

### DIFF
--- a/.github/workflows/shellspec.yaml
+++ b/.github/workflows/shellspec.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: jerop/tkn@v0.1.0
 


### PR DESCRIPTION
The script no longer fetches into `main` but to a temp branch. This should fix the:

```
fatal: refusing to fetch into branch 'refs/heads/main' checked out at '/home/runner/work/build-definitions/build-definitions'
```

error.

The script now takes into account running on GitHub Actions and takes the relevant git change commit id and base from the available environment variables.