### PR TITLE
STONEBLD-29: add slack-webhook-notification

### DIFF
--- a/pipelines/core-services/kustomization.yaml
+++ b/pipelines/core-services/kustomization.yaml
@@ -14,3 +14,6 @@ patches:
 - path: snyk-secret.yaml
   target:
     kind: Pipeline
+- path: slack-notification.yaml
+  target:
+    kind: Pipeline

--- a/pipelines/core-services/slack-notification.yaml
+++ b/pipelines/core-services/slack-notification.yaml
@@ -1,0 +1,24 @@
+- op: add
+  path: /spec/params/-
+  value:
+    name: slack-webhook-notification-team
+    default: ""
+- op: add
+  path: /spec/finally/-
+  value:
+    name: slack-webhook-notification
+    taskRef:
+      name: slack-webhook-notification
+      version: "0.1"
+    when:
+    - input: $(params.slack-webhook-notification-team)
+      operator: notin
+      values: [""]
+    - input: $(tasks.status)
+      operator: in
+      values: ["Failed"]
+    params:
+    - name: message
+      value: Tekton pipelineRun $(context.pipelineRun.name) failed
+    - name: key-name
+      value: $(params.slack-webhook-notification-team)

--- a/task/slack-webhook-notification/0.1/README.md
+++ b/task/slack-webhook-notification/0.1/README.md
@@ -1,0 +1,11 @@
+# slack-webhook-notification task
+
+Sends message to slack using incoming webhook
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|message|Message to be sent||true|
+|secret-name|Secret with least one key where value is webhook URL for slack. eg. oc create secret generic my-secret --from-literal team1=https://hooks.slack.com/services/XXX/XXXXXX --from-literal team2=https://hooks.slack.com/services/YYY/YYYYYY |slack-webhook-notification-secret|false|
+|key-name|Key in the key in secret which contains webhook URL for slack.||true|
+

--- a/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
+++ b/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
@@ -15,7 +15,7 @@ spec:
       description: Message to be sent
     - name: secret-name
       description: |
-        Secret with least one key where value is webhook URL for slack.
+        Secret with at least one key where value is webhook URL for slack.
         eg. oc create secret generic my-secret --from-literal team1=https://hooks.slack.com/services/XXX/XXXXXX --from-literal team2=https://hooks.slack.com/services/YYY/YYYYYY
       default: slack-webhook-notification-secret
     - name: key-name

--- a/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
+++ b/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio, hacbs"
+  name: slack-webhook-notification
+spec:
+  description: >-
+    Sends message to slack using incoming webhook
+  params:
+    - name: message
+      description: Message to be sent
+    - name: secret-name
+      description: |
+        Secret with least one key where value is webhook URL for slack.
+        eg. oc create secret generic my-secret --from-literal team1=https://hooks.slack.com/services/XXX/XXXXXX --from-literal team2=https://hooks.slack.com/services/YYY/YYYYYY
+      default: slack-webhook-notification-secret
+    - name: key-name
+      description: Key in the key in secret which contains webhook URL for slack.
+  volumes:
+    - name: webhook-secret
+      secret:
+        secretName: $(params.secret-name)
+        optional: true
+  steps:
+    - name: send-message
+      image: registry.access.redhat.com/ubi9/ubi-minimal:9.2-484@sha256:90d72025de22146c02d80fd4712cc9de828ec279bc107d7b4561f42e71687b0a
+      volumeMounts:
+        - name: webhook-secret
+          mountPath: "/etc/secrets"
+          readOnly: true
+      env:
+        - name: HOME
+          value: /tekton/home
+        - name: KEY_NAME
+          value: $(params.key-name)
+        - name: MESSAGE
+          value: $(params.message)
+      script: |
+        #!/usr/bin/env bash
+        if [ -f "/etc/secrets/$KEY_NAME" ]; then
+          WEBHOOK_URL=$(cat "/etc/secrets/$KEY_NAME"))
+        else
+          echo "Secret not defined properly"
+          exit 1
+        fi
+        curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$MESSAGE\"}" $WEBHOOK_URL

--- a/task/slack-webhook-notification/OWNERS
+++ b/task/slack-webhook-notification/OWNERS
@@ -1,0 +1,1 @@
+Stonesoup Build Team


### PR DESCRIPTION
Add new task for sending messages via slack using webhooks. Integrate the task with core-services pipeline so that teams can be notified when their push pipelinerun failed.