### PR TITLE
Hardcode the default "snyk-secret"

### DIFF
--- a/pipelines/core-services/kustomization.yaml
+++ b/pipelines/core-services/kustomization.yaml
@@ -11,6 +11,3 @@ patches:
 - path: infra-deploy.yaml
   target:
     kind: Pipeline
-- path: snyk-secret.yaml
-  target:
-    kind: Pipeline

--- a/pipelines/core-services/snyk-secret.yaml
+++ b/pipelines/core-services/snyk-secret.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/params/10/default
-  value: snyk-shared-secret

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -200,17 +200,11 @@ spec:
       - input: $(params.skip-checks)
         operator: in
         values: ["false"]
-      - input: $(params.snyk-secret)
-        operator: notin
-        values: [""]
       runAfter:
         - clone-repository
       taskRef:
         name: sast-snyk-check
         version: "0.1"
-      params:
-        - name: SNYK_SECRET
-          value: $(params.snyk-secret)
       workspaces:
       - name: workspace
         workspace: workspace

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -50,10 +50,6 @@ spec:
       name: java
       type: string
       default: "false"
-    - description: Snyk Token Secret Name
-      name: snyk-secret
-      type: string
-      default: ""
     - description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       default: ""

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -46,7 +46,7 @@ spec:
         if [[ -z $SNYK_TOKEN ]]; then
           
 
-          echo "If you wish to use the Snyk code SAST task, please consult documentation on how to create a secret with the key containing the Snyk token." | tee stdout.txt
+          echo "If you wish to use the Snyk code SAST task, please create a secret named snyk-secret with the key containing the Snyk token." | tee stdout.txt
 
           note="Task $(context.task.name) skipped: SNYK_TOKEN is empty."
           TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -44,10 +44,7 @@ spec:
         . /utils.sh
         SNYK_TOKEN="$(cat /etc/secrets/snyk_token)"
         if [[ -z $SNYK_TOKEN ]]; then
-          
-
           echo "If you wish to use the Snyk code SAST task, please create a secret named snyk-secret with the key containing the Snyk token." | tee stdout.txt
-
           note="Task $(context.task.name) skipped: SNYK_TOKEN is empty."
           TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
           exit 0

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -44,7 +44,7 @@ spec:
         . /utils.sh
         SNYK_TOKEN="$(cat /etc/secrets/snyk_token)"
         if [[ -z $SNYK_TOKEN ]]; then
-          echo "If you wish to use the Snyk code SAST task, please create a secret named snyk-secret with the key containing the Snyk token." | tee stdout.txt
+          echo "If you wish to use the Snyk code SAST task, please create a secret named snyk-secret with the key `token` containing the Snyk token." | tee stdout.txt
           note="Task $(context.task.name) skipped: SNYK_TOKEN is empty."
           TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
           exit 0

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -44,7 +44,7 @@ spec:
         . /utils.sh
         SNYK_TOKEN="$(cat /etc/secrets/snyk_token)"
         if [[ -z $SNYK_TOKEN ]]; then
-          echo "If you wish to use the Snyk code SAST task, please create a secret named snyk-secret with the key `token` containing the Snyk token." | tee stdout.txt
+          echo "If you wish to use the Snyk code SAST task, please create a secret named snyk-secret with the key `snyk_token` containing the Snyk token." | tee stdout.txt
           note="Task $(context.task.name) skipped: SNYK_TOKEN is empty."
           TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
           exit 0

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -44,7 +44,10 @@ spec:
         . /utils.sh
         SNYK_TOKEN="$(cat /etc/secrets/snyk_token)"
         if [[ -z $SNYK_TOKEN ]]; then
-          echo "SNYK_TOKEN not defined. Create $SNYK_SECRET secret with key containing Snyk token." | tee stdout.txt
+          
+
+          echo "If you wish to use the Snyk code SAST task, please consult documentation on how to create a secret with the key containing the Snyk token." | tee stdout.txt
+
           note="Task $(context.task.name) skipped: SNYK_TOKEN is empty."
           TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
           exit 0

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -16,7 +16,7 @@ spec:
   params:
     - name: SNYK_SECRET
       description: Name of secret which contains Snyk token.
-      default: ""
+      default: snyk-secret
     - name: ARGS
       type: string
       description: Append arguments.


### PR DESCRIPTION
* The name of the secret would always be `snyk-secret`
<img width="768" alt="image" src="https://github.com/redhat-appstudio/build-definitions/assets/545280/a605d51b-cf48-4d16-b057-e5ef5f3e400c">

* The volume is set to 'optional: true' which means the absence of the `secret` wouldn't cause a failure ?