### PR TITLE
STONEBLD-1046: Require MIGRATION.md for new versions

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -146,6 +146,33 @@ spec:
         workspaces:
           - name: source
             workspace: workspace
+      - name: check-task-migration-md
+        runAfter:
+          - fetch-repository
+        taskSpec:
+          steps:
+            - name: check-task-migration-md
+              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12
+              workingDir: $(workspaces.source.path)
+              script: |
+                #!/usr/bin/env bash
+                EXIT=0
+                for TASK_DIR in $(ls task); do
+                  # Do not check on initial version of task
+                  for VERSION in $(ls -d task/$TASK_DIR/*/ | sort --version-sort | tail -n+2); do
+                    MIGRATION_FILE=${VERSION}MIGRATION.md
+                    if [ ! -f $MIGRATION_FILE ]; then
+                       echo "Missing file $MIGRATION_FILE"
+                       EXIT=1
+                    fi
+                  done
+                done
+                exit $EXIT
+          workspaces:
+            - name: source
+        workspaces:
+          - name: source
+            workspace: workspace
     finally:
       - name: e2e-cleanup
         params:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Shellspec tests can be run by invoking `hack/test-shellspec.sh`.
 
 Release is done by setting env variable `MY_QUAY_USER=redhat-appstudio`, `BUILD_TAG=$(git rev-parse HEAD)` and running `hack/build-and-push.sh`.
 
+### Versioning
+
+When the task update changes the interface (eg. change of parameters, workspaces or results names) then a new version of the task should be created. The folder with the new version must contain `MIGRATION.md` with instructions on how to update the current pipeline file in user's `.tekton` folder.
+
+Adding a new parameter with a default value does not require the task version increase.
+
+Task version increase must be approved by Project Manager.
+
 ## Testing
 
 Script `./hack/test-builds.sh` creates pipelines and tasks directly in current namespace and executes there test builds. Images are pushed into OpenShift image streams, by setting environment variable `MY_QUAY_USER` the images will be pushed into user's quay repository, in that case creation of secret named `redhat-appstudio-staginguser-pull-secret` is required.

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -170,7 +170,7 @@ spec:
         values: ["false"]
       taskRef:
         name: deprecated-image-check
-        version: "0.1"
+        version: "0.2"
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)

--- a/task/deprecated-image-check/0.2/MIGRATION.md
+++ b/task/deprecated-image-check/0.2/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration from 0.1 to 0.2
+
+Workspace used by `deprecated-image-check` has been changed from `sanity-ws` to `test-ws`.
+
+## Action from users
+
+Update files in Pull-Request created by RHTAP bot:
+- Search for the task named `deprecated-base-image-check`
+- Change workspace named `sanity-ws` to `test-ws`

--- a/task/deprecated-image-check/0.2/README.md
+++ b/task/deprecated-image-check/0.2/README.md
@@ -1,0 +1,31 @@
+# deprecated-image-check task
+
+## Description:
+The deprecated-image-check checks for deprecated images that are no longer maintained and prone to security issues.
+It accomplishes this by verifying the data using Pyxis to query container image data and running Conftest using the
+supplied conftest policy. Conftest is an open-source tool that provides a way to enforce policies written
+in a high-level declarative language called Rego. 
+
+## Params:
+
+| name                | description                                     |
+|---------------------|-------------------------------------------------|
+| POLICY_DIR          | Path to directory containing Conftest policies. |
+| POLICY_NAMESPACE    | Namespace for Conftest policy.                  |
+| BASE_IMAGES_DIGESTS | Digests of base build images.                   |
+
+## Params:
+
+| name              | description                               |
+|-------------------|-------------------------------------------|
+| PYXIS_HTTP_CODE   | HTTP code returned by Pyxis API endpoint. |
+| HACBS_TEST_OUTPUT | Tekton task test output.                  |
+
+## Source repository for image:
+https://github.com/redhat-appstudio/hacbs-test
+
+## Additional links:
+https://catalog.redhat.com/api/containers/docs/
+https://www.redhat.com/en/blog/gathering-security-data-container-images-using-pyxis-api
+https://github.com/open-policy-agent/conftest
+https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/concepts/testing_applications/sanity_tests.html#_deprecated_image_checks

--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -1,0 +1,110 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio, hacbs"
+  name: deprecated-image-check
+spec:
+  description: >-
+    Identifies the unmaintained and potentially insecure deprecated base images.
+    Pyxis API collects metadata from image repository, and Conftest applies supplied policy to identify the deprecated images using that metadata.
+  params:
+    - name: POLICY_DIR
+      description: Path to directory containing Conftest policies.
+      default: "/project/repository/"
+    - name: POLICY_NAMESPACE
+      description: Namespace for Conftest policy.
+      default: "required_checks"
+    - name: BASE_IMAGES_DIGESTS
+      description: Digests of base build images.
+
+  results:
+    - name: PYXIS_HTTP_CODE
+      description: HTTP code returned by Pyxis API endpoint.
+    - description: Tekton task test output.
+      name: HACBS_TEST_OUTPUT
+
+  steps:
+    # Download Pyxis metadata about the image
+    - name: query-pyxis
+      image: registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107@sha256:987ae81ce046652ee4a2c3df54dad5e82faa1b078dab5d09f7cfaae11784ed30
+      env:
+        - name: BASE_IMAGES_DIGESTS
+          value: $(params.BASE_IMAGES_DIGESTS)
+      script: |
+        #!/usr/bin/env bash
+        readarray -t IMAGE_ARRAY < <(echo -n "$BASE_IMAGES_DIGESTS" | sed 's/\\n/\'$'\n''/g')
+        for BASE_IMAGE in ${IMAGE_ARRAY[@]};
+        do
+          IFS=:'/' read -r IMAGE_REGISTRY IMAGE_WITH_TAG <<< $BASE_IMAGE; echo "[$IMAGE_REGISTRY] [$IMAGE_WITH_TAG]"
+          IMAGE_REPOSITORY=`echo $IMAGE_WITH_TAG | cut -d ":" -f1`
+          IMAGE_REGISTRY=${IMAGE_REGISTRY//registry.redhat.io/registry.access.redhat.com}
+          export IMAGE_REPO_PATH=$(workspaces.test-ws.path)/${IMAGE_REPOSITORY}
+          mkdir -p ${IMAGE_REPO_PATH}
+          echo "Querying Pyxis for $BASE_IMAGE."
+          http_code=$(curl -s -k -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY}/repository/${IMAGE_REPOSITORY}")
+          echo "Response code: $http_code."
+          echo $http_code $IMAGE_REGISTRY $IMAGE_REPOSITORY>> $(results.PYXIS_HTTP_CODE.path)
+        done
+
+    # Run the tests and save output
+    - name: run-conftest
+      image: quay.io/redhat-appstudio/hacbs-test:v1.0.12@sha256:8c833349cad40d34262548295cd4eb1bd330e42fbb221ef54e6caee15ae1d208
+      env:
+        - name: POLICY_DIR
+          value: $(params.POLICY_DIR)
+        - name: POLICY_NAMESPACE
+          value: $(params.POLICY_NAMESPACE)
+      script: |
+        #!/usr/bin/env sh
+        source /utils.sh
+
+        success_counter=0
+        failure_counter=0
+        error_counter=0
+        if [ ! -f $(results.PYXIS_HTTP_CODE.path) ]; then
+          error_counter=$((error_counter++))
+        fi
+        while IFS= read -r line
+        do
+          IFS=:' ' read -r http_code IMAGE_REGISTRY IMAGE_REPOSITORY <<< $line; echo "[$http_code] [$IMAGE_REGISTRY] [$IMAGE_REPOSITORY]"
+          export IMAGE_REPO_PATH=$(workspaces.test-ws.path)/${IMAGE_REPOSITORY}
+          if [ "$http_code" == "200" ];
+          then
+            echo "Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace."
+            /usr/bin/conftest test --no-fail ${IMAGE_REPO_PATH}/repository_data.json \
+            --policy $POLICY_DIR --namespace $POLICY_NAMESPACE \
+            --output=json 2> ${IMAGE_REPO_PATH}/stderr.txt | tee ${IMAGE_REPO_PATH}/deprecated_image_check_output.json
+
+            failure_counter=$((failure_counter+$(jq -r '.[].failures|length' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)))
+            success_counter=$((success_counter+$(jq -r '.[].successes' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)))
+
+          elif [ "$http_code" == "404" ];
+          then
+            echo "Registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} not found in Pyxis." >> $(workspaces.test-ws.path)/stderr.txt
+            cat $(workspaces.test-ws.path)/stderr.txt
+          else
+            echo "Unexpected error HTTP code $http_code) occurred for registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}." >> $(workspaces.test-ws.path)/stderr.txt
+            cat $(workspaces.test-ws.path)/stderr.txt
+            error_counter=$((error_counter++))
+            exit 0
+          fi
+        done < $(results.PYXIS_HTTP_CODE.path)
+
+        note="Task $(context.task.name) failed: Command conftest failed. For details, check Tekton task log."
+        HACBS_ERROR_OUTPUT=$(make_result_json -r ERROR -n "$POLICY_NAMESPACE" -t "$note")
+        if [[ "$error_counter" == 0 && "$success_counter" > 0 ]];
+        then
+          if [[ "${failure_counter}" -gt 0 ]]; then RES="FAILURE"; else RES="SUCCESS"; fi
+          note="Task $(context.task.name) completed: Check result for task result."
+          HACBS_TEST_OUTPUT=$(make_result_json \
+            -r "${RES}" -n "$POLICY_NAMESPACE" \
+            -s "${success_counter}" -f "${failure_counter}" -t "$note")
+        fi
+        echo "${HACBS_TEST_OUTPUT:-${HACBS_ERROR_OUTPUT}}" | tee $(results.HACBS_TEST_OUTPUT.path)
+
+  workspaces:
+    - name: test-ws


### PR DESCRIPTION
- Start requiring new version when there is breaking change in the task -> when task update requires change of pipeline.
- Add check of existance of MIGRATION.md in new versions of tasks.
- Create version 0.2 of deprecated-image-check with MIGRATION.md - due to change from STONEINTG-233