### PR TITLE
feat(STONEINTG-425): add unknown vulnerabilities for clair

### DIFF
--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -71,7 +71,8 @@ spec:
               critical: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_critical_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0),
               high: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_high_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0),
               medium: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_medium_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0),
-              low: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_low_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0)
+              low: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_low_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0),
+              unknown: (.[] | .warnings? // [] | map(select(.metadata.details.name=="clair_unknown_vulnerabilities").metadata."vulnerabilities_number" // 0)| add // 0)
             }}' /tekton/home/clair-vulnerabilities.json | tee $(results.CLAIR_SCAN_RESULT.path)
 
         note="Task $(context.task.name) completed: Refer to Tekton task result CLAIR_SCAN_RESULT for vulnerabilities scanned by Clair."


### PR DESCRIPTION
* Add the `unkown` field to clair-scan task output to catch vulnerabilities of Unkown severity level

Example vulnerability output for Unknown severity:
![image](https://github.com/redhat-appstudio/build-definitions/assets/34320458/6b72f4b6-0b93-4c52-b982-19e526b0e4fd)
Example clair-scan task result:
![image](https://github.com/redhat-appstudio/build-definitions/assets/34320458/8fe24d8d-2810-4a4e-a608-38642c1aed49)
