### PR TITLE
feat(ROX-20233): add fetchTags option to git-clone task

### DIFF
--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -21,7 +21,7 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |gitInitImage|The image providing the git-init binary that this Task runs.|registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8|false|
 |userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden the gitInitImage param with an image containing custom user configuration. |/tekton/home|false|
 |enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.|true|false|
-|fetchTags|Fetch all tags from the remote after git init.|false|false|
+|fetchTags|Fetch all tags for the repo.|false|false|
 
 ## Results
 |name|description|

--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -21,6 +21,7 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |gitInitImage|The image providing the git-init binary that this Task runs.|registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8|false|
 |userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden the gitInitImage param with an image containing custom user configuration. |/tekton/home|false|
 |enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.|true|false|
+|fetchTags|Fetch all tags from the remote after git init.|false|false|
 
 ## Results
 |name|description|

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -80,6 +80,10 @@ spec:
       Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
     name: enableSymlinkCheck
     type: string
+  - default: "false"
+    description: Fetch all tags from the remote after git init.
+    name: fetchTags
+    type: string
   results:
   - description: The precise commit SHA that was fetched by this Task.
     name: commit
@@ -118,6 +122,8 @@ spec:
       value: $(params.sparseCheckoutDirectories)
     - name: PARAM_USER_HOME
       value: $(params.userHome)
+    - name: PARAM_FETCH_TAGS
+      value: $(params.fetchTags)
     - name: WORKSPACE_OUTPUT_PATH
       value: $(workspaces.output.path)
     - name: WORKSPACE_SSH_DIRECTORY_BOUND
@@ -205,6 +211,12 @@ spec:
       fi
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+
+      if [ "${PARAM_FETCH_TAGS}" = "true" ] ; then
+        echo "Fetching tags"
+        git fetch --tags
+      fi
+
   - name: symlink-check
     image: registry.redhat.io/ubi9:9.2-696
     env:

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -81,7 +81,7 @@ spec:
     name: enableSymlinkCheck
     type: string
   - default: "false"
-    description: Fetch all tags from the remote after git init.
+    description: Fetch all tags for the repo.
     name: fetchTags
     type: string
   results:


### PR DESCRIPTION
## Description

ACS builds expect tags to be present in the checked out repository to set the version of the binary with commands like `git describe --tags`.

This PR adds a new parameter to the `git-clone` task to fetch the tags after the initial checkout. 
Because this is not a required parameter and provides a default value, a new version of the task is not needed.

## Testing 

We have tested this change with a custom build pipeline pointing to a self-bundled task with this change. 
Reviewers may find the compiled task bundle in `quay.io/tommartensen/rhtap-tasks@sha256:47190ad64bce76f1b8c50d66089fcd89a4afc80888372b5de61e33d89dd2fa91`. 

Example PipelineRun: https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/roxctl-on-pull-request-t6674.

We fetched build logs as additional proof from a [previous PipelineRun](https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/pipelineruns/roxctl-on-pull-request-zl4z6), which has since been purged from RHTAP. 

