### PR TITLE
chore: update all emptyDirs to 'medium: Memory'

### DIFF
--- a/.tekton/tasks/buildah.yaml
+++ b/.tekton/tasks/buildah.yaml
@@ -88,7 +88,8 @@ spec:
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
   volumes:
-  - emptyDir: {}
+  - emptyDir:
+      medium: Memory
     name: varlibcontainers
   workspaces:
   - name: source

--- a/task/buildah-10gb/0.1/patch.yaml
+++ b/task/buildah-10gb/0.1/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/resources/requests/memory
   value: 8Gi
+- op: replace
+  path: /spec/steps/6/resources/limits/memory
+  value: 10Gi
+- op: replace
+  path: /spec/steps/6/resources/requests/memory
+  value: 8Gi

--- a/task/buildah-6gb/0.1/patch.yaml
+++ b/task/buildah-6gb/0.1/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/resources/requests/memory
   value: 4Gi
+- op: replace
+  path: /spec/steps/6/resources/limits/memory
+  value: 6Gi
+- op: replace
+  path: /spec/steps/6/resources/requests/memory
+  value: 4Gi

--- a/task/buildah-8gb/0.1/patch.yaml
+++ b/task/buildah-8gb/0.1/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/resources/requests/memory
   value: 6Gi
+- op: replace
+  path: /spec/steps/6/resources/limits/memory
+  value: 8Gi
+- op: replace
+  path: /spec/steps/6/resources/requests/memory
+  value: 6Gi

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -91,7 +91,7 @@ spec:
     name: build
     resources:
       limits:
-        memory: 4Gi
+        memory: 5Gi
         cpu: 2
       requests:
         memory: 512Mi
@@ -276,7 +276,13 @@ spec:
 
   - name: inject-sbom-and-push
     image: $(params.BUILDER_IMAGE)
-    resources: {}
+    resources:
+      limits:
+        memory: 5Gi
+        cpu: 2
+      requests:
+        memory: 512Mi
+        cpu: 250m
     script: |
       # Expose base image digests
       buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
@@ -331,7 +337,8 @@ spec:
     workingDir: $(workspaces.source.path)
 
   volumes:
-  - emptyDir: {}
+  - emptyDir:
+      medium: Memory
     name: varlibcontainers
   workspaces:
   - name: source

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -255,9 +255,11 @@ spec:
     workingDir: $(workspaces.source.path)
 
   volumes:
-  - emptyDir: {}
+  - emptyDir:
+      medium: Memory
     name: varlibcontainers
-  - emptyDir: {}
+  - emptyDir:
+      medium: Memory
     name: gen-source
   workspaces:
   - mountPath: /workspace/source

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -221,9 +221,11 @@ spec:
     workingDir: $(workspaces.source.path)
 
   volumes:
-  - emptyDir: {}
+  - emptyDir:
+      medium: Memory
     name: varlibcontainers
-  - emptyDir: {}
+  - emptyDir:
+      medium: Memory
     name: gen-source
   workspaces:
   - mountPath: /workspace/source

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -72,4 +72,5 @@ spec:
       echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
   volumes:
   - name: shared
-    emptyDir: {}
+    emptyDir:
+      medium: Memory

--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -41,7 +41,8 @@ spec:
         # 'private-key' - private key for Github app
         secretName: $(params.shared-secret)
     - name: shared-dir
-      emptyDir: {}
+      emptyDir:
+        medium: Memory
 
   steps:
     - name: git-clone-infra-deployments


### PR DESCRIPTION
@jhutar @pmacik @amfred @psuriset 

I've mentioned this in some of the WG calls.  We should compare the numbers from https://github.com/redhat-appstudio/build-definitions/pull/514 with this change

I'm curious how alleviating the use of aws storage for the sbom-json-check during the adv pipeline in particular has on overall disk IO

fwiw I don't see the use of the s2i-nodejs task in our runs

but ideally we pull the trigger on all our emptydirs at this point