### PR TITLE
Update snyk-shared-secret replace patch

### DIFF
--- a/pipelines/core-services/snyk-secret.yaml
+++ b/pipelines/core-services/snyk-secret.yaml
@@ -1,3 +1,3 @@
 - op: replace
-  path: /spec/params/10/default
+  path: /spec/params/11/default
   value: snyk-shared-secret


### PR DESCRIPTION
## Why this change?
- #400 adds a parameter to the list of params before snyk-shared-secret,
  but the replace patch is not updated to reflect the change.
  
  https://github.com/redhat-appstudio/build-definitions/blob/c31f6ad4939f52b30b10331097a21a0d03ca1745/pipelines/core-services/snyk-secret.yaml#L2
  
- This causes wrong parameter to be replaced and the sync-secret remains
  empty, causing the check to be skipped.
  
![image](https://github.com/redhat-appstudio/build-definitions/assets/74113200/d90da452-d060-40b8-ae4c-e5f3c74fcd9c)

## Expected

![image](https://github.com/redhat-appstudio/build-definitions/assets/74113200/cb7d559e-2e04-4728-8c6f-c7bc91a30c15)

## Fixes 
- This commit updates the patch to replace the correct parameter
- Fixes: PLNSRVCE-1315

## References
- https://github.com/redhat-appstudio/build-definitions/blob/main/task/sast-snyk-check/0.1/sast-snyk-check.yaml#L46-L49
- [Before] https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/tekton-ci/tekton.dev~v1beta1~PipelineRun/release-service-on-push-kwgtp/yaml
- [After] https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/tekton-ci/tekton.dev~v1beta1~PipelineRun/tekton-results-watcher-on-pull-request-lk7c4/yaml

Signed-off-by: Avinal Kumar <avinal@redhat.com>
