### PR TITLE
PLNSRVCE-1533: enforce use of image digests in all image tags

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -80,6 +80,9 @@ spec:
           steps:
             - name: check-task-structure
               image: quay.io/redhat-appstudio/pull-request-builds:build-definitions-utils-{{revision}}
+              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+              # the cluster will set imagePullPolicy to IfNotPresent
+              # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
@@ -88,6 +91,9 @@ spec:
                 cat partner-tasks.out
             - name: create-comment
               image: quay.io/redhat-appstudio/github-app-token@sha256:b4f2af12e9beea68055995ccdbdb86cfe1be97688c618117e5da2243dc1da18e
+              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+              # the cluster will set imagePullPolicy to IfNotPresent
+              # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
               volumeMounts:
                 - name: infra-deployments-pr-creator
                   mountPath: /secrets/deploy-key
@@ -143,6 +149,9 @@ spec:
           steps:
             - name: build-bundles
               image: quay.io/redhat-appstudio/pull-request-builds:build-definitions-utils-{{revision}}
+              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+              # the cluster will set imagePullPolicy to IfNotPresent
+              # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
@@ -179,7 +188,10 @@ spec:
         taskSpec:
           steps:
             - name: fail-when-repo-is-missed
-              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12
+              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12@sha256:2098dc35cf999984ffb2a0aebd4f8bb1b52f1e2c308efef90831a3660c75c358
+              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+              # the cluster will set imagePullPolicy to IfNotPresent
+              # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
@@ -203,7 +215,10 @@ spec:
         taskSpec:
           steps:
             - name: check-task-migration-md
-              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12
+              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12@sha256:9deda623e4768ecbaa6f1c6204077d9a151d55f9569bfe414e793fcb36cc391e
+              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+              # the cluster will set imagePullPolicy to IfNotPresent
+              # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
@@ -235,7 +250,10 @@ spec:
               type: string
           steps:
             - name: e2e-cleanup
-              image: registry.redhat.io/openshift4/ose-cli:v4.12@sha256:9f0cdc00b1b1a3c17411e50653253b9f6bb5329ea4fb82ad983790a6dbf2d9ad
+              image: registry.redhat.io/openshift4/ose-cli:v4.12@sha256:0d21299d2adfa3cb74562c4dffbedd3b107fffac3a2a537f14770088abd4671f
+              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+              # the cluster will set imagePullPolicy to IfNotPresent
+              # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
               script: |
                 #!/usr/bin/env bash
                 # Perform cleanup of resources created by gitops service

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -65,6 +65,9 @@ spec:
           steps:
             - name: build-bundles
               image: quay.io/redhat-appstudio/appstudio-utils:{{ revision }}
+              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+              # the cluster will set imagePullPolicy to IfNotPresent
+              # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
               workingDir: $(workspaces.source.path)/source
               command: ["./hack/build-and-push.sh"]
               env:
@@ -116,6 +119,9 @@ spec:
           steps:
             - name: build-bundles
               image: quay.io/redhat-appstudio/appstudio-utils:{{ revision }}
+              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+              # the cluster will set imagePullPolicy to IfNotPresent
+              # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
               script: |-
                 #!/usr/bin/env bash
                 set -euo pipefail

--- a/.tekton/tasks/buildah.yaml
+++ b/.tekton/tasks/buildah.yaml
@@ -14,6 +14,9 @@ spec:
     name: IMAGE
     type: string
   - default: registry.access.redhat.com/ubi8/buildah@sha256:31f84b19a0774be7cfad751be38fc97f5e86cefd26e0abaec8047ddc650b00bf
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
@@ -44,6 +47,9 @@ spec:
     name: IMAGE_URL
   steps:
   - image: $(params.BUILDER_IMAGE)
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent; our default param above specifies a digest
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: build
     computeResources:
       limits:

--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -18,8 +18,9 @@ spec:
       type: string
   steps:
     - name: e2e-test
