### PR TITLE
Fixing inconsistencies in utilization of source directory

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -279,7 +279,7 @@ spec:
       with open("./sbom-image.json") as f:
         image_sbom = json.load(f)
 
-      with open("./sbom-source.json") as f:
+      with open("./source/sbom-source.json") as f:
         source_sbom = json.load(f)
 
       # fetch unique components from available SBOMs

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -220,7 +220,7 @@ spec:
       with open("./sbom-image.json") as f:
         image_sbom = json.load(f)
 
-      with open("./sbom-source.json") as f:
+      with open("./source/sbom-source.json") as f:
         source_sbom = json.load(f)
 
       # fetch unique components from available SBOMs

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -180,7 +180,7 @@ spec:
       with open("./sbom-image.json") as f:
         image_sbom = json.load(f)
 
-      with open("./sbom-source.json") as f:
+      with open("./source/sbom-source.json") as f:
         source_sbom = json.load(f)
 
       # fetch unique components from available SBOMs

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -147,7 +147,7 @@ spec:
       with open("./sbom-image.json") as f:
         image_sbom = json.load(f)
 
-      with open("./sbom-source.json") as f:
+      with open("./source/sbom-source.json") as f:
         source_sbom = json.load(f)
 
       # fetch unique components from available SBOMs


### PR DESCRIPTION
When cloning source code into a dedicated directory (#586), the ramifications of this change on the generated SBOM data was missed. This PR ensures that we have the proper source SBOM data for merging.