### PR TITLE
fix(deprecated-image-check): update versions to correct value

### DIFF
--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "appstudio, hacbs"

--- a/task/deprecated-image-check/0.3/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.3/deprecated-image-check.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "appstudio, hacbs"


### PR DESCRIPTION
New versions of the task didn't have updated version label values