### PR TITLE
ec policy check on all tasks 

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -138,6 +138,59 @@ spec:
         workspaces:
           - name: source
             workspace: workspace
+
+
+      - name: get-tasks-to-evaluate
+        runAfter:
+          - fetch-repository        
+        taskSpec:
+          results:
+          - description: Directory containing the build tasks
+            name: build_tasks_dir
+          - description: Directory containing all tasks
+            name: all_tasks_dir
+          steps:
+            - name: gather-tasks
+              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12
+              workingDir: $(workspaces.source.path)
+              script: |
+                #!/usr/bin/env bash
+                source .tekton/scripts/ec-checks.sh
+                $(build_tasks_dir build_tasks)
+                $(all_tasks_dir all_tasks)
+          workspaces:
+            - name: source
+        workspaces:
+          - name: source
+            workspace: workspace
+
+
+    - name: evaluate tasks
+        runAfter:
+          - get-tasks-to-evaluate        
+        taskSpec:
+          steps:
+            - name: validate
+              workingDir: "$(workspaces.output.path)"
+              image: quay.io/hacbs-contract/ec-cli:snapshot
+              command: [ec]
+              args:
+                - validate
+                - definition
+                - "--file"
+                - "all_tasks"
+                - "--policy"
+                - "git::https://github.com/hacbs-contract/ec-policies//policy/task"
+                - "--policy"
+                - "git::https://github.com/hacbs-contract/ec-policies//policy/lib"
+                - "--data"
+                - "git::https://github.com/hacbs-contract/ec-policies//data"
+          workspaces:
+            - name: source
+        workspaces:
+          - name: source
+            workspace: workspace
+
     finally:
       - name: e2e-cleanup
         params:

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -138,7 +138,7 @@ spec:
         workspaces:
           - name: source
             workspace: workspace
-      - name: evaluate-tasks
+      - name: ec-task-checks
         runAfter:
           - fetch-repository
         taskRef:

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -138,59 +138,14 @@ spec:
         workspaces:
           - name: source
             workspace: workspace
-
-
-      - name: get-tasks-to-evaluate
+      - name: evaluate-tasks
         runAfter:
-          - fetch-repository        
-        taskSpec:
-          results:
-          - description: Directory containing the build tasks
-            name: build_tasks_dir
-          - description: Directory containing all tasks
-            name: all_tasks_dir
-          steps:
-            - name: gather-tasks
-              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12
-              workingDir: $(workspaces.source.path)
-              script: |
-                #!/usr/bin/env bash
-                source .tekton/scripts/ec-checks.sh
-                $(build_tasks_dir build_tasks)
-                $(all_tasks_dir all_tasks)
-          workspaces:
-            - name: source
+          - fetch-repository
+        taskRef:
+          name: ec-checks
         workspaces:
           - name: source
             workspace: workspace
-
-
-    - name: evaluate tasks
-        runAfter:
-          - get-tasks-to-evaluate        
-        taskSpec:
-          steps:
-            - name: validate
-              workingDir: "$(workspaces.output.path)"
-              image: quay.io/hacbs-contract/ec-cli:snapshot
-              command: [ec]
-              args:
-                - validate
-                - definition
-                - "--file"
-                - "all_tasks"
-                - "--policy"
-                - "git::https://github.com/hacbs-contract/ec-policies//policy/task"
-                - "--policy"
-                - "git::https://github.com/hacbs-contract/ec-policies//policy/lib"
-                - "--data"
-                - "git::https://github.com/hacbs-contract/ec-policies//data"
-          workspaces:
-            - name: source
-        workspaces:
-          - name: source
-            workspace: workspace
-
     finally:
       - name: e2e-cleanup
         params:

