### PR TITLE
RHTAPBUGS-1025: set CPU requests _and_ limits for buildah task

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -101,9 +101,10 @@ spec:
   steps:
   - computeResources:
       limits:
+        cpu: 2
         memory: 4Gi
       requests:
-        cpu: 250m
+        cpu: 1
         memory: 512Mi
     env:
     - name: COMMIT_SHA

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -101,10 +101,10 @@ spec:
   steps:
   - computeResources:
       limits:
-        cpu: 2
+        cpu: "2"
         memory: 4Gi
       requests:
-        cpu: 1
+        cpu: "1"
         memory: 512Mi
     env:
     - name: COMMIT_SHA

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -92,9 +92,10 @@ spec:
     computeResources:
       limits:
         memory: 4Gi
+        cpu: 2
       requests:
         memory: 512Mi
-        cpu: 250m
+        cpu: 1
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)


### PR DESCRIPTION
In #673 , the CPU limit was removed from this task. 
Because of that, the LimitRanger applied its CPU limit of 350m - which led to PipelineRun timeouts, because the build did not finish in time within the hour. Instead of continuing to fiddle with the LimitRanger and influence the CPU limit for all tasks in the namespace, we suggest to reintroduce the CPU limit.

We increased the CPU request to `1`, so that the over-provisioning is reasonable and help the scheduler.