### PR TITLE
RHTAPBUGS-288: Remove annotation from summary step

### DIFF
--- a/task/summary/0.1/summary.yaml
+++ b/task/summary/0.1/summary.yaml
@@ -43,10 +43,6 @@ spec:
           echo "Generated Image is in : $IMAGE_URL"
         fi
         echo
-        oc annotate --overwrite pipelinerun $PIPELINERUN_NAME build.appstudio.openshift.io/repo=$GIT_URL
-        if [ "$BUILD_TASK_STATUS" == "Succeeded" ]; then
-          oc annotate --overwrite pipelinerun $PIPELINERUN_NAME build.appstudio.openshift.io/image=$IMAGE_URL
-        fi
         echo End Summary
 
         oc delete --ignore-not-found=true secret $PIPELINERUN_NAME


### PR DESCRIPTION
This annotation is not used by appstudio. Currently it was even broken due to switch to new Openshift Pipelines.
Modifying pipelineRun directly in pipelineRun could be also security issue.