### PR TITLE
Trigger an update of the source-build Task

### DIFF
--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "appstudio"
+
 spec:
   description: Source image build.
   params:


### PR DESCRIPTION
This commit adds a no-op change to the source-build Task in order to debug an issue with how acceptable bundles are being tracked by EC.

Ref: EC-230