### PR TITLE
fix: change sh back to bash in task deprecated-image-check

### DIFF
--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -35,7 +35,7 @@ spec:
         - name: BASE_IMAGES_DIGESTS
           value: $(params.BASE_IMAGES_DIGESTS)
       script: |
-        #!/usr/bin/env sh
+        #!/usr/bin/env bash
         set -euo pipefail
         source /utils.sh
         trap 'handle_error' EXIT

--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -35,7 +35,7 @@ spec:
         - name: BASE_IMAGES_DIGESTS
           value: $(params.BASE_IMAGES_DIGESTS)
       script: |
-        #!/usr/bin/env sh
+        #!/usr/bin/env bash
         set -euo pipefail
         source /utils.sh
         trap 'handle_error' EXIT

--- a/task/deprecated-image-check/0.3/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.3/deprecated-image-check.yaml
@@ -35,7 +35,7 @@ spec:
         - name: BASE_IMAGES_DIGESTS
           value: $(params.BASE_IMAGES_DIGESTS)
       script: |
-        #!/usr/bin/env sh
+        #!/usr/bin/env bash
         set -euo pipefail
         source /utils.sh
         trap 'handle_error' EXIT


### PR DESCRIPTION
Changing `bash` to `sh` in [PR](https://github.com/redhat-appstudio/build-definitions/commit/f18be5eb68f613e6168b0f7c8d666682b04baa47#diff-91bba1c97642720c1a3c3afd61f64b72f7b53bf70f5f10b6d9f5d095687159adR38) makes command `readarray -t IMAGE_ARRAY < <(echo -n "$BASE_IMAGES_DIGESTS" | sed 's/\\n/\'$'\n''/g')` fail with error as below
```
unexpected token `<'
Unexpected error: Script errored at command: trap 'handle_error' EXIT.
```
So let's rollback the change.
With the fix, it can pass like this:
```
step-query-pyxis
[registry.access.redhat.com] [ubi8/ubi:8.8-1067.1696517599@sha256:dd3ea588640fd91ea85f6324df14627b2f8ad52ac55ecd907ca3201cd78667e6]
Querying Pyxis for registry.access.redhat.com/ubi8/ubi:8.8-1067.1696517599@sha256:dd3ea588640fd91ea85f6324df14627b2f8ad52ac55ecd907ca3201cd78667e6.
Response code: 200.

step-run-conftest
[200] [registry.access.redhat.com] [ubi8/ubi]
Running conftest using /project/repository/ policy, required_checks namespace.
[
	{
		"filename": "/tekton/home/ubi8/ubi/repository_data.json",
		"namespace": "required_checks",
		"successes": 1
	}
]
{"result":"SUCCESS","timestamp":"1697706387","note":"Task deprecated-image-check completed: Check result for task result.","namespace":"required_checks","successes":1,"failures":0,"warnings":0}
```

Signed-off-by: Hongwei Liu <hongliu@redhat.com>