### PR TITLE
Adds --prune to remove older entries

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -141,6 +141,7 @@ spec:
                   --input "oci:${DATA_BUNDLE_REPO}:latest" \
                   --output "oci:${DATA_BUNDLE_REPO}:${TAG}" \
                   --freshen \
+                  --prune \
                   ${BUNDLES_PARAM[@]}
 
                 # To facilitate usage in some contexts, tag the image with the floating "latest" tag.


### PR DESCRIPTION
Without `--prune` the acceptable bundles data image only increases in
size.

Also builds on https://github.com/redhat-appstudio/build-definitions/pull/661 to ease merging.

Ref. https://issues.redhat.com/browse/EC-220