### PR TITLE
STONEBLD-963: use infra-deployments-updater GitHub App

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -114,7 +114,7 @@ spec:
           - name: SCRIPT_IMAGE
             value: "$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)"
           - name: GITHUB_APP_INSTALLATION_ID
-            value: "25969606"
+            value: "35269653"
           - name: SCRIPT
             value: |
               BUNDLES=(

--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -27,14 +27,14 @@ spec:
       default: infra-deployments-pr-creator
     - name: GITHUB_APP_ID
       description: ID of Github app used for updating PR
-      default: "172616"
+      default: "305606"
     - name: GITHUB_APP_INSTALLATION_ID
       description: Installation ID of Github app in the organization
-      default: "23331085"
+      default: "35269675"
   volumes:
     - name: infra-deployments-pr-creator
       secret:
-        # 'appstudio-staging-ci' - private key for appstudio-staging-ci Github app
+        # 'private-key' - private key for infra-deployments-updater Github app
         secretName: $(params.shared-secret)
     - name: shared-dir
       emptyDir: {}
@@ -87,7 +87,7 @@ spec:
       workingDir: /shared
       env:
         - name: GITHUBAPP_KEY_PATH
-          value: /secrets/deploy-key/appstudio-staging-ci
+          value: /secrets/deploy-key/private-key
         - name: GITHUBAPP_APP_ID
           value: "$(params.GITHUB_APP_ID)"
         - name: GITHUBAPP_INSTALLATION_ID
@@ -236,7 +236,7 @@ spec:
                     })
                 json_output = req.json()
                 for item in json_output:
-                    if item["user"]["login"] == "appstudio-staging-ci[bot]" and item["head"]["ref"] == repo_name:
+                    if item["user"]["login"] == "infra-deployments-updater[bot]" and item["head"]["ref"] == repo_name:
                         return item
 
             def get_pr_url_from_sha(self, sha):


### PR DESCRIPTION
Use new github app for updating infra-deployments.

https://github.com/apps/infra-deployments-updater


- [x] Application created
- [x] Application installed to infra-deployments
- [x] Application installed to ec-policies
- [x] Private key generated
- [x] Secret updated in Vault
- [x] Secret is updated in tekton-ci namespace