### PR TITLE
Set default value on show-summary for build-task-status

### DIFF
--- a/task/summary/0.1/summary.yaml
+++ b/task/summary/0.1/summary.yaml
@@ -19,6 +19,8 @@ spec:
       description: Image URL
     - name: build-task-status
       description: State of build task in pipelineRun
+      # Default Succeeded for backward compatibility
+      default: Succeeded
   steps:
     - name: appstudio-summary
       image: registry.redhat.io/openshift4/ose-cli:v4.12@sha256:9f0cdc00b1b1a3c17411e50653253b9f6bb5329ea4fb82ad983790a6dbf2d9ad


### PR DESCRIPTION
New parameter was added in #349 without default value which causes that renovate bot update breaks the pipelinerun. We have to always set default value for newly created tasks.