### PR TITLE
Attempt to fix build-bundles step

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -66,7 +66,7 @@ spec:
             - name: build-bundles
               image: quay.io/redhat-appstudio/appstudio-utils:{{ revision }}
               workingDir: $(workspaces.source.path)
-              command: ["./hack/build-and-push.sh"]
+              command: ["hack/build-and-push.sh"]
               env:
                 - name: MY_QUAY_USER
                   value: redhat-appstudio-tekton-catalog


### PR DESCRIPTION
Recently the CI has started to fail with the error: Error executing command: fork/exec ./hack/build-and-push.sh: no such file or directory

Presumably, this is due to a change in behavior in Tekton. This is an attempt to fix the error by removing `./` from the command path.