### PR TITLE
Add --debug to ec track command

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -135,7 +135,7 @@ spec:
                 DATA_BUNDLE_REPO='quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles'
 
                 # Update the OPA data bundle.
-                ec track bundle \
+                ec track bundle --debug \
                   --input "oci:${DATA_BUNDLE_REPO}:latest" \
                   --output "oci:${DATA_BUNDLE_REPO}:${TAG}" \
                   --freshen \


### PR DESCRIPTION
We have noticed that some content is missing from the OPA bundle maintained by the `ec track bundle` command. This will help us debug what is going on.

Ref: [EC-230](https://issues.redhat.com//browse/EC-230)