### PR TITLE
Don't fail when image sbom does not contain components

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -286,15 +286,16 @@ spec:
       def get_identifier(component):
         return component["name"] + '@' + component.get("version", "")
 
-      existing_components = [get_identifier(component) for component in image_sbom["components"]]
+      image_sbom_components = image_sbom.get("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
 
       source_sbom_components = source_sbom.get("components", [])
       for component in source_sbom_components:
         if get_identifier(component) not in existing_components:
-          image_sbom["components"].append(component)
+          image_sbom_components.append(component)
           existing_components.append(get_identifier(component))
 
-      image_sbom["components"].sort(key=lambda c: get_identifier(c))
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
 
       # write the CycloneDX unified SBOM
       with open("./sbom-cyclonedx.json", "w") as f:
@@ -326,7 +327,7 @@ spec:
       with open("./sbom-cyclonedx.json") as f:
         cyclonedx_sbom = json.load(f)
 
-      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom["components"] if "purl" in component]
+      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
       purl_content = {"image_contents": {"dependencies": purls}}
 
       with open("sbom-purl.json", "w") as output_file:

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -229,15 +229,16 @@ spec:
       def get_identifier(component):
         return component["name"] + '@' + component.get("version", "")
 
-      existing_components = [get_identifier(component) for component in image_sbom["components"]]
+      image_sbom_components = image_sbom.get("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
 
       source_sbom_components = source_sbom.get("components", [])
       for component in source_sbom_components:
         if get_identifier(component) not in existing_components:
-          image_sbom["components"].append(component)
+          image_sbom_components.append(component)
           existing_components.append(get_identifier(component))
 
-      image_sbom["components"].sort(key=lambda c: get_identifier(c))
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
 
       # write the CycloneDX unified SBOM
       with open("./sbom-cyclonedx.json", "w") as f:
@@ -269,7 +270,7 @@ spec:
       with open("./sbom-cyclonedx.json") as f:
         cyclonedx_sbom = json.load(f)
 
-      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom["components"] if "purl" in component]
+      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
       purl_content = {"image_contents": {"dependencies": purls}}
 
       with open("sbom-purl.json", "w") as output_file:

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -189,22 +189,23 @@ spec:
       def get_identifier(component):
         return component["name"] + '@' + component.get("version", "")
 
-      existing_components = [get_identifier(component) for component in image_sbom["components"]]
+      image_sbom_components = image_sbom.get("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
 
       source_sbom_components = source_sbom.get("components", [])
       for component in source_sbom_components:
         if get_identifier(component) not in existing_components:
-          image_sbom["components"].append(component)
+          image_sbom_components.append(component)
           existing_components.append(get_identifier(component))
 
-      image_sbom["components"].sort(key=lambda c: get_identifier(c))
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
 
       # write the CycloneDX unified SBOM
       with open("./sbom-cyclonedx.json", "w") as f:
         json.dump(image_sbom, f, indent=4)
 
       # create and write the PURL unified SBOM
-      purls = [{"purl": component["purl"]} for component in image_sbom["components"] if "purl" in component]
+      purls = [{"purl": component["purl"]} for component in image_sbom_components if "purl" in component]
       purl_content = {"image_contents": {"dependencies": purls}}
 
       with open("sbom-purl.json", "w") as output_file:

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -156,22 +156,23 @@ spec:
       def get_identifier(component):
         return component["name"] + '@' + component.get("version", "")
 
-      existing_components = [get_identifier(component) for component in image_sbom["components"]]
+      image_sbom_components = image_sbom.get("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
 
       source_sbom_components = source_sbom.get("components", [])
       for component in source_sbom_components:
         if get_identifier(component) not in existing_components:
-          image_sbom["components"].append(component)
+          image_sbom_components.append(component)
           existing_components.append(get_identifier(component))
 
-      image_sbom["components"].sort(key=lambda c: get_identifier(c))
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
 
       # write the CycloneDX unified SBOM
       with open("./sbom-cyclonedx.json", "w") as f:
         json.dump(image_sbom, f, indent=4)
 
       # create and write the PURL unified SBOM
-      purls = [{"purl": component["purl"]} for component in image_sbom["components"] if "purl" in component]
+      purls = [{"purl": component["purl"]} for component in image_sbom_components if "purl" in component]
       purl_content = {"image_contents": {"dependencies": purls}}
 
       with open("sbom-purl.json", "w") as output_file:


### PR DESCRIPTION
In previous versions of syft, if the image did not contain any components, the field was empty list:

  "components": []

But in newer versions, the field is omitted completely.