### PR TITLE
STONEBUGS-109: bump ose-tools-rhel8 to newest version

### DIFF
--- a/task/init/0.1/init.yaml
+++ b/task/init/0.1/init.yaml
@@ -36,7 +36,7 @@ spec:
           sharedSecret: $(params.shared-secret)
   steps:
     - name: init
-      image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12@sha256:253d042ecfad7b64593112a4aa3f528d39cb5fe738852e44f009db87964cf051
+      image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12@sha256:4d89da145a14501b049397dc723a2b5feba1f2238c9f71659c9512bd27ca4e95
       volumeMounts:
         - name: default-push-secret
           mountPath: /secret/default-push-secret


### PR DESCRIPTION
Sometimes RH registry are having issue with pulling older images.