### PR TITLE
Check acceptable bundles repo on push

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -117,15 +117,20 @@ spec:
             value: "35269653"
           - name: SCRIPT
             value: |
+              export BUNDLES_FILE=data/acceptable_tekton_bundles.yml
+
               BUNDLES=(
                 $(workspaces.artifacts.path)/task-bundle-list
                 $(workspaces.artifacts.path)/pipeline-bundle-list
               )
               BUNDLES_PARAM=($(cat ${BUNDLES[@]} | awk '{ print "--bundle=" $0 }'))
               ec track bundle \
-                --input data/acceptable_tekton_bundles.yml \
+                --input "${BUNDLES_FILE}" \
                 --replace \
                 ${BUNDLES_PARAM[@]}
+
+              # Ensure no bundles were previously missed
+              ./hack/check-acceptable-tekton-bundles.sh "${BUNDLES_FILE}"
         workspaces:
           - name: artifacts
             workspace: workspace


### PR DESCRIPTION
This commit changes the push pipeline to run an additional script as part of the `update-ec-policies` TaskRun. This script ensure that if a previous CI run failed or was skipped, for whatever reason, then the next run should catch previous missed acceptable bundle images.

https://issues.redhat.com/browse/HACBS-2395