### PR TITLE
fix(s2i-java): use ubi9 python

### DIFF
--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -169,7 +169,7 @@ spec:
       name: varlibcontainers
     securityContext:
       runAsUser: 0
-  - image: registry.access.redhat.com/ubi8/python-39:1-134.1692783617
+  - image: registry.access.redhat.com/ubi9/python-39:1-133.1692772345
     name: merge-sboms
     script: |
       #!/bin/python3


### PR DESCRIPTION
Unify version of the python image, other build scripts are using ubi9 this one is the only one for ubi8. This causes extra updates by renovate bot.