### PR TITLE
STONEBLD-960: summary - do not show image if build failed

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -258,6 +258,8 @@ spec:
         value: "$(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)"
       - name: image-url
         value: $(params.output-image)
+      - name: build-task-status
+        value: $(tasks.build-container.status)
   results:
     - name: IMAGE_URL
       value: "$(tasks.build-container.results.IMAGE_URL)"

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -46,8 +46,6 @@ spec:
       value: vfs
     - name: DOCKER_CONFIG
       value: /secrets/registry-auth
-    - name: PATH_CONTEXT
-      value: $(params.PATH_CONTEXT)
     - name: TLSVERIFY
       value: $(params.TLSVERIFY)
     - name: IMAGE
@@ -65,7 +63,7 @@ spec:
     command:
     - s2i
     - build
-    - $PATH_CONTEXT
+    - $(params.PATH_CONTEXT)
     - $(params.BASE_IMAGE)
     - --as-dockerfile
     - /gen-source/Dockerfile.gen

--- a/task/summary/0.1/summary.yaml
+++ b/task/summary/0.1/summary.yaml
@@ -17,6 +17,8 @@ spec:
       description: Git URL
     - name: image-url
       description: Image URL
+    - name: build-task-status
+      description: State of build task in pipelineRun
   steps:
     - name: appstudio-summary
       image: registry.redhat.io/openshift4/ose-cli:v4.12@sha256:9f0cdc00b1b1a3c17411e50653253b9f6bb5329ea4fb82ad983790a6dbf2d9ad
@@ -27,16 +29,22 @@ spec:
           value: $(params.image-url)
         - name: PIPELINERUN_NAME
           value: $(params.pipelinerun-name)
+        - name: BUILD_TASK_STATUS
+          value: $(params.build-task-status)
       script: |
         #!/usr/bin/env bash
         echo
         echo "Build Summary:"
         echo
         echo "Build repository: $GIT_URL"
-        echo "Generated Image is in : $IMAGE_URL"
+        if [ "$BUILD_TASK_STATUS" == "Succeeded" ]; then
+          echo "Generated Image is in : $IMAGE_URL"
+        fi
         echo
         oc annotate --overwrite pipelinerun $PIPELINERUN_NAME build.appstudio.openshift.io/repo=$GIT_URL
-        oc annotate --overwrite pipelinerun $PIPELINERUN_NAME build.appstudio.openshift.io/image=$IMAGE_URL
+        if [ "$BUILD_TASK_STATUS" == "Succeeded" ]; then
+          oc annotate --overwrite pipelinerun $PIPELINERUN_NAME build.appstudio.openshift.io/image=$IMAGE_URL
+        fi
         echo End Summary
 
         oc delete --ignore-not-found=true secret $PIPELINERUN_NAME


### PR DESCRIPTION
Do not show generated image in summary when build-container task failed.