### PR TITLE
Use /source subdir in build-bundles task

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -66,7 +66,7 @@ spec:
             - name: build-bundles
               image: quay.io/redhat-appstudio/appstudio-utils:{{ revision }}
               workingDir: $(workspaces.source.path)
-              command: ["hack/build-and-push.sh"]
+              command: ["./hack/build-and-push.sh"]
               env:
                 - name: MY_QUAY_USER
                   value: redhat-appstudio-tekton-catalog

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -65,7 +65,7 @@ spec:
           steps:
             - name: build-bundles
               image: quay.io/redhat-appstudio/appstudio-utils:{{ revision }}
-              workingDir: $(workspaces.source.path)
+              workingDir: $(workspaces.source.path)/source
               command: ["./hack/build-and-push.sh"]
               env:
                 - name: MY_QUAY_USER


### PR DESCRIPTION
A [previous change](https://github.com/redhat-appstudio/build-definitions/commit/0765369ae500ce4240f3a09dd0b9e8b5e20a9450) updated the git-clone task to clone repositories into a subdir which has the default value of `source`. The build-bundles task was missed during that update.