### PR TITLE
core-service: Allow to define additional repo to modify

### DIFF
--- a/pipelines/core-services/kustomization.yaml
+++ b/pipelines/core-services/kustomization.yaml
@@ -11,6 +11,9 @@ patches:
 - path: infra-deploy.yaml
   target:
     kind: Pipeline
+- path: update-repo.yaml
+  target:
+    kind: Pipeline
 - path: snyk-secret.yaml
   target:
     kind: Pipeline

--- a/pipelines/core-services/update-repo.yaml
+++ b/pipelines/core-services/update-repo.yaml
@@ -1,0 +1,36 @@
+- op: add
+  path: /spec/params/-
+  value:
+    name: update-repo-script
+    default: ""
+- op: add
+  path: /spec/params/-
+  value:
+    name: update-repo-name
+    default: ""
+- op: add
+  path: /spec/finally/-
+  value:
+    name: update-repo
+    taskRef:
+      name: update-infra-deployments
+      version: "0.1"
+    when:
+    - input: $(params.update-repo-script)
+      operator: notin
+      values: [""]
+    - input: $(params.update-repo-name)
+      operator: notin
+      values: [""]
+    - input: $(tasks.status)
+      operator: notin
+      values: ["Failed"]
+    params:
+    - name: ORIGIN_REPO
+      value: $(params.git-url)
+    - name: REVISION
+      value: $(params.revision)
+    - name: SCRIPT
+      value: $(params.update-repo-script)
+    - name: TARGET_GH_REPO
+      value: $(params.update-repo-name)


### PR DESCRIPTION
Create two new params 'update-repo-script' and 'update-repo-name' when defined then the 'update-repo-name' (eg. redhat-appstudio/build-service) is cloned, script 'update-repo-script' is executed and pull request is created.