### PR TITLE
Emit BASE_IMAGES_DIGESTS result from separate step

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -179,6 +179,9 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
+      # Expose base image digests
+      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
+
     securityContext:
       capabilities:
         add:
@@ -283,9 +286,6 @@ spec:
     image: $(params.BUILDER_IMAGE)
     resources: {}
     script: |
-      # Expose base image digests
-      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
-
       base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
       base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
       container=$(buildah from --pull-never $IMAGE)


### PR DESCRIPTION
Tekton results have a size limit, see
https://tekton.dev/docs/pipelines/tasks/ (search for "termination messages").

The overall limit for a Task is 4096 bytes, but the limit for each *step* within a task is lower. And the more steps a task has, the lower the per-step limit.

The inject-sbom-and-push step emits too many results. The most problematic one is BASE_IMAGES_DIGESTS, which is a newline-separated list of the base images for all the stages of an image build.

Move the BASE_IMAGES_DIGESTS to a separate step to reduce the chance of hitting the size limit.

This is a temporary solution at best, we will need to work out a better way to pass data between tasks.