### PR TITLE
STONEBLD-978: renovate - disable dashboard creation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:base"
   ],
+  "dependencyDashboard": false,
   "tekton": {
       "fileMatch": ["\\.yaml$", "\\.yml$"],
       "includePaths": [".tekton/**", "task/**"]


### PR DESCRIPTION
Avoid creation of renovate dashoard which is creating issues which are synced to our Jira. PR in github is enough.