### PR TITLE
RHTAPBUGS-464,STONEBLD-1494: unify memory usage

### DIFF
--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -30,6 +30,8 @@
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+  - name: MEMORY_REQUEST
+    value: "$(params.build_task_memory_request)"
 - op: add
   path: /spec/results/-
   value:

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -28,6 +28,8 @@
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+  - name: MEMORY_REQUEST
+    value: "$(params.build_task_memory_request)"
 - op: add
   path: /spec/tasks/-
   value:

--- a/pipelines/java-builder/patch.yaml
+++ b/pipelines/java-builder/patch.yaml
@@ -24,6 +24,8 @@
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+  - name: MEMORY_REQUEST
+    value: "$(params.build_task_memory_request)"
 - op: add
   path: /spec/results/-
   value:

--- a/pipelines/nodejs-builder/patch.yaml
+++ b/pipelines/nodejs-builder/patch.yaml
@@ -24,3 +24,5 @@
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+  - name: MEMORY_REQUEST
+    value: "$(params.build_task_memory_request)"

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -57,6 +57,10 @@ spec:
     - description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       default: ""
+    - name: build_task_memory_request
+      description: Set memory request and limit for build task.
+      type: string
+      default: "4Gi"
   tasks:
     - name: init
       params:

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -54,6 +54,10 @@ spec:
     description: The image is built from this commit.
     type: string
     default: ""
+  - name: MEMORY_REQUEST
+    description: Set memory request and limit for building step.
+    type: string
+    default: "4Gi"
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -91,10 +95,10 @@ spec:
     name: build
     resources:
       limits:
-        memory: 4Gi
+        memory: $(params.MEMORY_REQUEST)
         cpu: 2
       requests:
-        memory: 512Mi
+        memory: $(params.MEMORY_REQUEST)
         cpu: 250m
     env:
     - name: COMMIT_SHA

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -47,6 +47,10 @@ spec:
     description: The image is built from this commit.
     type: string
     default: ""
+  - name: MEMORY_REQUEST
+    description: Set memory request and limit for building step.
+    type: string
+    default: "4Gi"
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -129,10 +133,10 @@ spec:
       value: $(params.COMMIT_SHA)
     resources:
       limits:
-        memory: 4Gi
+        memory: $(params.MEMORY_REQUEST)
         cpu: 2
       requests:
-        memory: 512Mi
+        memory: $(params.MEMORY_REQUEST)
         cpu: 10m
     securityContext:
       runAsUser: 0

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -41,6 +41,10 @@ spec:
     description: Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: IMAGE_EXPIRES_AFTER
     type: string
+  - name: MEMORY_REQUEST
+    description: Set memory request and limit for building step.
+    type: string
+    default: "4Gi"
   # Unused only as placeholder
   - default: ""
     description: The base URL of a mirror used for retrieving artifacts
@@ -111,10 +115,10 @@ spec:
       value: $(params.COMMIT_SHA)
     resources:
       limits:
-        memory: 2Gi
+        memory: $(params.MEMORY_REQUEST)
         cpu: 2
       requests:
-        memory: 512Mi
+        memory: $(params.MEMORY_REQUEST)
         cpu: 10m
     securityContext:
       capabilities:


### PR DESCRIPTION
Set memory request and limit to same value to ensure that scheduled node has enough memory.

Make memory of build task configurable via PipelineRun parameter `build_task_memory_request`