### PR TITLE
Fix slack-webhook-notification task

### DIFF
--- a/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
+++ b/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
@@ -42,7 +42,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         if [ -f "/etc/secrets/$KEY_NAME" ]; then
-          WEBHOOK_URL=$(cat "/etc/secrets/$KEY_NAME"))
+          WEBHOOK_URL=$(cat "/etc/secrets/$KEY_NAME")
         else
           echo "Secret not defined properly"
           exit 1


### PR DESCRIPTION
There was a syntax error in the bash script.

Tested in https://github.com/containerbuildsystem/cachi2/pull/235 by inlining the fixed content of the task