### PR TITLE
Do not use in-memory emptyDir for source-build task

### DIFF
--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -33,14 +33,13 @@ spec:
       description: The workspace where source code is included.
   volumes:
     - name: source-build-work-place
-      emptyDir:
-        medium: Memory
+      emptyDir: {}
   steps:
     - name: build
       image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils:latest
       resources:
         limits:
-          memory: 8Gi
+          memory: 2Gi
           cpu: 1
         requests:
           memory: 512Mi


### PR DESCRIPTION
Meanwhile, lower the resources.limits.memory.

Haven't noticed the revert PR https://github.com/redhat-appstudio/build-definitions/pull/612 during the review of https://github.com/redhat-appstudio/build-definitions/pull/621. Thanks for the reminding by @mmorhun 