--- a/.tekton/tasks/ec-checks.yaml
+++ b/.tekton/tasks/ec-checks.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: ec-checks
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/displayName: "Enterprise Contract Checks"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This task can be used to run enterprise contract checks
+  steps:
+  - name: gather-tasks
+    image: quay.io/redhat-appstudio/appstudio-utils:512cca38316355d6dbfc9c23ed3c5afabb943d24
+    workingDir: $(workspaces.source.path)
+    script: |
+      source hack/ec-checks.sh
+      $(build_tasks_dir build_tasks-ec)
+      $(all_tasks_dir all_tasks-ec)
+  - name: validate-all-tasks
+    workingDir: "$(workspaces.source.path)"
+    image: quay.io/hacbs-contract/ec-cli:snapshot
+    command: [ec]
+    args:
+      - validate
+      - definition
+      - "--file"
+      - "./all_tasks-ec"
+      - "--policy"
+      - "git::https://github.com/hacbs-contract/ec-policies//policy/task"
+      - "--policy"
+      - "git::https://github.com/hacbs-contract/ec-policies//policy/lib"
+      - "--data"
+      - "git::https://github.com/hacbs-contract/ec-policies//data"
+      - "--strict"
+  - name: validate-build-tasks
+    workingDir: "$(workspaces.source.path)"
+    image: quay.io/hacbs-contract/ec-cli:snapshot
+    command: [ec]
+    args:
+      - validate
+      - definition
+      - "--file"
+      - "./build_tasks-ec"
+      - "--policy"
+      - "git::https://github.com/hacbs-contract/ec-policies//policy/build_task"
+      - "--policy"
+      - "git::https://github.com/hacbs-contract/ec-policies//policy/lib"
+      - "--data"
+      - "git::https://github.com/hacbs-contract/ec-policies//data"
+      - "--strict"
+  workspaces:
+    - name: source

--- a/hack/ec-checks.sh
+++ b/hack/ec-checks.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+# extract the build container task name
+function build_container_name {
+  local pipeline=$1
+  cat $pipeline | yq '.spec.tasks[] | select(.name == "build-container") .taskRef.name' | tr -d '"'
+}
+
+# the same build task can be used for multiple pipelines
+# so find all the task files while filtering duplicates
+# also find all versions of a task
+function copy_all_task_versions {
+  local task=$1
+  local tmp_dir=$2
+  for version in `find task/${task}/*/${task}.yaml`
+    do
+      number=$(basename "$(dirname "$version")")
+      file=$(basename "$version")
+      cp $version "${tmp_dir}/${number}_${file}"
+  done
+}
+
+# find all BUILD tasks in a tekton catalog layout. 
+# copy them to a temp directory with the format version_task.yaml
+function build_tasks_dir {
+  # if [[ ! -d $1 ]]; then
+  #   mkdir $1
+  # fi
+  local tasks_dir=$(mktemp -d -p .)
+  # where to store the generated pipelines after running kustomize
+  local generated_pipelines_dir=$(mktemp -d)
+  kustomize build --output $generated_pipelines_dir pipelines/
+  for f in `find $generated_pipelines_dir/* -maxdepth 1 -type f`; 
+  do
+    # find all tasks that are named "build-container" in each pipeline
+    name=$(build_container_name $f)
+    if [[ -z $name ]]; then
+      continue
+    fi
+    copy_all_task_versions $name $tasks_dir
+  done
+  echo $tasks_dir
+}
+
+# find all tasks in a tekton catalog layout. 
+# copy them to a temp directory with the format version_task.yaml
+function all_tasks_dir {
+  # if [[ ! -d $1 ]]; then
+  #   mkdir $1
+  # fi
+  local tasks_dir=$(mktemp -d -p .)
+  
+  for task in `find  task/* -maxdepth 0 -type d -exec sh -c 'for f do basename "$f";done' sh {} +`; do
+    copy_all_task_versions $task $tasks_dir
+ done
+ echo $tasks_dir
+}


### PR DESCRIPTION
The purpose of this change is to create CI that validates the tasks in this repo against the policies in [ec-policies](https://github.com/enterprise-contract/ec-policies). There are two policies that will run. The first is [tasks](https://github.com/enterprise-contract/ec-policies/tree/main/policy/task). This policy will run against all tasks. The second policy is the [build tasks](https://github.com/enterprise-contract/ec-policies/tree/main/policy/build_task). This policy runs against just the build tasks. The build tasks are identified from the pipelines by the name `build-container`.