### PR TITLE
fix: use latest e2e-tests image for testing

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -124,7 +124,7 @@ spec:
               type: string
           steps:
             - name: e2e-test
-              image: quay.io/redhat-appstudio/e2e-tests:16e830d2ba3e8208208a7524fa9c3cec4e520a77
+              image: quay.io/redhat-appstudio/e2e-tests:main
               imagePullPolicy: Always
               args: [
                 "--ginkgo.label-filter=build-templates-e2e",


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/STONEBLD-875

### Changes
* updated e2e-tests to work in this repo (there were some breaking changes introduced to e2e-tests recently that caused e2e to fail, so we had to use the fixed e2e-tests image tag) ([link to related commit](https://github.com/redhat-appstudio/e2e-tests/pull/386/commits/a0f4c87fe35c3ba8ba3a315ec45359373770f23d))
* added ec-policy validation check to e2e ([link to related commit](https://github.com/redhat-appstudio/e2e-tests/pull/386/commits/10e0a0ea3369eb693bfc3fdfea538219493027f7))