### PR TITLE
fix(STONEINTG-31): use versions with clamDB

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,13 @@
       ],
       "schedule": ["on monday and wednesday"],
       "groupName": "shared"
+    },
+    {
+      "matchPackageNames": [
+        "quay.io/redhat-appstudio/clamav-db"
+      ],
+      "enabled": false,
+      "groupName": "ignore"
     }
   ]
 }

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -148,7 +148,7 @@ spec:
   # provides latest virus database for clamscan only
   # does not execute anything
   sidecars:
-    - image: quay.io/redhat-appstudio/clamav-db:latest  # explicit floating tag, daily updates
+    - image: quay.io/redhat-appstudio/clamav-db:v1  # explicit floating tag, daily updates
       imagePullPolicy: Always
       name: database
       script: |


### PR DESCRIPTION
Using major version will allow us to do breaking changes in future without breaking user workflows.

Explicitly disable renovatebot from updating tags, we want to keep the same floating tag there.

Note: we also keep latest tag for compat reasons (but not forever)