-      image: quay.io/redhat-appstudio/e2e-tests:main
-      imagePullPolicy: Always
+      image: quay.io/redhat-appstudio/e2e-tests:83d12bbd8fb4a0c998eacf21325ced379bb42796
+      # a la infra-deployment updates, when PRs merge in e2e-tests, PRs will be opened
+      # against build-definitions to update this tag
       args: [
         "--ginkgo.label-filter=build-templates-e2e",
         "--ginkgo.v",

--- a/.tekton/tasks/ec-checks.yaml
+++ b/.tekton/tasks/ec-checks.yaml
@@ -14,6 +14,9 @@ spec:
   steps:
   - name: gather-tasks
     image: quay.io/redhat-appstudio/appstudio-utils:512cca38316355d6dbfc9c23ed3c5afabb943d24
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     workingDir: $(workspaces.source.path)/source
     script: |
       source hack/ec-checks.sh

--- a/.tekton/tasks/yaml-lint.yaml
+++ b/.tekton/tasks/yaml-lint.yaml
@@ -24,6 +24,9 @@ spec:
   steps:
     - name: lint-yaml-files
       image: docker.io/cytopia/yamllint:1.26@sha256:1bf8270a671a2e5f2fea8ac2e80164d627e0c5fa083759862bbde80628f942b2  # tag: 1.23
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       workingDir: $(workspaces.shared-workspace.path)/source
       command:
         - yamllint
@@ -31,6 +34,9 @@ spec:
         - $(params.args)
     - name: ensure-params-not-in-script
       image: quay.io/redhat-appstudio/appstudio-utils:d8a93bf5650424a4f20ee065578609792d70af1c
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       script: |
         #!/bin/bash
         for task in $(find task -name '*.yaml'); do

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -47,6 +47,9 @@ spec:
       value: $(params.TLSVERIFY)
   steps:
   - image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: build
     computeResources:
       limits:

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -245,7 +245,7 @@ spec:
       readOnly: true
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/redhat-appstudio/syft:v0.98.0
+    image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
     name: sbom-syft-generate
     script: |
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
@@ -270,7 +270,7 @@ spec:
     - mountPath: /var/lib/containers
       name: varlibcontainers
   - computeResources: {}
-    image: registry.access.redhat.com/ubi9/python-39:1-158
+    image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
     name: merge-syft-sboms
     script: |
       #!/bin/python3
@@ -319,7 +319,7 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: registry.access.redhat.com/ubi9/python-39:1-158
+    image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
     name: create-purl-sbom
     script: |
       #!/bin/python3
@@ -387,7 +387,7 @@ spec:
     - cyclonedx
     - $(params.IMAGE)
     computeResources: {}
-    image: quay.io/redhat-appstudio/cosign:v2.1.1
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
     name: upload-sbom
     workingDir: $(workspaces.source.path)
   volumes:

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -19,6 +19,9 @@ spec:
     name: IMAGE
     type: string
   - default: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
@@ -88,6 +91,9 @@ spec:
       value: $(params.IMAGE_EXPIRES_AFTER)
   steps:
   - image: $(params.BUILDER_IMAGE)
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent; our default param above specifies a digest
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: build
     computeResources:
       limits:
@@ -186,7 +192,10 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: sbom-syft-generate
-    image: quay.io/redhat-appstudio/syft:v0.98.0
+    image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     script: |
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
       find $(cat /workspace/container_path) -xtype l -delete
@@ -196,6 +205,9 @@ spec:
       name: varlibcontainers
   - name: analyse-dependencies-java-sbom
     image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:1d417e6f1f3e68c6c537333b5759796eddae0afc
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     script: |
       if [ -f /var/lib/containers/java ]; then
         /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /workspace/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
@@ -210,7 +222,10 @@ spec:
       runAsUser: 0
 
   - name: merge-syft-sboms
-    image: registry.access.redhat.com/ubi9/python-39:1-158
+    image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     script: |
       #!/bin/python3
       import json
@@ -246,6 +261,9 @@ spec:
 
   - name: merge-cachi2-sbom
     image: quay.io/redhat-appstudio/cachi2:0.3.0@sha256:46097f22b57e4d48a3fce96d931e08ccfe3a3e6421362d5f9353961279078eef
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     script: |
       if [ -n "${PREFETCH_INPUT}" ]; then
         echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
@@ -259,7 +277,10 @@ spec:
       runAsUser: 0
 
   - name: create-purl-sbom
-    image: registry.access.redhat.com/ubi9/python-39:1-158
+    image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     script: |
       #!/bin/python3
       import json
@@ -321,7 +342,10 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: upload-sbom
-    image: quay.io/redhat-appstudio/cosign:v2.1.1
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     args:
       - attach
       - sbom

--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -26,7 +26,7 @@ spec:
       description: Clair scan result.
   steps:
     - name: get-vulnerabilities
-      image: quay.io/redhat-appstudio/clair-in-ci:v1  # explicit floating tag, daily updates
+      image: quay.io/redhat-appstudio/clair-in-ci:v1  # explicit floating tag, daily updates, per arch call this is exempt for now for use of image digest
       imagePullPolicy: Always
       env:
         - name: IMAGE_URL
@@ -43,6 +43,9 @@ spec:
         clair-action report --image-ref=$imageanddigest --db-path=/tmp/matcher.db --format=quay | tee /tekton/home/clair-result.json || true
     - name: conftest-vulnerabilities
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       securityContext:
         capabilities:
           add:

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -25,6 +25,9 @@ spec:
   steps:
     - name: extract-and-scan-image
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       workingDir: /work
       # need to change user since 'oc image extract' requires more privileges when running as root
       # https://bugzilla.redhat.com/show_bug.cgi?id=1969929
@@ -77,6 +80,9 @@ spec:
           name: work
     - name: modify-clam-output-to-json
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       script: |
         #!/usr/bin/env python3.9
         import json
@@ -126,6 +132,9 @@ spec:
             main()
     - name: store-hacbs-test-output-result
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -154,7 +163,7 @@ spec:
   # provides latest virus database for clamscan only
   # does not execute anything
   sidecars:
-    - image: quay.io/redhat-appstudio/clamav-db:v1  # explicit floating tag, daily updates
+    - image: quay.io/redhat-appstudio/clamav-db:v1  # explicit floating tag, daily updates, per arch call this is exempt for now for use of image digest
       imagePullPolicy: Always
       name: database
       script: |

--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -31,6 +31,9 @@ spec:
     # Download Pyxis metadata about the image
     - name: query-pyxis
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       env:
         - name: BASE_IMAGES_DIGESTS
           value: $(params.BASE_IMAGES_DIGESTS)
@@ -57,6 +60,9 @@ spec:
     # Run the tests and save output
     - name: run-conftest
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       env:
         - name: POLICY_DIR
           value: $(params.POLICY_DIR)

--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -31,6 +31,9 @@ spec:
     # Download Pyxis metadata about the image
     - name: query-pyxis
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       env:
         - name: BASE_IMAGES_DIGESTS
           value: $(params.BASE_IMAGES_DIGESTS)
@@ -57,6 +60,9 @@ spec:
     # Run the tests and save output
     - name: run-conftest
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       env:
         - name: POLICY_DIR
           value: $(params.POLICY_DIR)

--- a/task/deprecated-image-check/0.3/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.3/deprecated-image-check.yaml
@@ -30,6 +30,9 @@ spec:
   steps:
     - name: check-images
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       env:
         - name: POLICY_DIR
           value: $(params.POLICY_DIR)

--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -18,6 +18,9 @@ spec:
   steps:
     - name: check-related-images
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       computeResources:
         limits:

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -27,6 +27,9 @@ spec:
   steps:
     - name: extract-and-check-binaries
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       env:
         - name: IMAGE_URL

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -66,6 +66,8 @@ spec:
     name: verbose
     type: string
   - default: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
     description: The image providing the git-init binary that this Task runs.
     name: gitInitImage
     type: string
@@ -218,7 +220,10 @@ spec:
       fi
 
   - name: symlink-check
-    image: registry.redhat.io/ubi9:9.2-696
+    image: registry.redhat.io/ubi9:9.2-696@sha256:089bd3b82a78ac45c0eed231bb58bfb43bfcd0560d9bba240fc6355502c92976
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     env:
     - name: PARAM_ENABLE_SYMLINK_CHECK
       value: $(params.enableSymlinkCheck)

--- a/task/init/0.1/init.yaml
+++ b/task/init/0.1/init.yaml
@@ -37,6 +37,9 @@ spec:
   steps:
     - name: init
       image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       env:
         - name: IMAGE_URL
           value: $(params.image-url)

--- a/task/inspect-image/0.1/inspect-image.yaml
+++ b/task/inspect-image/0.1/inspect-image.yaml
@@ -34,6 +34,9 @@ spec:
   steps:
   - name: inspect-image
     image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     workingDir: $(workspaces.source.path)/hacbs/$(context.task.name)
     securityContext:
       runAsUser: 0

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -16,6 +16,9 @@ spec:
     name: input
   steps:
   - image: quay.io/redhat-appstudio/cachi2:0.3.0@sha256:46097f22b57e4d48a3fce96d931e08ccfe3a3e6421362d5f9353961279078eef
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: prefetch-dependencies
     env:
     - name: INPUT

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -16,6 +16,9 @@ spec:
     name: IMAGE
     type: string
   - default: quay.io/redhat-user-workloads/project-sagano-tenant/ostree-builder/ostree-builder-fedora-38:d124414a81d17f31b1d734236f55272a241703d7
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     description: The location of the rpm-ostree builder image.
     name: BUILDER_IMAGE
     type: string
@@ -71,7 +74,9 @@ spec:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
     image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
-    imagePullPolicy: Always
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: build
     computeResources:
       limits:
@@ -129,7 +134,10 @@ spec:
       name: ssh
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - image: quay.io/redhat-appstudio/syft:v0.98.0
+  - image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: sbom-syft-generate
     computeResources:
       limits:
@@ -141,7 +149,10 @@ spec:
     volumeMounts:
       - mountPath: /var/lib/containers
         name: varlibcontainers
-  - image: registry.access.redhat.com/ubi9/python-39:1-158
+  - image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: create-purl-sbom
     computeResources: {}
     script: |
@@ -160,6 +171,9 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: inject-sbom-and-push
     computeResources: {}
     script: |
@@ -209,7 +223,10 @@ spec:
     - --type
     - cyclonedx
     - $(params.IMAGE)
-    image: quay.io/redhat-appstudio/cosign:v2.1.1
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: upload-sbom
     computeResources: {}
     workingDir: $(workspaces.source.path)

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -32,6 +32,9 @@ spec:
     name: IMAGE
     type: string
   - default: registry.access.redhat.com/ubi9/buildah:9.1.0-5@sha256:30eac1803d669d58c033838076a946156e49018e0d4f066d94896f0cc32030af
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
@@ -145,7 +148,10 @@ spec:
       name: gen-source
     workingDir: /gen-source
 
-  - image: quay.io/redhat-appstudio/syft:v0.98.0
+  - image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: sbom-syft-generate
     script: |
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
@@ -168,7 +174,10 @@ spec:
       name: varlibcontainers
     securityContext:
       runAsUser: 0
-  - image: registry.access.redhat.com/ubi9/python-39:1-158
+  - image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: merge-sboms
     script: |
       #!/bin/python3
@@ -213,6 +222,7 @@ spec:
       runAsUser: 0
 
   - image: $(params.BUILDER_IMAGE)
+    # default above is image digest specific
     name: inject-sbom-and-push
     computeResources: {}
     script: |
@@ -244,7 +254,10 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: upload-sbom
-    image: quay.io/redhat-appstudio/cosign:v2.1.1
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     args:
       - attach
       - sbom

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -14,7 +14,10 @@ spec:
     s2i-nodejs task builds source code into a container image and pushes the image into container registry using S2I and buildah tool.
     In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
   params:
-  - default: registry.access.redhat.com/ubi9/nodejs-16:1-75.1669634583
+  - default: registry.access.redhat.com/ubi9/nodejs-16:1-75.1669634583@sha256:c17111ec54c7f57f22d03f2abba206b0bdc54dcdfb02d6a8278ce088231eced1
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     description: NodeJS builder image
     name: BASE_IMAGE
     type: string
@@ -126,7 +129,10 @@ spec:
       name: gen-source
     workingDir: /gen-source
 
-  - image: quay.io/redhat-appstudio/syft:v0.98.0
+  - image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: sbom-syft-generate
     script: |
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
@@ -135,7 +141,10 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
-  - image: registry.access.redhat.com/ubi9/python-39:1-158
+  - image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: merge-sboms
     script: |
       #!/bin/python3
@@ -210,7 +219,10 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: upload-sbom
-    image: quay.io/redhat-appstudio/cosign:v2.1.1
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     args:
       - attach
       - sbom

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -29,6 +29,9 @@ spec:
   steps:
     - name: sast-snyk-check
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       volumeMounts:
         - name: snyk-secret

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -19,6 +19,9 @@ spec:
   steps:
   - name: sbom-json-check
     image: quay.io/redhat-appstudio/hacbs-test:v1.1.7@sha256:e151fb5300b7196c798c691f0570ee4713dde0d4a9e6913e307e9954a44ca9b0
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     securityContext:
       runAsUser: 0
       capabilities:

--- a/task/show-sbom/0.1/show-sbom.yaml
+++ b/task/show-sbom/0.1/show-sbom.yaml
@@ -17,7 +17,10 @@ spec:
       type: string
   steps:
   - name: show-sbom
-    image: quay.io/redhat-appstudio/cosign:v2.1.1
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     env:
     - name: IMAGE_URL
       value: $(params.IMAGE_URL)

--- a/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
+++ b/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
@@ -28,6 +28,9 @@ spec:
   steps:
     - name: send-message
       image: registry.access.redhat.com/ubi9/ubi-minimal:9.3-1361.1699548032@sha256:3e313209ac617a92b50350286752311d99ea2dafc429ef0e5311889294b0bc21
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       volumeMounts:
         - name: webhook-secret
           mountPath: "/etc/secrets"

--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -36,7 +36,10 @@ spec:
       emptyDir: {}
   steps:
     - name: build
-      image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils:latest
+      image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils@sha256:7521b6e85d881be625e0f39e4bbd65c29628e2a9f2431dd825fda0a47f9e171e
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       computeResources:
         limits:
           memory: 2Gi

--- a/task/summary/0.1/summary.yaml
+++ b/task/summary/0.1/summary.yaml
@@ -24,6 +24,9 @@ spec:
   steps:
     - name: appstudio-summary
       image: registry.access.redhat.com/ubi9/ubi-minimal:9.3-1361.1699548032@sha256:3e313209ac617a92b50350286752311d99ea2dafc429ef0e5311889294b0bc21
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       env:
         - name: GIT_URL
           value: $(params.git-url)

--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -23,9 +23,16 @@ spec:
     - name: GIT_IMAGE
       description: Image reference containing the git command
       default: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+     # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     - name: SCRIPT_IMAGE
       description: Image reference for SCRIPT execution
-      default: quay.io/mkovarik/ose-cli-git:4.11
+      # https://issues.redhat.com/browse/RHTAPBUGS-1043 is tracking re-creating this image in an appstudio image repo vs. and personal image repo
+      default: quay.io/mkovarik/ose-cli-git:4.11@sha256:cb0352fb73e6ad2ba05b71cba3785d11bbbe67854c2b2799e24d02bc0c0e9516
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     - name: shared-secret
       default: infra-deployments-pr-creator
       description: secret in the namespace which contains private key for the GitHub App
@@ -83,6 +90,9 @@ spec:
     # Based on https://github.com/tektoncd/catalog/tree/main/task/github-app-token/0.2/
     - name: create-mr
       image: quay.io/redhat-appstudio/github-app-token@sha256:b4f2af12e9beea68055995ccdbdb86cfe1be97688c618117e5da2243dc1da18e
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       volumeMounts:
         - name: infra-deployments-pr-creator
           mountPath: /secrets/deploy-key


### PR DESCRIPTION
QE has recently observed image pull throttling to the point of failed PipelineRuns during execution of the e2e's.  While QE is on a path to creating more quay.io robot accounts for their tests to increase their overall quota with the kubelet/quay.io access, this PR intend to both minimize the container level image pulling performed by the kubelet, as well as facilitate dependency updates via mechanisms like renovate and dependabot, by forcing use of image digests (but coulped with tags for human ease of use) and IfNotPreset pull poicy whenever possible.


See https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1700747494517799

I've marked as reviewers those most active in discussing this with me.  But if you think I've missed important reviewers please advise.

Also, I will be creating an e2e-tests PR for updating the e2e-tests.yaml this repo uses.  While the branch names are the same to facilitate pairing, in reality this PR should merge first so there is a commit sha in the image digest for the e2e-tests change to update.