### PR TITLE
STONEBLD-836: fix s2i builds which were showing wrong base digest

### DIFF
--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -92,7 +92,7 @@ spec:
   - script: |
       touch /var/lib/containers/java
       sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
-      buildah bud --tls-verify=$(params.TLSVERIFY) --layers --ulimit nofile=4096:4096 -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+      buildah bud --tls-verify=$(params.TLSVERIFY) --ulimit nofile=4096:4096 -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
 
       container=$(buildah from --pull-never $(params.IMAGE))
       buildah mount $container | tee /workspace/container_path

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -75,7 +75,7 @@ spec:
     workingDir: $(workspaces.source.path)
   - script: |
       sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
-      buildah bud --tls-verify=$(params.TLSVERIFY) --layers -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
+      buildah bud --tls-verify=$(params.TLSVERIFY) -f /gen-source/Dockerfile.gen -t $(params.IMAGE) .
 
       container=$(buildah from --pull-never $(params.IMAGE))
       buildah mount $container | tee /workspace/container_path


### PR DESCRIPTION
org.opencontainers.image.base.digest is not set properly with '--layers' option.