### PR TITLE
prefetch-dependencies: use semver for cachi2 image

### DIFF
--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -15,7 +15,7 @@ spec:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
   steps:
-  - image: quay.io/redhat-appstudio/cachi2@sha256:eca73b595a560fa88d9b1aac58855c55c9fb9dec2c38440cecb158f946cc04eb
+  - image: quay.io/redhat-appstudio/cachi2:0.1.0@sha256:5f6dfde43f0970c88337319608b09745bdf03a151a0e97867250796a69fa721f
     name: prefetch-dependencies
     env:
     - name: INPUT


### PR DESCRIPTION
STONEBLD-1270

The cachi2 image gets rebuilt almost everyday, but the changes are often not relevant. To prevent renovatebot from spamming the repository with irrelevant version bumps, use the recently released 0.1.0 semantic version. Renovatebot should now bump cachi2 only when it gets a new release.