### PR TITLE
fix(STONEINTG-662): fix jq command for config label in fbc-validate

### DIFF
--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -94,7 +94,7 @@ spec:
         fi
 
         status=0
-        conffolder=$(jq -f ../inspect-image/image_inspect.json -r '.Labels ."operators.operatorframework.io.index.configs.v1"') || status=$?
+        conffolder=$(jq -r '.Labels ."operators.operatorframework.io.index.configs.v1"' ../inspect-image/image_inspect.json) || status=$?
         if [ $status -ne 0 ]; then
           echo "Could not get labels from inspect-image/image_inspect.json. Make sure file exists and it contains this label: operators.operatorframework.io.index.configs.v1."
           TEST_OUTPUT="$(make_result_json -r ERROR)"


### PR DESCRIPTION
* Remove usage of -f option and set image_inspect.json as the file parameter

Before the change, the jq command failed with this output in the task log:
![image](https://github.com/redhat-appstudio/build-definitions/assets/34320458/25b39f7f-fcb3-4391-98ac-499daec9cd3c)

After this change, the task is able to run correctly and validate the FBC image:
![image](https://github.com/redhat-appstudio/build-definitions/assets/34320458/ba627f75-42a6-4407-9846-3879088e7e40)
