### PR TITLE
fix(STONEINTG-653): adjust args of clamscan command line

### DIFF
--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -45,7 +45,7 @@ spec:
           memory: 4Gi
         requests:
           memory: 512Mi
-          cpu: 10m
+          cpu: 1
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -70,8 +70,16 @@ spec:
           echo "Unable to extract image. Skipping ClamAV scan!"
           exit 0
         fi
+
         echo "Scanning image. This operation may take a while."
-        clamscan -ri --max-scansize=250M | tee /tekton/home/clamscan-result.log
+        clamscan -ri --max-scansize=4095M --max-filesize=4095M \
+          --max-scantime=0 --max-files=0 --max-recursion=1000 --max-dir-recursion=20000 --max-embeddedpe=4095M \
+          --max-htmlnormalize=4095M --max-htmlnotags=4095M --max-scriptnormalize=4095M --max-ziptypercg=4095M \
+          --max-partitions=50000 --max-iconspe=100000 --max-rechwp3=20000 --pcre-match-limit=100000000 --pcre-recmatch-limit=2000000 \
+          --pcre-max-filesize=4095M --alert-broken=yes --alert-exceeds-max=yes --alert-broken-media=yes \
+          --alert-encrypted=yes --alert-encrypted-archive=yes --alert-encrypted-doc=yes --alert-macros=yes \
+          --alert-phishing-ssl=yes --alert-phishing-cloak=yes --alert-partition-intersection=yes \
+          | tee /tekton/home/clamscan-result.log || true
         echo "Executed-on: Scan was executed on version - $(clamscan --version)" | tee -a /tekton/home/clamscan-result.log
       volumeMounts:
         - mountPath: /var/lib/clamav
@@ -145,13 +153,20 @@ spec:
         then
           cat /tekton/home/clamscan-result.json
           INFECTED_FILES=$(jq -r '.infected_files' /tekton/home/clamscan-result.json || true )
+          WARNING_FILES=$(jq -r '.hits|length' /tekton/home/clamscan-result.json || true )
           if [ -z "${INFECTED_FILES}" ]; then
             echo "Failed to get number of infected files."
             note="Task $(context.task.name) failed: Unable to get number of infected files from /tekton/home/clamscan-result.json. For details, check Tekton task log."
           else
-            if [[ "${INFECTED_FILES}" -gt 0 ]]; then RES="FAILURE"; else RES="SUCCESS"; fi
+            if [[ "${INFECTED_FILES}" -gt 0 ]]; then
+             RES="FAILURE";
+            elif [[ "${WARNING_FILES}" -gt 0 ]]; then
+              RES="WARNING";
+            else
+              RES="SUCCESS";
+            fi
             note="Task $(context.task.name) completed: Check result for antivirus scan result."
-            TEST_OUTPUT=$(make_result_json -r "${RES}" -s 1 -f "${INFECTED_FILES}" -t "$note")
+            TEST_OUTPUT=$(make_result_json -r "${RES}" -s 1 -f "${INFECTED_FILES}" -w "${WARNING_FILES}" -t "$note")
           fi
         else
           note="Task $(context.task.name) failed: /tekton/home/clamscan-result.json doesn't exist. For details, check Tekton task log."


### PR DESCRIPTION
Add args to clamcan command line to scan more files, refer to https://docs.google.com/document/d/10KT44kmQeXFmbWtbqo3kVOsG3NFEbbS09S4fJGV_9dQ/edit#heading=h.655mtb2n05wb for more details

1. Add more clamscan parameters –max-* and alert-* in Tekton task params and set the value in task
2. Check alerts in clamscan-result.log when exceeding the limitations in clamscan command, we need parse clamscan-result.log and calculate the number of alert then add number to `warnings` and set result of TEST_OUTPUT to `WARNING` `{"result":"WARNING,"timestamp":"1701677631","note":"Task clamav-scan completed: Check result for antivirus scan result.","namespace":"default","successes":1,"failures":0,"warnings":4}`
3. Increase [requests.cpu](https://github.com/redhat-appstudio/build-definitions/blob/main/task/clamav-scan/0.1/clamav-scan.yaml#L45) to 1 to make clamav-scan run faster as requested in [RHTAPBUGS-1025](https://issues.redhat.com/browse/RHTAPBUGS-1025), refer to https://github.com/redhat-appstudio/build-definitions/pull/691 as well
    
Signed-off-by: Hongwei Liu <hongliu@redhat.com>