### PR TITLE
fix(STONEINTG-603) remove insecure connection from curl

### DIFF
--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -45,7 +45,7 @@ spec:
           export IMAGE_REPO_PATH=$(workspaces.test-ws.path)/${IMAGE_REPOSITORY}
           mkdir -p ${IMAGE_REPO_PATH}
           echo "Querying Pyxis for $BASE_IMAGE."
-          http_code=$(curl -s -k -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY}/repository/${IMAGE_REPOSITORY}")
+          http_code=$(curl -s -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY}/repository/${IMAGE_REPOSITORY}")
           echo "Response code: $http_code."
           echo $http_code $IMAGE_REGISTRY $IMAGE_REPOSITORY>> $(results.PYXIS_HTTP_CODE.path)
         done

--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -45,7 +45,7 @@ spec:
           export IMAGE_REPO_PATH=$(workspaces.test-ws.path)/${IMAGE_REPOSITORY}
           mkdir -p ${IMAGE_REPO_PATH}
           echo "Querying Pyxis for $BASE_IMAGE."
-          http_code=$(curl -s -k -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY}/repository/${IMAGE_REPOSITORY}")
+          http_code=$(curl -s -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY}/repository/${IMAGE_REPOSITORY}")
           echo "Response code: $http_code."
           echo $http_code $IMAGE_REGISTRY $IMAGE_REPOSITORY>> $(results.PYXIS_HTTP_CODE.path)
         done

--- a/task/deprecated-image-check/0.3/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.3/deprecated-image-check.yaml
@@ -45,7 +45,7 @@ spec:
           export IMAGE_REPO_PATH=/tekton/home/${IMAGE_REPOSITORY}
           mkdir -p ${IMAGE_REPO_PATH}
           echo "Querying Pyxis for $BASE_IMAGE."
-          http_code=$(curl -s -k -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY}/repository/${IMAGE_REPOSITORY}")
+          http_code=$(curl -s -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY}/repository/${IMAGE_REPOSITORY}")
           echo "Response code: $http_code."
           echo $http_code $IMAGE_REGISTRY $IMAGE_REPOSITORY>> $(results.PYXIS_HTTP_CODE.path)
         done


### PR DESCRIPTION
curl -k runs insecure connection to the server. This is a security issue to skip SSL certificate errors by adding -k or --insecure option in curl commands. 
This PR is to remove the -k option from the curl command of the deprecated-image-check