### PR TITLE
STONEBLD-1120 Download corresponding .dockerignore

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -100,6 +100,11 @@ spec:
           echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ $http_code = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $CONTEXT/.dockerignore
+        fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
         exit 1


### PR DESCRIPTION
If there is a .Dockerignore for a remote dockerfile then download it as well and replace the current file.