### PR TITLE
Add check for symlinks pointing outside of repo

### DIFF
--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -20,6 +20,7 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |verbose|Log the commands that are executed during `git-clone`'s operation.|true|false|
 |gitInitImage|The image providing the git-init binary that this Task runs.|registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8|false|
 |userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden the gitInitImage param with an image containing custom user configuration. |/tekton/home|false|
+|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.|true|false|
 
 ## Results
 |name|description|

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -75,13 +75,19 @@ spec:
       the gitInitImage param with an image containing custom user configuration.
     name: userHome
     type: string
+  - default: "true"
+    description: |
+      Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
+    name: enableSymlinkCheck
+    type: string
   results:
   - description: The precise commit SHA that was fetched by this Task.
     name: commit
   - description: The precise URL that was fetched by this Task.
     name: url
   steps:
-  - env:
+  - name: clone
+    env:
     - name: HOME
       value: $(params.userHome)
     - name: PARAM_URL
@@ -123,7 +129,6 @@ spec:
     - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
       value: $(workspaces.basic-auth.path)
     image: $(params.gitInitImage)
-    name: clone
     resources: {}
     securityContext:
       runAsUser: 0
@@ -190,6 +195,40 @@ spec:
       fi
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+  - name: symlink-check
+    image: registry.redhat.io/ubi9:9.2-696
+    env:
+    - name: PARAM_ENABLE_SYMLINK_CHECK
+      value: $(params.enableSymlinkCheck)
+    - name: PARAM_SUBDIRECTORY
+      value: $(params.subdirectory)
+    - name: WORKSPACE_OUTPUT_PATH
+      value: $(workspaces.output.path)
+    resources: {}
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+      check_symlinks() {
+        FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
+        while read symlink
+        do
+          target=$(readlink -f "$symlink")
+          if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
+            echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
+            FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
+          fi
+        done < <(find $CHECKOUT_DIR -type l -print)
+        if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ] ; then
+          return 1
+        fi
+      }
+
+      if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ] ; then
+        echo "Running symlink check"
+        check_symlinks
+      fi
   workspaces:
   - description: The git repo will be cloned onto the volume backing this Workspace.
     name: output


### PR DESCRIPTION
If the check is enabled and the cloned repository contains symlinks pointing outside of the repo, the build will fail.

[STONEBLD-1328](https://issues.redhat.com//browse/STONEBLD-1328)