### PR TITLE
fix(STONEINTG-626): add runafter to deprecated-base-image-check

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -148,6 +148,8 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      runAfter:
+        - build-container
     - name: clair-scan
       when:
       - input: $(params.skip-checks)


### PR DESCRIPTION
* add runafter to task deprecated-base-image-check

Signed-off-by: Hongwei Liu <hongliu@redhat.com>