### PR TITLE
WIP: DIY Trusted Artifacts

### DIFF
--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -30,6 +30,8 @@
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+  - name: SOURCE
+    value: "$(tasks.clone-repository.results.source)"
 - op: add
   path: /spec/results/-
   value:

--- a/task/buildah-10gb/0.1/patch.yaml
+++ b/task/buildah-10gb/0.1/patch.yaml
@@ -2,8 +2,8 @@
   path: /metadata/name
   value: buildah-10gb
 - op: replace
-  path: /spec/steps/0/resources/limits/memory
+  path: /spec/steps/2/resources/limits/memory
   value: 10.1Gi
 - op: replace
-  path: /spec/steps/0/resources/requests/memory
+  path: /spec/steps/2/resources/requests/memory
   value: 8Gi

--- a/task/buildah-6gb/0.1/patch.yaml
+++ b/task/buildah-6gb/0.1/patch.yaml
@@ -2,8 +2,8 @@
   path: /metadata/name
   value: buildah-6gb
 - op: replace
-  path: /spec/steps/0/resources/limits/memory
+  path: /spec/steps/2/resources/limits/memory
   value: 6.1Gi
 - op: replace
-  path: /spec/steps/0/resources/requests/memory
+  path: /spec/steps/2/resources/requests/memory
   value: 4Gi

--- a/task/buildah-8gb/0.1/patch.yaml
+++ b/task/buildah-8gb/0.1/patch.yaml
@@ -2,8 +2,8 @@
   path: /metadata/name
   value: buildah-8gb
 - op: replace
-  path: /spec/steps/0/resources/limits/memory
+  path: /spec/steps/2/resources/limits/memory
   value: 8.1Gi
 - op: replace
-  path: /spec/steps/0/resources/requests/memory
+  path: /spec/steps/2/resources/requests/memory
   value: 6Gi

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -54,6 +54,15 @@ spec:
     description: The image is built from this commit.
     type: string
     default: ""
+  - name: SOURCE
+    type: object
+    properties:
+      path:
+        type: string
+      hash:
+        type: string
+      type:
+        type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -89,6 +98,32 @@ spec:
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.IMAGE_EXPIRES_AFTER)
   steps:
+  - name: get-source-archive
+    image: quay.io/lucarval/trusted-artifacts-demo@sha256:a14a655d2675754e2c92a8382f68acc622b5184ca2e4d8e1aef27b3aad52b333
+    command: ["consume-archive"]
+    args:
+      - $(workspaces.source.path)/$(params.SOURCE.path)
+      - $(params.SOURCE.hash)
+      - /var/run/safesource
+    volumeMounts:
+    - mountPath: /var/run/safesource
+      name: safesource
+    # This means this is the only step that has access to the workspace. At least that's how it's
+    # supposed to work. Not sure if it is.
+    # https://tekton.dev/docs/pipelines/workspaces/#isolating-workspaces-to-specific-steps-or-sidecars
+    workspaces:
+    - name: source
+
+  # TODO: This is meant for initial debugging. Remove this eventually.
+  - name: show-source-archive
+    image: registry.access.redhat.com/ubi9:latest
+    script: |
+      set -euo pipefail
+      find /var/run/safesource/
+    volumeMounts:
+    - mountPath: /var/run/safesource
+      name: safesource
+
   - image: $(params.BUILDER_IMAGE)
     name: build
     resources:
@@ -102,6 +137,9 @@ spec:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
     script: |
+      echo "Anything in a workspace?"
+      find "$(workspaces.source.path)" || true
+
       SOURCE_CODE_DIR=source
       if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
         dockerfile_path="$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
@@ -186,22 +224,28 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
-    workingDir: $(workspaces.source.path)
+    - mountPath: /var/run/safesource
+      name: safesource
+    # TODO: Is there a variable like $(volumes.safesource.path) ?
+    workingDir: /var/run/safesource
 
   - name: sbom-syft-generate
     image: quay.io/redhat-appstudio/syft:v0.94.0
     script: |
-      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      syft dir:/var/run/safesource/source --output cyclonedx-json=/var/run/safesource/sbom-source.json
       find $(cat /workspace/container_path) -xtype l -delete
-      syft dir:$(cat /workspace/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+      syft dir:$(cat /workspace/container_path) --output cyclonedx-json=/var/run/safesource/sbom-image.json
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
+    - mountPath: /var/run/safesource
+      name: safesource
+
   - name: analyse-dependencies-java-sbom
     image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:1d417e6f1f3e68c6c537333b5759796eddae0afc
     script: |
       if [ -f /var/lib/containers/java ]; then
-        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /workspace/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /workspace/container_path) -s /var/run/safesource/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
         sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
       else
         touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
@@ -209,6 +253,8 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
+    - mountPath: /var/run/safesource
+      name: safesource
     securityContext:
       runAsUser: 0
 
@@ -242,7 +288,10 @@ spec:
       # write the CycloneDX unified SBOM
       with open("./sbom-cyclonedx.json", "w") as f:
         json.dump(image_sbom, f, indent=4)
-    workingDir: $(workspaces.source.path)
+    volumeMounts:
+    - mountPath: /var/run/safesource
+      name: safesource
+    workingDir: /var/run/safesource
     securityContext:
       runAsUser: 0
 
@@ -256,7 +305,10 @@ spec:
       else
         echo "Skipping step since no Cachi2 SBOM was produced"
       fi
-    workingDir: $(workspaces.source.path)
+    volumeMounts:
+    - mountPath: /var/run/safesource
+      name: safesource
+    workingDir: /var/run/safesource
     securityContext:
       runAsUser: 0
 
@@ -274,7 +326,10 @@ spec:
 
       with open("sbom-purl.json", "w") as output_file:
         json.dump(purl_content, output_file, indent=4)
