### PR TITLE
STONEBLD-894: inject labels into built image

### DIFF
--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -28,6 +28,8 @@
     value: "$(params.prefetch-input)"
   - name: IMAGE_EXPIRES_AFTER
     value: "$(params.image-expires-after)"
+  - name: COMMIT_SHA
+    value: "$(tasks.clone-repository.results.commit)"
 - op: add
   path: /spec/results/-
   value:

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -26,6 +26,8 @@
     value: "true"
   - name: IMAGE_EXPIRES_AFTER
     value: "$(params.image-expires-after)"
+  - name: COMMIT_SHA
+    value: "$(tasks.clone-repository.results.commit)"
 - op: add
   path: /spec/tasks/-
   value:

--- a/pipelines/java-builder/patch.yaml
+++ b/pipelines/java-builder/patch.yaml
@@ -22,6 +22,8 @@
     value: "$(params.output-image)"
   - name: IMAGE_EXPIRES_AFTER
     value: "$(params.image-expires-after)"
+  - name: COMMIT_SHA
+    value: "$(tasks.clone-repository.results.commit)"
 - op: add
   path: /spec/results/-
   value:

--- a/pipelines/nodejs-builder/patch.yaml
+++ b/pipelines/nodejs-builder/patch.yaml
@@ -22,3 +22,5 @@
     value: "$(params.output-image)"
   - name: IMAGE_EXPIRES_AFTER
     value: "$(params.image-expires-after)"
+  - name: COMMIT_SHA
+    value: "$(tasks.clone-repository.results.commit)"

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -50,6 +50,10 @@ spec:
     description: Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: IMAGE_EXPIRES_AFTER
     type: string
+  - name: COMMIT_SHA
+    description: The image is built from this commit.
+    type: string
+    default: ""
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -92,6 +96,9 @@ spec:
       requests:
         memory: 512Mi
         cpu: 250m
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
     script: |
       if [ -e "$CONTEXT/$DOCKERFILE" ]; then
         dockerfile_path="$CONTEXT/$DOCKERFILE"
@@ -144,11 +151,18 @@ spec:
         echo "Prefetched content will be made available"
       fi
 
-      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS="--label quay.expires-after=$IMAGE_EXPIRES_AFTER"
+      LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah build \
         $VOLUME_MOUNTS \
         $BUILDAH_ARGS \
-        $LABELS \
+        ${LABELS[@]} \
         --tls-verify=$TLSVERIFY --no-cache \
         --ulimit nofile=4096:4096 \
         -f "$dockerfile_path" -t $IMAGE $CONTEXT

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -43,6 +43,10 @@ spec:
     description: Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: IMAGE_EXPIRES_AFTER
     type: string
+  - name: COMMIT_SHA
+    description: The image is built from this commit.
+    type: string
+    default: ""
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -103,16 +107,26 @@ spec:
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
 
+      LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
       touch /var/lib/containers/java
       sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
-      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS="--label quay.expires-after=$IMAGE_EXPIRES_AFTER"
-      buildah build --tls-verify=$TLSVERIFY $LABELS --ulimit nofile=4096:4096 -f /gen-source/Dockerfile.gen -t $IMAGE .
+      buildah build --tls-verify=$TLSVERIFY ${LABELS[@]} --ulimit nofile=4096:4096 -f /gen-source/Dockerfile.gen -t $IMAGE .
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /workspace/container_path
       echo $container > /workspace/container_name
     image: $(params.BUILDER_IMAGE)
     name: build
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
     resources:
       limits:
         memory: 4Gi

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -45,6 +45,10 @@ spec:
   - default: ""
     description: The base URL of a mirror used for retrieving artifacts
     name: MAVEN_MIRROR_URL
+  - name: COMMIT_SHA
+    description: The image is built from this commit.
+    type: string
+    default: ""
   stepTemplate:
     env:
     - name: BUILDAH_FORMAT
@@ -86,15 +90,25 @@ spec:
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
 
+      LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
       sed -i 's/^short-name-mode = .*/short-name-mode = "disabled"/' /etc/containers/registries.conf
-      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS="--label quay.expires-after=$IMAGE_EXPIRES_AFTER"
-      buildah build --tls-verify=$TLSVERIFY $LABELS -f /gen-source/Dockerfile.gen -t $IMAGE .
+      buildah build --tls-verify=$TLSVERIFY ${LABELS[@]} -f /gen-source/Dockerfile.gen -t $IMAGE .
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /workspace/container_path
       echo $container > /workspace/container_name
     image: $(params.BUILDER_IMAGE)
     name: build
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
     resources:
       limits:
         memory: 2Gi


### PR DESCRIPTION
This change affects docker-build pipeline only. Images built by nodejs and Java pipelines already have the requested labels.