### PR TITLE
Use correct data source for ec-checks

### DIFF
--- a/.tekton/tasks/ec-checks.yaml
+++ b/.tekton/tasks/ec-checks.yaml
@@ -49,7 +49,7 @@ spec:
       - "--policy"
       - "git::https://github.com/enterprise-contract/ec-policies//policy/lib"
       - "--data"
-      - "git::https://github.com/enterprise-contract/ec-policies//data"
+      - "git::https://github.com/release-engineering/rhtap-ec-policy//data"
       - "--strict"
   workspaces:
     - name: source


### PR DESCRIPTION
A previous commit missed updating one reference to the deprecated EC data source.