### PR TITLE
fix: bump default build task to 6gb

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -91,7 +91,7 @@ spec:
     name: build
     resources:
       limits:
-        memory: 5Gi
+        memory: 6Gi
         cpu: 2
       requests:
         memory: 512Mi


### PR DESCRIPTION
Despite all the performance WG testing in PR #551, once the switch to memory for the build task /var/lib/containers landed; various builds started to fail because of memory issues.  Before we revert, we are bumping the default some more.

@mmorhun @arewm PTAL

if this does not suffice, we'll revert the change