### PR TITLE
fix(hack): link to right service account

### DIFF
--- a/hack/test-build.sh
+++ b/hack/test-build.sh
@@ -27,10 +27,10 @@ if [ -z "$MY_QUAY_USER" ]; then
   echo MY_QUAY_USER env variable is not set, pushing to $IMG
 else
   if oc get secret redhat-appstudio-staginguser-pull-secret &>/dev/null; then
-     # Ensure that the pipeline service account has access to the secret. Although the
+     # Ensure that the appstudio-pipeline service account has access to the secret. Although the
      # secret is mounted directly on the pipeline, Tekton Chains needs this linkage so
      # it can push the image signature and attestation to the same OCI repository.
-     oc secrets link pipeline redhat-appstudio-staginguser-pull-secret
+     oc secrets link appstudio-pipeline redhat-appstudio-staginguser-pull-secret
   else
      echo "Secret redhat-appstudio-staginguser-pull-secret is not created, can be created by:"
      echo "Docker:"
@@ -39,7 +39,7 @@ else
      echo "  oc create secret docker-registry redhat-appstudio-staginguser-pull-secret --from-file=.dockerconfigjson=${XDG_RUNTIME_DIR}/containers/auth.json"
      echo "(Note: it will upload all login credentials, make sure that you are not logged into sensitive registries, or create the particular secret manually!)"
      echo "and link it to the pipeline ServiceAccount:"
-     echo "  oc secrets link pipeline redhat-appstudio-staginguser-pull-secret"
+     echo "  oc secrets link appstudio-pipeline redhat-appstudio-staginguser-pull-secret"
      echo ""
   fi
   IMG=quay.io/$MY_QUAY_USER/$APPNAME:$IMAGE_SHORT_TAG

--- a/hack/test-builds.sh
+++ b/hack/test-builds.sh
@@ -21,6 +21,8 @@ oc apply -k $SCRIPTDIR/../pipelines/ -o yaml --dry-run=client | \
   yq e 'del(.items.[] | .spec.tasks.[] | .taskRef.version, .items.[] | .spec.finally.[] | .taskRef.version)' | \
   oc apply -f-
 
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/hack/build/setup-namespace.sh)"
+
 [ "$1" == "skip_checks" ] && export SKIP_CHECKS=1
 $SCRIPTDIR/test-build.sh https://github.com/jduimovich/spring-petclinic java-builder
 $SCRIPTDIR/test-build.sh https://github.com/jduimovich/single-nodejs-app nodejs-builder


### PR DESCRIPTION
There was a change from `pipeline` to `appstudio-pipeline`. Reflecting this change in hack script.

Without this change, custom secret is not linked to PLRs.