### PR TITLE
RHTAPBUGS-464: sync memory limit and request

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -94,7 +94,7 @@ spec:
         memory: 4Gi
         cpu: 2
       requests:
-        memory: 512Mi
+        memory: 4Gi
         cpu: 250m
     env:
     - name: COMMIT_SHA

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -132,7 +132,7 @@ spec:
         memory: 4Gi
         cpu: 2
       requests:
-        memory: 512Mi
+        memory: 4Gi
         cpu: 10m
     securityContext:
       runAsUser: 0

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -114,7 +114,7 @@ spec:
         memory: 2Gi
         cpu: 2
       requests:
-        memory: 512Mi
+        memory: 2Gi
         cpu: 10m
     securityContext:
       capabilities:


### PR DESCRIPTION
Avoid issue with failing build because of running on node with enough memory availably.