### PR TITLE
fix(deprecated-image-check): migration guide to v0.3

### DIFF
--- a/task/deprecated-image-check/0.3/MIGRATION.md
+++ b/task/deprecated-image-check/0.3/MIGRATION.md
@@ -1,10 +1,55 @@
 # Migration from 0.2 to 0.3
 
-Workspace used by the `deprecated-image-check` is removed. This is not required as it doesn't need any PVCs. 
+Workspace used by the `deprecated-image-check` is removed. This is not required as it doesn't need any PVCs.
 
 ## Action from users
 
 Update files in Pull-Request created by RHTAP bot:
 - Search for the task named `deprecated-base-image-check`
-- Remove the workspaces section from [deprecated-image-check.yaml](https://github.com/redhat-appstudio/build-definitions/blob/main/task/deprecated-image-check/0.2/deprecated-image-check.yaml)
-- Replace `$(workspaces.test-ws.path)` with `/tekton/home`
+- Remove the workspaces section from the task
+- Do NOT remove workspaces from the other tasks
+
+Example how the section should look like:
+
+BEFORE:
+```yaml
+  - name: deprecated-base-image-check
+    params:
+    - name: BASE_IMAGES_DIGESTS
+      value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+    taskRef:
+       params:
+       - name: name
+         value: deprecated-image-check
+     #
+     # ...
+     #
+     when:
+     - input: $(params.skip-checks)
+       operator: in
+       values:
+       - "false"
+     workspaces:             # <-- remove this
+     - name: test-ws         # <-- remove this
+       workspace: workspace  # <-- remove this
+```
+
+AFTER:
+```yaml
+  - name: deprecated-base-image-check
+    params:
+    - name: BASE_IMAGES_DIGESTS
+      value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+    taskRef:
+       params:
+       - name: name
+         value: deprecated-image-check
+     #
+     # ...
+     #
+     when:
+     - input: $(params.skip-checks)
+       operator: in
+       values:
+       - "false"
+```


### PR DESCRIPTION
Migration guide was written to udpate tasks, but users must update pipeline definitions in PRs created by bot, there is no task definition there and no updated to task should be done.