### PR TITLE
Use Cachi2 image from Quay's redhat-appstudio org

### DIFF
--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -15,7 +15,7 @@ spec:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
   steps:
-  - image: quay.io/containerbuildsystem/cachi2@sha256:9036f5941fb13c713d5d6b615ad69c923479cd78ca3f67f0dd0a064c76924c2a
+  - image: quay.io/redhat-appstudio/cachi2@sha256:8f9e2f985936fe4b8c3b3ebf10fd821a83d39a4e81e6c0ec4fd37a267fbd3e66
     name: prefetch-dependencies
     env:
     - name: INPUT


### PR DESCRIPTION
The images in this respository are built using the RHTAP pipeline, and are now more compliant to the Enterprise Contract policies.