### git-clone
```
STEP-CLONE

+ '[' true = true ']'
+ '[' -f /workspace/basic-auth/.git-credentials ']'
+ '[' -f /workspace/basic-auth/.gitconfig ']'
+ cp /workspace/basic-auth/.git-credentials /tekton/home/.git-credentials
+ cp /workspace/basic-auth/.gitconfig /tekton/home/.gitconfig
+ chmod 400 /tekton/home/.git-credentials
+ chmod 400 /tekton/home/.gitconfig
+ '[' false = true ']'
+ CHECKOUT_DIR=/workspace/output/
+ '[' true = true ']'
+ cleandir
+ '[' -d /workspace/output/ ']'
+ rm -rf /workspace/output//lost+found
+ rm -rf '/workspace/output//.[!.]*'
+ rm -rf '/workspace/output//..?*'
+ test -z ''
+ test -z ''
+ test -z ''
+ /ko-app/git-init -url=https://github.com/stackrox/stackrox -revision=7cf5b0061ed64a41084369dae189b8d39cf9edf7 -refspec= -path=/workspace/output/ -sslVerify=true -submodules=true -depth=0 -sparseCheckoutDirectories=
{"level":"info","ts":1696930503.7613628,"caller":"git/git.go:178","msg":"Successfully cloned https://github.com/stackrox/stackrox @ 7cf5b0061ed64a41084369dae189b8d39cf9edf7 (HEAD) in path /workspace/output/"}
{"level":"info","ts":1696930503.8085682,"caller":"git/git.go:217","msg":"Successfully initialized and updated submodules in path /workspace/output/"}
+ cd /workspace/output/
++ git rev-parse HEAD
+ RESULT_SHA=7cf5b0061ed64a41084369dae189b8d39cf9edf7
+ EXIT_CODE=0
+ '[' 0 '!=' 0 ']'
+ printf %s 7cf5b0061ed64a41084369dae189b8d39cf9edf7
+ printf %s https://github.com/stackrox/stackrox
+ '[' true = true ']'
Fetching tags
+ echo 'Fetching tags'
+ git fetch --tags
From https://github.com/stackrox/stackrox
 * [new branch]            3.73.x-cloud-fix        -> origin/3.73.x-cloud-fix
 * [new branch]            C                       -> origin/C
 * [new branch]            D                       -> origin/D
 * [new branch]            Limit-@dependabot-Go-PRs-to-1 -> origin/Limit-@dependabot-Go-PRs-to-1
 * [new branch]            ROX-10310-generate      -> origin/ROX-10310-generate
 [...OUTPUT CROPPED...]
 * [new branch]            yury/test-disable-owner-ref-injection -> origin/yury/test-disable-owner-ref-injection
 * [new tag]               0.0.2                   -> 0.0.2
 * [new tag]               3.0.50.0                -> 3.0.50.0
 * [new tag]               3.0.50.1                -> 3.0.50.1
 * [new tag]               3.0.51.0                -> 3.0.51.0
 * [new tag]               3.0.51.1                -> 3.0.51.1
 [...OUTPUT CROPPED...]
 * [new tag]               operator-3.68.0-rc.9    -> operator-3.68.0-rc.9


STEP-SYMLINK-CHECK

Running symlink check
```

The output shows that the parameter value `"true"` triggered the option and all tags were fetched. The output also shows that branches were fetched - the `build-container` output however shows only the checked out branch present. 

### build-container

```
STEP-BUILD

[1/2] STEP 1/6: FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
[...OUTPUT CROPPED...]
[1/2] STEP 2/6: WORKDIR /go/src/github.com/stackrox/rox/app
[1/2] STEP 3/6: COPY . .
[1/2] STEP 4/6: RUN git config --global --add safe.directory /go/src/github.com/stackrox/rox/app &&     echo "BRANCHES:" &&     git branch -l &&     echo "TAGS:" &&     git tag -l &&     mkdir -p image/bin
BRANCHES:
* (HEAD detached at 7cf5b0061e)
TAGS:
0.0.2
3.0.50.0
3.0.50.1
3.0.51.0
[...OUTPUT CROPPED...]
operator-3.68.0-rc.6
operator-3.68.0-rc.7
operator-3.68.0-rc.8
operator-3.68.0-rc.9
[1/2] STEP 5/6: ENV CI=1 GOFLAGS="" GOTAGS="release"
[1/2] STEP 6/6: RUN RACE=0 CGO_ENABLED=1 GOOS=linux GOARCH=$(go env GOARCH) BUILD_TAG=$(make tag) scripts/go-build.sh ./roxctl &&     cp bin/linux_$(go env GOARCH)/roxctl image/bin/roxctl
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./roxctl to bin/linux_amd64/roxctl
go: downloading github.com/spf13/cobra v1.7.0
[...OUTPUT CROPPED...]
```

This shows that only the initially fetched branch (of the checked out revision) is present, and all tags have been fetched.

### Artifacts

The pipeline produced the image `quay.io/redhat-user-workloads/rh-acs-tenant/acs/roxctl:on-pr-7cf5b0061ed64a41084369dae189b8d39cf9edf7` for https://github.com/stackrox/stackrox/commit/7cf5b0061ed64a41084369dae189b8d39cf9edf7. 

```bash
$ docker run quay.io/redhat-user-workloads/rh-acs-tenant/acs/roxctl:on-pr-7cf5b0061ed64a41084369dae189b8d39cf9edf7 version
4.2.x-330-g7cf5b0061e-dirty
$ git checkout 7cf5b0061ed64a41084369dae189b8d39cf9edf7
$ git describe --tags --abbrev=10 --dirty --long --exclude '*-nightly-*'
4.2.x-330-g7cf5b0061e
```

Ignoring the `--dirty` suffix which was added because some files were not copied to the container due to our `.containerignore` file, the versions match as expected. 