### PR TITLE
fix(RHTAPBUGS-761): show more explanatory message to users

### DIFF
--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -50,8 +50,7 @@ spec:
           SNYK_TOKEN="$(cat ${SNYK_TOKEN_PATH})"
           export SNYK_TOKEN
         else
-          echo 'If you wish to use the Snyk code SAST task, please create a secret named snyk-secret with the key "snyk_token" containing the Snyk token.' | tee stdout.txt
-          note="Task $(context.task.name) skipped: SNYK_TOKEN is empty."
+          note="Task $(context.task.name) skipped: If you wish to use the Snyk code SAST task, please create a secret named snyk-secret with the key "snyk_token" containing the Snyk token."
           TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
           echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
           exit 0


### PR DESCRIPTION
Instead of hiding how to enable snyk task in logs, show it to user in message which can be retrieved from summary and in web UI