### PR TITLE
Update to latest bundle for Enterprise Contract task

### DIFF
--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -63,4 +63,4 @@ spec:
           value: ""
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot@sha256:b6687cf819ff0bb36961877aaa0a6ab2b2a91fdbcd91a49513261edd09d92146
+        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot@sha256:6685198616225b66f2c69a2afc89dca4ab92261a139e45ecfe543b54f9fee4d8


### PR DESCRIPTION
Needed in a hurry for the change to the task result name, i.e. it's TEST_OUTPUT instead of HACBS_TEST_OUTPUT.