### PR TITLE
remove reference to hacbs-contract quay org

### DIFF
--- a/.tekton/tasks/ec-checks.yaml
+++ b/.tekton/tasks/ec-checks.yaml
@@ -21,7 +21,7 @@ spec:
       $(all_tasks_dir all_tasks-ec)
   - name: validate-all-tasks
     workingDir: "$(workspaces.source.path)"
-    image: quay.io/hacbs-contract/ec-cli:snapshot
+    image: quay.io/enterprise-contract/ec-cli:snapshot
     command: [ec]
     args:
       - validate
@@ -29,15 +29,15 @@ spec:
       - "--file"
       - "./all_tasks-ec"
       - "--policy"
-      - "git::https://github.com/hacbs-contract/ec-policies//policy/task"
+      - "git::https://github.com/enterprise-contract/ec-policies//policy/task"
       - "--policy"
-      - "git::https://github.com/hacbs-contract/ec-policies//policy/lib"
+      - "git::https://github.com/enterprise-contract/ec-policies//policy/lib"
       - "--data"
-      - "git::https://github.com/hacbs-contract/ec-policies//data"
+      - "git::https://github.com/enterprise-contract/ec-policies//data"
       - "--strict"
   - name: validate-build-tasks
     workingDir: "$(workspaces.source.path)"
-    image: quay.io/hacbs-contract/ec-cli:snapshot
+    image: quay.io/enterprise-contract/ec-cli:snapshot
     command: [ec]
     args:
       - validate
@@ -45,11 +45,11 @@ spec:
       - "--file"
       - "./build_tasks-ec"
       - "--policy"
-      - "git::https://github.com/hacbs-contract/ec-policies//policy/build_task"
+      - "git::https://github.com/enterprise-contract/ec-policies//policy/build_task"
       - "--policy"
-      - "git::https://github.com/hacbs-contract/ec-policies//policy/lib"
+      - "git::https://github.com/enterprise-contract/ec-policies//policy/lib"
       - "--data"
-      - "git::https://github.com/hacbs-contract/ec-policies//data"
+      - "git::https://github.com/enterprise-contract/ec-policies//data"
       - "--strict"
   workspaces:
     - name: source

--- a/pipelines/enterprise-contract-everything.yaml
+++ b/pipelines/enterprise-contract-everything.yaml
@@ -62,4 +62,4 @@ spec:
           value: ""
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot@sha256:4ae0ad9ab369b49a86a5c9ffd971e01b3a74ef3cc7bf2c51b0d8f1b8ca198175
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot@sha256:17c3f896f3b1ec9faff7b45f415d3d7c65c4b70e9c5c01e368b1b50f574a7282

--- a/pipelines/enterprise-contract-redhat.yaml
+++ b/pipelines/enterprise-contract-redhat.yaml
@@ -62,4 +62,4 @@ spec:
           value: ""
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot@sha256:4ae0ad9ab369b49a86a5c9ffd971e01b3a74ef3cc7bf2c51b0d8f1b8ca198175
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot@sha256:17c3f896f3b1ec9faff7b45f415d3d7c65c4b70e9c5c01e368b1b50f574a7282

--- a/pipelines/enterprise-contract-slsa1.yaml
+++ b/pipelines/enterprise-contract-slsa1.yaml
@@ -62,4 +62,4 @@ spec:
           value: ""
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot@sha256:4ae0ad9ab369b49a86a5c9ffd971e01b3a74ef3cc7bf2c51b0d8f1b8ca198175
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot@sha256:17c3f896f3b1ec9faff7b45f415d3d7c65c4b70e9c5c01e368b1b50f574a7282

--- a/pipelines/enterprise-contract-slsa2.yaml
+++ b/pipelines/enterprise-contract-slsa2.yaml
@@ -62,4 +62,4 @@ spec:
           value: ""
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot@sha256:4ae0ad9ab369b49a86a5c9ffd971e01b3a74ef3cc7bf2c51b0d8f1b8ca198175
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot@sha256:17c3f896f3b1ec9faff7b45f415d3d7c65c4b70e9c5c01e368b1b50f574a7282

--- a/pipelines/enterprise-contract-slsa3.yaml
+++ b/pipelines/enterprise-contract-slsa3.yaml
@@ -62,4 +62,4 @@ spec:
           value: ""
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot@sha256:4ae0ad9ab369b49a86a5c9ffd971e01b3a74ef3cc7bf2c51b0d8f1b8ca198175
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot@sha256:17c3f896f3b1ec9faff7b45f415d3d7c65c4b70e9c5c01e368b1b50f574a7282

--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -63,4 +63,4 @@ spec:
           value: ""
       taskRef:
         name: verify-enterprise-contract
-        bundle: quay.io/hacbs-contract/ec-task-bundle:snapshot@sha256:4ae0ad9ab369b49a86a5c9ffd971e01b3a74ef3cc7bf2c51b0d8f1b8ca198175
+        bundle: quay.io/enterprise-contract/ec-task-bundle:snapshot@sha256:17c3f896f3b1ec9faff7b45f415d3d7c65c4b70e9c5c01e368b1b50f574a7282

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     },
     {
       "matchPackagePrefixes": [
-        "quay.io/hacbs-contract/"
+        "quay.io/enterprise-contract/"
       ],
       "matchPackageNames": [
         "quay.io/openshift-pipeline/openshift-pipelines-cli-tkn"


### PR DESCRIPTION
This is to remove any reference of hacbs with regard to the enterprise contract.

https://issues.redhat.com/browse/HACBS-2047