### PR TITLE
Add memory and CPU request to git-clone task

### DIFF
--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -124,7 +124,10 @@ spec:
       value: $(workspaces.basic-auth.path)
     image: $(params.gitInitImage)
     name: clone
-    resources: {}
+    resources: #we request the same amount of memory as the buildah task, as this task is run first it will determine the AZ the pipeline runs in
+      requests:
+        memory: 512Mi
+        cpu: 250m
     securityContext:
       runAsUser: 0
     script: |


### PR DESCRIPTION
This is the first task that is run using the PVC, so when this task is scheduled to an AZ all other tasks in the PipelineRun that use the workspace will be scheduled to the same AZ.

If this task has no resource requests the scheduler can over assign tasks to the same AZ.