### PR TITLE
chore: Remove CPU limits from tasks

### DIFF
--- a/.tekton/tasks/buildah.yaml
+++ b/.tekton/tasks/buildah.yaml
@@ -48,7 +48,6 @@ spec:
     computeResources:
       limits:
         memory: 2Gi
-        cpu: 2
       requests:
         memory: 512Mi
         cpu: 10m

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -51,7 +51,6 @@ spec:
     computeResources:
       limits:
         memory: 4Gi
-        cpu: 2
       requests:
         memory: 512Mi
         cpu: 250m

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -101,7 +101,6 @@ spec:
   steps:
   - computeResources:
       limits:
-        cpu: "2"
         memory: 4Gi
       requests:
         cpu: 250m

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -92,7 +92,6 @@ spec:
     computeResources:
       limits:
         memory: 4Gi
-        cpu: 2
       requests:
         memory: 512Mi
         cpu: 250m

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -40,7 +40,6 @@ spec:
       computeResources:
         limits:
           memory: 4Gi
-          cpu: 2
         requests:
           memory: 512Mi
           cpu: 10m

--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -22,7 +22,6 @@ spec:
       computeResources:
         limits:
           memory: 4Gi
-          cpu: 2
         requests:
           memory: 512Mi
           cpu: 10m

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -43,7 +43,6 @@ spec:
       computeResources:
         limits:
           memory: 4Gi
-          cpu: 2
         requests:
           memory: 512Mi
           cpu: 10m

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -75,7 +75,6 @@ spec:
     name: build
     computeResources:
       limits:
-        cpu: "0.5"
         memory: 512Mi
       requests:
         cpu: 250m

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -130,7 +130,6 @@ spec:
     computeResources:
       limits:
         memory: 4Gi
-        cpu: 2
       requests:
         memory: 512Mi
         cpu: 10m

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -112,7 +112,6 @@ spec:
     computeResources:
       limits:
         memory: 2Gi
-        cpu: 2
       requests:
         memory: 512Mi
         cpu: 10m

--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -40,7 +40,6 @@ spec:
       computeResources:
         limits:
           memory: 2Gi
-          cpu: 1
         requests:
           memory: 512Mi
           cpu: 250m


### PR DESCRIPTION
CPU `limits` are known as unhelpful and actually harmful as they cause throttling.
When containers have CPU `requests`, they should always get at least as much as requested. They can also get extra CPU cycles when available unless there are `limits` which prevent that.

This is well described in the following article: https://home.robusta.dev/blog/stop-using-cpu-limits

----

I simply searched for `cpu:` in all files of the repo and removed attributes that were in `limits:`. I feel some CPU `requests` can be tweaked but that's likely a job for separate PRs and requires more observations.

Initially, I created this PR observing that our build task gets throttled at 2 CPUs while it could get a speedup benefit if given more.

Testing: I haven't tested this change, and I hope it should work as expected.