### PR TITLE
add label for enterprise contract pipeline

### DIFF
--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -6,6 +6,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: enterprise-contract
+  labels:
+    build.appstudio.redhat.com/pipeline: "enterprise-contract"
 spec:
   params:
     - name: SNAPSHOT


### PR DESCRIPTION
This will be used to identify it's the enterprise contract pipeline by the UI

https://issues.redhat.com/browse/HACBS-2062