### PR TITLE
artifacts workspace is referenced in push.yaml

### DIFF
--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -299,3 +299,4 @@ spec:
   workspaces:
     - name: artifacts
       description: Workspace containing arbitrary artifacts used during the task run.
+      optional: true

--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -295,3 +295,7 @@ spec:
 
         if __name__ == '__main__':
             main()
+
+  workspaces:
+    - name: artifacts
+      description: Workspace containing arbitrary artifacts used during the task run.


### PR DESCRIPTION
This is to fix a CI error `workspace binding "artifacts" does not match any declared workspace`