### PR TITLE
Fix security tab regression from ec-cli

### DIFF
--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -63,4 +63,4 @@ spec:
           value: ""
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot@sha256:c1cb66d3307cbbe9e7f4bad8c81502a0212ca7702dd8b366d45ddd2bd7285ff9
+        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot@sha256:b6687cf819ff0bb36961877aaa0a6ab2b2a91fdbcd91a49513261edd09d92146


### PR DESCRIPTION
A change was introduced to `ec-cli` that caused errors in the Security tab. The change has been reverted, and this new build should include the fix. 