### PR TITLE
Revert "Emit SBOM_BLOB_URL result on build tasks"

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -66,8 +66,6 @@ spec:
     type: string
   - name: JAVA_COMMUNITY_DEPENDENCIES
     description: The Java dependencies that came from community sources such as Maven central.
-  - name: SBOM_BLOB_URL
-    description: Reference, including digest to the SBOM blob
   stepTemplate:
     env:
     - name: BUILDAH_FORMAT
@@ -312,12 +310,6 @@ spec:
 
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-
-      # Remove tag from IMAGE while allowing registry to contain a port number.
-      sbom_repo="${IMAGE%:*}"
-      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
-      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
-      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee $(results.SBOM_BLOB_URL.path)
 
     securityContext:
       runAsUser: 0

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -59,8 +59,6 @@ spec:
     type: string
   - name: JAVA_COMMUNITY_DEPENDENCIES
     description: The Java dependencies that came from community sources such as Maven central.
-  - name: SBOM_BLOB_URL
-    description: Reference, including digest to the SBOM blob
   stepTemplate:
     env:
     - name: BUILDAH_FORMAT
@@ -234,12 +232,6 @@ spec:
         docker://$IMAGE
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-
-      # Remove tag from IMAGE while allowing registry to contain a port number.
-      sbom_repo="${IMAGE%:*}"
-      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
-      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
-      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee $(results.SBOM_BLOB_URL.path)
 
     securityContext:
       runAsUser: 0

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -68,8 +68,6 @@ spec:
     name: IMAGE_URL
   - description: Digests of the base images used for build
     name: BASE_IMAGES_DIGESTS
-  - name: SBOM_BLOB_URL
-    description: Reference, including digest to the SBOM blob
   steps:
   - name: generate
     image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:e518e05a730ae066e371a4bd36a5af9cedc8686fd04bd59648d20ea0a486d7e5
@@ -201,12 +199,6 @@ spec:
         docker://$IMAGE
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-
-      # Remove tag from IMAGE while allowing registry to contain a port number.
-      sbom_repo="${IMAGE%:*}"
-      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
-      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
-      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee $(results.SBOM_BLOB_URL.path)
 
     securityContext:
       runAsUser: 0


### PR DESCRIPTION
This reverts commit a26fa79cde9fd37cf7fa4f58fcf83080b9780e05.

The additional result is causing the max Tekton result size to be reached which causes pipeline failures. Let's revert this change until we come up with an alternative idea.

Ref: RHTAPBUGS-935