### PR TITLE
tasks/rpm-ostree: Support older rpm-ostree

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Tasks are bundled and pushed into repositories prefixed with `task-` and tagged 
 
 Currently a set of utilities are bundled with App Studio in `quay.io/redhat-appstudio/appstudio-utils:$GIT_SHA` as a convenience but tasks may be run from different per-task containers.
 
+
 ## Building
 
 Script `hack/build-and-push.sh` creates bundles for pipelines, tasks and create appstudio-utils image. Images are pushed into your quay.io repository. You will need to set `MY_QUAY_USER` to use this feature and be logged into quay.io on your workstation.

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -105,7 +105,7 @@ spec:
       #!/bin/sh
       set -o verbose
       cd $(workspaces.source.path)
-      rpm-ostree compose image --initialize-mode always --format oci "source/$IMAGE_FILE" rhtap-final-image
+      rpm-ostree compose image --initialize --format oci "source/$IMAGE_FILE" rhtap-final-image
 
       REMOTESSHEOF
       chmod +x scripts/script-build.sh


### PR DESCRIPTION
The `--initialize-mode` argument is only in newer releases; this ensures we work with current c9s.