### PR TITLE
Fix EC task to get bundles from correct location

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -121,10 +121,12 @@ spec:
                 set -euo pipefail
 
                 BUNDLES=(
-                  $(workspaces.artifacts.path)/task-bundle-list
-                  $(workspaces.artifacts.path)/pipeline-bundle-list
+                  $(workspaces.artifacts.path)/source/task-bundle-list
+                  $(workspaces.artifacts.path)/source/pipeline-bundle-list
                 )
                 touch ${BUNDLES[@]}
+                echo "Bundles to be added:"
+                cat ${BUNDLES[@]}
                 BUNDLES_PARAM=($(cat ${BUNDLES[@]} | awk '{ print "--bundle=" $0 }'))
 
                 # The OPA data bundle is tagged with the current timestamp. This has two main

--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -8,7 +8,6 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "appstudio"
-
 spec:
   description: Source image build.
   params:


### PR DESCRIPTION
At some point, the git-clone Task was modified to clone repositories into the `/source` sub-directory. As part of that work, the `build-bundles` Task in the push PipelineRun started emitting the task-bundle-list and the pipeline-bundle-list files also under the `/source` sub-directory. However, the task build-acceptable-bundles was not updated with the new location. This caused that Task to never pick up new bundles. This went unperceived because the Task has functionality to query the registry for any bundles that it may have missed. This, of course, only works if the repo for the bundle is already in the list. New repos for new bundles were completely skipped.

This commit changes the build-acceptable-bundles to look for the expected bundle reference files in the updated location.

It also adds a debug message listing all the bundle references that are going to be added. This will make diagnosing such issues much simpler in the future.

Ref: [EC-230](https://issues.redhat.com//browse/EC-230)