### PR TITLE
fix(STONEINTG-626): add runAfter to fbc-validate task

### DIFF
--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -36,6 +36,8 @@
     - input: $(params.skip-checks)
       operator: in
       values: ["false"]
+    runAfter:
+      - inspect-image
     taskRef:
       name: fbc-validation
       version: "0.1"


### PR DESCRIPTION
This change fixes the issue of the fbc-validate task running before the inspect-image task finishes.