### PR TITLE
change workspace to /tekton/home for deprecated-image-check

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -144,13 +144,10 @@ spec:
         values: ["false"]
       taskRef:
         name: deprecated-image-check
-        version: "0.2"
+        version: "0.3"
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
-      workspaces:
-      - name: test-ws
-        workspace: workspace
     - name: clair-scan
       when:
       - input: $(params.skip-checks)

--- a/task/deprecated-image-check/0.3/MIGRATION.md
+++ b/task/deprecated-image-check/0.3/MIGRATION.md
@@ -1,0 +1,10 @@
+# Migration from 0.2 to 0.3
+
+Workspace used by the `deprecated-image-check` is removed. This is not required as it doesn't need any PVCs. 
+
+## Action from users
+
+Update files in Pull-Request created by RHTAP bot:
+- Search for the task named `deprecated-base-image-check`
+- Remove the workspaces section from [deprecated-image-check.yaml](https://github.com/redhat-appstudio/build-definitions/blob/main/task/deprecated-image-check/0.2/deprecated-image-check.yaml)
+- Replace `$(workspaces.test-ws.path)` with `/tekton/home`

--- a/task/deprecated-image-check/0.3/README.md
+++ b/task/deprecated-image-check/0.3/README.md
@@ -1,0 +1,31 @@
+# deprecated-image-check task
+
+## Description:
+The deprecated-image-check checks for deprecated images that are no longer maintained and prone to security issues.
+It accomplishes this by verifying the data using Pyxis to query container image data and running Conftest using the
+supplied conftest policy. Conftest is an open-source tool that provides a way to enforce policies written
+in a high-level declarative language called Rego. 
+
+## Params:
+
+| name                | description                                     |
+|---------------------|-------------------------------------------------|
+| POLICY_DIR          | Path to directory containing Conftest policies. |
+| POLICY_NAMESPACE    | Namespace for Conftest policy.                  |
+| BASE_IMAGES_DIGESTS | Digests of base build images.                   |
+
+## Results:
+
+| name              | description                               |
+|-------------------|-------------------------------------------|
+| PYXIS_HTTP_CODE   | HTTP code returned by Pyxis API endpoint. |
+| TEST_OUTPUT | Tekton task test output.                  |
+
+## Source repository for image:
+https://github.com/redhat-appstudio/hacbs-test
+
+## Additional links:
+https://catalog.redhat.com/api/containers/docs/
+https://www.redhat.com/en/blog/gathering-security-data-container-images-using-pyxis-api
+https://github.com/open-policy-agent/conftest
+https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/concepts/testing_applications/sanity_tests.html#_deprecated_image_checks

--- a/task/deprecated-image-check/0.3/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.3/deprecated-image-check.yaml
@@ -1,0 +1,107 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio, hacbs"
+  name: deprecated-image-check
+spec:
+  description: >-
+    Identifies the unmaintained and potentially insecure deprecated base images.
+    Pyxis API collects metadata from image repository, and Conftest applies supplied policy to identify the deprecated images using that metadata.
+  params:
+    - name: POLICY_DIR
+      description: Path to directory containing Conftest policies.
+      default: "/project/repository/"
+    - name: POLICY_NAMESPACE
+      description: Namespace for Conftest policy.
+      default: "required_checks"
+    - name: BASE_IMAGES_DIGESTS
+      description: Digests of base build images.
+
+  results:
+    - name: PYXIS_HTTP_CODE
+      description: HTTP code returned by Pyxis API endpoint.
+    - description: Tekton task test output.
+      name: TEST_OUTPUT
+
+  steps:
+    # Download Pyxis metadata about the image
+    - name: query-pyxis
+      image: registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037@sha256:8d43664c250c72d35af8498c7ff76a9f0d42f16b9b3b29f0caa747121778de0e
+      env:
+        - name: BASE_IMAGES_DIGESTS
+          value: $(params.BASE_IMAGES_DIGESTS)
+      script: |
+        #!/usr/bin/env bash
+        readarray -t IMAGE_ARRAY < <(echo -n "$BASE_IMAGES_DIGESTS" | sed 's/\\n/\'$'\n''/g')
+        for BASE_IMAGE in ${IMAGE_ARRAY[@]};
+        do
+          IFS=:'/' read -r IMAGE_REGISTRY IMAGE_WITH_TAG <<< $BASE_IMAGE; echo "[$IMAGE_REGISTRY] [$IMAGE_WITH_TAG]"
+          IMAGE_REPOSITORY=`echo $IMAGE_WITH_TAG | cut -d ":" -f1`
+          IMAGE_REGISTRY=${IMAGE_REGISTRY//registry.redhat.io/registry.access.redhat.com}
+          export IMAGE_REPO_PATH=/tekton/home/${IMAGE_REPOSITORY}
+          mkdir -p ${IMAGE_REPO_PATH}
+          echo "Querying Pyxis for $BASE_IMAGE."
+          http_code=$(curl -s -k -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY}/repository/${IMAGE_REPOSITORY}")
+          echo "Response code: $http_code."
+          echo $http_code $IMAGE_REGISTRY $IMAGE_REPOSITORY>> $(results.PYXIS_HTTP_CODE.path)
+        done
+
+    # Run the tests and save output
+    - name: run-conftest
+      image: quay.io/redhat-appstudio/hacbs-test:v1.1.1@sha256:81acb2ba5e819b7d155ced648e48161e5f7e2bae5c0e4a0bab196651a9044afe
+      env:
+        - name: POLICY_DIR
+          value: $(params.POLICY_DIR)
+        - name: POLICY_NAMESPACE
+          value: $(params.POLICY_NAMESPACE)
+      script: |
+        #!/usr/bin/env sh
+        source /utils.sh
+
+        success_counter=0
+        failure_counter=0
+        error_counter=0
+        if [ ! -f $(results.PYXIS_HTTP_CODE.path) ]; then
+          error_counter=$((error_counter++))
+        fi
+        while IFS= read -r line
+        do
+          IFS=:' ' read -r http_code IMAGE_REGISTRY IMAGE_REPOSITORY <<< $line; echo "[$http_code] [$IMAGE_REGISTRY] [$IMAGE_REPOSITORY]"
+          export IMAGE_REPO_PATH=/tekton/home/${IMAGE_REPOSITORY}
+          if [ "$http_code" == "200" ];
+          then
+            echo "Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace."
+            /usr/bin/conftest test --no-fail ${IMAGE_REPO_PATH}/repository_data.json \
+            --policy $POLICY_DIR --namespace $POLICY_NAMESPACE \
+            --output=json 2> ${IMAGE_REPO_PATH}/stderr.txt | tee ${IMAGE_REPO_PATH}/deprecated_image_check_output.json
+
+            failure_counter=$((failure_counter+$(jq -r '.[].failures|length' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)))
+            success_counter=$((success_counter+$(jq -r '.[].successes' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)))
+
+          elif [ "$http_code" == "404" ];
+          then
+            echo "Registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} not found in Pyxis." >> /tekton/home/stderr.txt
+            cat /tekton/home/stderr.txt
+          else
+            echo "Unexpected error HTTP code $http_code) occurred for registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}." >> /tekton/home/stderr.txt
+            cat /tekton/home/stderr.txt
+            error_counter=$((error_counter++))
+            exit 0
+          fi
+        done < $(results.PYXIS_HTTP_CODE.path)
+
+        note="Task $(context.task.name) failed: Command conftest failed. For details, check Tekton task log."
+        ERROR_OUTPUT=$(make_result_json -r ERROR -n "$POLICY_NAMESPACE" -t "$note")
+        if [[ "$error_counter" == 0 && "$success_counter" > 0 ]];
+        then
+          if [[ "${failure_counter}" -gt 0 ]]; then RES="FAILURE"; else RES="SUCCESS"; fi
+          note="Task $(context.task.name) completed: Check result for task result."
+          TEST_OUTPUT=$(make_result_json \
+            -r "${RES}" -n "$POLICY_NAMESPACE" \
+            -s "${success_counter}" -f "${failure_counter}" -t "$note")
+        fi
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)


### PR DESCRIPTION
As the deprecated-image-check is not sharing any info between the different tasks and only using its own working directory, it doesn't seem to need any PVC to be used from the workspace. 
Hence, the workspace can be removed/replaced with the /tekton/home directory in the build-definitions deprecated-image-check task.