-    workingDir: $(workspaces.source.path)
+    volumeMounts:
+    - mountPath: /var/run/safesource
+      name: safesource
+    workingDir: /var/run/safesource
     securityContext:
       runAsUser: 0
 
@@ -301,7 +356,7 @@ spec:
         echo "Pushing sbom image to registry"
         buildah push \
           --tls-verify=$TLSVERIFY \
-          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          --digestfile /var/run/safesource/image-digest $IMAGE \
           docker://$IMAGE && break || status=$?
       done
       if [ "$status" -ne 0 ]; then
@@ -309,7 +364,7 @@ spec:
           exit 1
       fi
 
-      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      cat /var/run/safesource/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
 
       # Remove tag from IMAGE while allowing registry to contain a port number.
@@ -326,7 +381,9 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
-    workingDir: $(workspaces.source.path)
+    - mountPath: /var/run/safesource
+      name: safesource
+    workingDir: /var/run/safesource
 
   - name: upload-sbom
     image: quay.io/redhat-appstudio/cosign:v2.1.1
@@ -338,11 +395,16 @@ spec:
       - --type
       - cyclonedx
       - $(params.IMAGE)
-    workingDir: $(workspaces.source.path)
+    volumeMounts:
+    - mountPath: /var/run/safesource
+      name: safesource
+    workingDir: /var/run/safesource
 
   volumes:
   - emptyDir: {}
     name: varlibcontainers
+  - emptyDir: {}
+    name: safesource
   workspaces:
   - name: source
     description: Workspace containing the source code to build.

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -89,6 +89,16 @@ spec:
     name: commit
   - description: The precise URL that was fetched by this Task.
     name: url
+  - name: source
+    type: object
+    description: The archive with the clone repo contents
+    properties:
+      path:
+        type: string
+      hash:
+        type: string
+      type:
+        type: string
   steps:
   - name: clone
     env:
@@ -251,6 +261,22 @@ spec:
         echo "Running symlink check"
         check_symlinks
       fi
+
+  - name: produce-archive
+    image: quay.io/lucarval/trusted-artifacts-demo@sha256:a14a655d2675754e2c92a8382f68acc622b5184ca2e4d8e1aef27b3aad52b333
+    command: ["produce-archive"]
+    args:
+      - $(workspaces.output.path)/$(params.subdirectory)
+      - source.tar.gz
+      - $(results.source.path)
+    workingDir: $(workspaces.output.path)
+
+  - name: delete-raw-source
+    image: registry.access.redhat.com/ubi9:latest
+    script: |
+      set -euo pipefail
+      rm -rvf $(workspaces.output.path)/source
+
   workspaces:
   - description: The git repo will be cloned onto the volume backing this Workspace.
     name: output


### PR DESCRIPTION
This PR modifies the git-clone and the buildah task to use a pattern that ensures the buildah task is using the unmodified contents of the git repo cloned by the git-clone task.

There is an ongoing effort in the Tekton community to introduce the concept of trusted artifacts, TEP-0130
https://github.com/tektoncd/community/pull/1044

This change is directly influenced by that effort.

The approach taken here is a stop gap until the platform, i.e. Tekton, supports the idea of trusted artifacts natively.

Here's how it works...

I created a couple of little bash scripts to encapsulate producing and consuming an artifact: https://github.com/lcarva/trusted-artifacts These are available in the image: https://quay.io/lucarval/trusted-artifacts-demo This is meant to make it easier to use them in a Tekton task, instead of just stuffing bash scripts all over the place.

The creation of an artifact is pretty simple. It just creates a tarball containing whichever files are deemed part of the artifact. In this case, the artifact is the directory containing a cloned git repo.

The consumption of the artifact is the inverse. It extracts the tarball into a certain location. There are two things that make this step essential.

First, the hash of the archive must match what is expected. Otherwise, the consumption step fails.

Second, the archive is extracted to an emptyDir volume which is only accessible by a single Task. This means once the archive is consumed, no other Tasks can influence its contents. This avoids certain issues with Time of Check vs Time of Usage, (think parallel tasks sharing a workspace).

The SLSA Provenance generated for a PipelineRun using these tasks records the results of the git-clone task, and the parameters for the buildah task. This allows us to create policies that ensure the buildah task used the exact archive the git-clone task produced.

I was able to run this in production and produce an image, e.g. quay.io/redhat-user-workloads/lucarval-tenant/devfile-sample-code-with-quarkus/devfile-sample-code-with-quarkus:3e33c4d702b468aaa46751dc94cf8de5d5233e67

Here's what the SLSA Provenance says for the git-clone task results:

```
$ < /tmp/attestation.json jq '.payload | @base64d | fromjson | .predicate.buildConfig.tasks[] | select(.name == "clone-repository").results[] | select(.name=="source").value.hash'
"6d99e197c4bda4564211943f774561cf85fd0e2ab33226b34eb73d60edaac7aa"
```

And here's what it says for the parameters of the buildah task:

```
$ < /tmp/attestation.json jq '.payload | @base64d | fromjson | .predicate.buildConfig.tasks[] | select(.name == "build-container").invocation.parameters.SOURCE.hash'
"6d99e197c4bda4564211943f774561cf85fd0e2ab33226b34eb73d60edaac7aa"
```

Why bother with this change? This is about ensuring certain segments of the Pipeline are protected. Today, EC expects all the Tasks on the Pipeline to be trusted. This is secure, but it's very rigid. It's not possible for someone to run, for example, a custom Taks to run unit tests between git-clone and buildah without also customizing the organization policy. The proposed changes here would allow EC to be more specific on what it checks instead of just using a general umbrella.

This change is a proof of concept. So it may not fully work as expected. But hopefully it's enough to help us decide on whether or not to move forward with this.