### PR TITLE
Introduce trusted artifacts

### DIFF
--- a/.github/workflows/check-buildah-remote.yaml
+++ b/.github/workflows/check-buildah-remote.yaml
@@ -1,5 +1,5 @@
 name: Validate PR - buildah-remote
-on:
+'on':
   pull_request:
     branches: [main]
 jobs:

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -29,7 +29,9 @@ spec:
         taskRef:
           name: git-clone
         workspaces:
-          - name: output
+          - name: source
+            workspace: workspace
+          - name: artifacts
             workspace: workspace
         params:
           - name: url
@@ -58,7 +60,9 @@ spec:
         taskRef:
           name: sast-snyk-check
         workspaces:
-          - name: workspace
+          - name: source
+            workspace: workspace
+          - name: artifacts
             workspace: workspace
       - name: build-container
         runAfter:
@@ -72,6 +76,8 @@ spec:
           name: buildah
         workspaces:
           - name: source
+            workspace: workspace
+          - name: artifacts
             workspace: workspace
       - name: check-partner-tasks
         runAfter:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -34,7 +34,9 @@ spec:
         taskRef:
           name: git-clone
         workspaces:
-          - name: output
+          - name: source
+            workspace: workspace
+          - name: artifacts
             workspace: workspace
       - name: build-container
         params:
@@ -48,6 +50,8 @@ spec:
           name: buildah
         workspaces:
           - name: source
+            emptyDir: {}
+          - name: artifacts
             workspace: workspace
       - name: build-bundles
         params:

--- a/pipelines/docker-build-dance/patch.yaml
+++ b/pipelines/docker-build-dance/patch.yaml
@@ -84,7 +84,7 @@
     taskRef:
       name: acs-image-check
     workspaces:
-      - name: workspace
+      - name: source
         workspace: workspace
 - op: add
   path: /spec/tasks/-

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -30,6 +30,10 @@
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+  - name: SOURCE_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+  - name: CACHI2_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
 - op: add
   path: /spec/results/-
   value:

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -28,6 +28,10 @@
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+  - name: SOURCE_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+  - name: CACHI2_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
 - op: add
   path: /spec/tasks/-
   value:
@@ -70,7 +74,7 @@
     - name: BASE_IMAGE
       value: $(tasks.inspect-image.results.BASE_IMAGE)
     workspaces:
-      - name: workspace
+      - name: source
         workspace: workspace
 - op: add
   path: /spec/tasks/-
@@ -86,7 +90,7 @@
       name: fbc-related-image-check
       version: "0.1"
     workspaces:
-      - name: workspace
+      - name: source
         workspace: workspace
 # - op: remove
 #   # build-source-image as source images are not needed for FBC components

--- a/pipelines/java-builder/patch.yaml
+++ b/pipelines/java-builder/patch.yaml
@@ -24,6 +24,10 @@
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+  - name: SOURCE_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+  - name: CACHI2_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
 - op: add
   path: /spec/results/-
   value:

--- a/pipelines/nodejs-builder/patch.yaml
+++ b/pipelines/nodejs-builder/patch.yaml
@@ -24,3 +24,7 @@
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+  - name: SOURCE_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+  - name: CACHI2_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)

--- a/pipelines/prototypes/prototype-build-compliance.yaml
+++ b/pipelines/prototypes/prototype-build-compliance.yaml
@@ -49,7 +49,7 @@ spec:
       taskRef:
         name: git-clone
       workspaces:
-        - name: output
+        - name: source
           workspace: workspace
         - name: basic-auth
           workspace: git-auth

--- a/pipelines/tekton-bundle-builder/kustomization.yaml
+++ b/pipelines/tekton-bundle-builder/kustomization.yaml
@@ -22,6 +22,10 @@ patches:
         value: $(params.output-image)
       - name: CONTEXT
         value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     # Remove tasks that assume a binary image
     - op: remove
       path: /spec/tasks/9  # sbom-json-check

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -81,18 +81,18 @@ spec:
         name: git-clone
         version: "0.1"
       workspaces:
-        - name: output
+        - name: source
           workspace: workspace
         - name: basic-auth
           workspace: git-auth
     - name: prefetch-dependencies
-      when:
-      - input: $(params.hermetic)
-        operator: in
-        values: ["true"]
       params:
         - name: input
           value: $(params.prefetch-input)
+        - name: hermetic
+          value: $(params.hermetic)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
       runAfter:
         - clone-repository
       taskRef:
@@ -106,12 +106,17 @@ spec:
       - input: $(tasks.init.results.build)
         operator: in
         values: ["true"]
-      runAfter:
-        - prefetch-dependencies
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       taskRef:
         name: $REPLACE_ME
       workspaces:
         - name: source
+          emptyDir: {}
+        - name: artifacts
           workspace: workspace
     - name: build-source-image
       when:
@@ -131,8 +136,14 @@ spec:
           value: "$(params.output-image)"
         - name: BASE_IMAGES
           value: "$(tasks.build-container.results.BASE_IMAGES_DIGESTS)"
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       workspaces:
-        - name: workspace
+        - name: source
+          emptyDir: {}
+        - name: artifacts
           workspace: workspace
     - name: deprecated-base-image-check
       when:
@@ -167,13 +178,20 @@ spec:
       - input: $(params.skip-checks)
         operator: in
         values: ["false"]
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
         - clone-repository
       taskRef:
         name: sast-snyk-check
         version: "0.1"
       workspaces:
-      - name: workspace
+      - name: source
+        emptyDir: {}
+      - name: artifacts
         workspace: workspace
     - name: clamav-scan
       when:

--- a/task/buildah-10gb/0.1/patch.yaml
+++ b/task/buildah-10gb/0.1/patch.yaml
@@ -2,8 +2,8 @@
   path: /metadata/name
   value: buildah-10gb
 - op: replace
-  path: /spec/steps/0/computeResources/limits/memory
+  path: /spec/steps/1/computeResources/limits/memory
   value: 10Gi
 - op: replace
-  path: /spec/steps/0/computeResources/requests/memory
+  path: /spec/steps/1/computeResources/requests/memory
   value: 8Gi

--- a/task/buildah-6gb/0.1/patch.yaml
+++ b/task/buildah-6gb/0.1/patch.yaml
@@ -2,8 +2,8 @@
   path: /metadata/name
   value: buildah-6gb
 - op: replace
-  path: /spec/steps/0/computeResources/limits/memory
+  path: /spec/steps/1/computeResources/limits/memory
   value: 6Gi
 - op: replace
-  path: /spec/steps/0/computeResources/requests/memory
+  path: /spec/steps/1/computeResources/requests/memory
   value: 4Gi

--- a/task/buildah-8gb/0.1/patch.yaml
+++ b/task/buildah-8gb/0.1/patch.yaml
@@ -2,8 +2,8 @@
   path: /metadata/name
   value: buildah-8gb
 - op: replace
-  path: /spec/steps/0/computeResources/limits/memory
+  path: /spec/steps/1/computeResources/limits/memory
   value: 8Gi
 - op: replace
-  path: /spec/steps/0/computeResources/requests/memory
+  path: /spec/steps/1/computeResources/requests/memory
   value: 6Gi

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -69,6 +69,14 @@ spec:
     description: Target path on the container in which yum repository files should
       be made available
     name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: The source trusted artifact URI
+    name: SOURCE_ARTIFACT
+    type: string
+  - default: ""
+    description: The prefetched dependencies trusted artifact URI
+    name: CACHI2_ARTIFACT
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -115,6 +123,15 @@ spec:
     - name: BUILDER_IMAGE
       value: $(params.BUILDER_IMAGE)
   steps:
+  - args:
+    - use
+    - --store
+    - $(workspaces.artifacts.path)
+    - $(params.SOURCE_ARTIFACT)=$(workspaces.source.path)/source
+    - $(params.CACHI2_ARTIFACT)=$(workspaces.source.path)/cachi2
+    computeResources: {}
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+    name: use-trusted-artifact
   - computeResources:
       limits:
         memory: 4Gi
@@ -155,6 +172,7 @@ spec:
       fi
 
       rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
+      rsync -ra $(workspaces.artifacts.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/artifacts/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
       cat >scripts/script-build.sh <<'REMOTESSHEOF'
@@ -276,11 +294,13 @@ spec:
        -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
        -e COMMIT_SHA="$COMMIT_SHA" \
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
+       -v "$BUILD_DIR/workspaces/artifacts:$(workspaces.artifacts.path):Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
        -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
        -v $BUILD_DIR/scripts:/script:Z \
       --user=0  --rm  "$BUILDER_IMAGE" /script/script-build.sh
       rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
+      rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/artifacts/" "$(workspaces.artifacts.path)/"
       rsync -ra "$SSH_HOST:$BUILD_DIR/tekton-results/" "/tekton/results/"
       buildah pull oci:rhtap-final-image
       buildah images
@@ -452,3 +472,5 @@ spec:
   workspaces:
   - description: Workspace containing the source code to build.
     name: source
+  - description: The trusted artifact store
+    name: artifacts

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -28,6 +28,14 @@ spec:
     description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
     name: TLSVERIFY
     type: string
+  - name: SOURCE_ARTIFACT
+    type: string
+    description: The source trusted artifact URI
+    default: ""
+  - name: CACHI2_ARTIFACT
+    type: string
+    description: The prefetched dependencies trusted artifact URI
+    default: ""
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -48,6 +56,14 @@ spec:
     - name: TLSVERIFY
       value: $(params.TLSVERIFY)
   steps:
+  - name: use-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+    args:
+      - use
+      - --store
+      - $(workspaces.artifacts.path)
+      - $(params.SOURCE_ARTIFACT)=$(workspaces.source.path)/source
+      - $(params.CACHI2_ARTIFACT)=$(workspaces.source.path)/cachi2
   - name: build
     image: registry.access.redhat.com/ubi9/buildah@sha256:04fde77ea72c25b56efb3f71db809c5d7b09938130df2da9175a3c888b94043d
     script: |
@@ -172,3 +188,5 @@ spec:
   workspaces:
   - name: source
     description: Workspace containing the source code to build.
+  - name: artifacts
+    description: The trusted artifact store

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -66,6 +66,14 @@ spec:
   - name: YUM_REPOS_D_TARGET
     description: Target path on the container in which yum repository files should be made available
     default: /etc/yum.repos.d
+  - name: SOURCE_ARTIFACT
+    type: string
+    description: The source trusted artifact URI
+    default: ""
+  - name: CACHI2_ARTIFACT
+    type: string
+    description: The prefetched dependencies trusted artifact URI
+    default: ""
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -105,6 +113,14 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
   steps:
+  - name: use-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+    args:
+      - use
+      - --store
+      - $(workspaces.artifacts.path)
+      - $(params.SOURCE_ARTIFACT)=$(workspaces.source.path)/source
+      - $(params.CACHI2_ARTIFACT)=$(workspaces.source.path)/cachi2
   - image: $(params.BUILDER_IMAGE)
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent; our default param above specifies a digest
@@ -392,3 +408,5 @@ spec:
   workspaces:
   - name: source
     description: Workspace containing the source code to build.
+  - name: artifacts
+    description: The trusted artifact store

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -91,6 +91,9 @@ spec:
     name: commit
   - description: The precise URL that was fetched by this Task.
     name: url
+  - description: Produced trusted source artifact
+    name: SOURCE_ARTIFACT
+    type: string
   steps:
   - name: clone
     env:
@@ -127,7 +130,7 @@ spec:
     - name: PARAM_FETCH_TAGS
       value: $(params.fetchTags)
     - name: WORKSPACE_OUTPUT_PATH
-      value: $(workspaces.output.path)
+      value: $(workspaces.source.path)
     - name: WORKSPACE_SSH_DIRECTORY_BOUND
       value: $(workspaces.ssh-directory.bound)
     - name: WORKSPACE_SSH_DIRECTORY_PATH
@@ -230,7 +233,7 @@ spec:
     - name: PARAM_SUBDIRECTORY
       value: $(params.subdirectory)
     - name: WORKSPACE_OUTPUT_PATH
-      value: $(workspaces.output.path)
+      value: $(workspaces.source.path)
     computeResources: {}
     script: |
       #!/usr/bin/env bash
@@ -256,9 +259,17 @@ spec:
         echo "Running symlink check"
         check_symlinks
       fi
+
+  - name: create-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+    args:
+      - create
+      - --store
+      - $(workspaces.source.path)
+      - $(results.SOURCE_ARTIFACT.path)=$(workspaces.source.path)/$(params.subdirectory)
   workspaces:
   - description: The git repo will be cloned onto the volume backing this Workspace.
-    name: output
+    name: source
   - description: |
       A .ssh directory with private key, known_hosts, config, etc. Copied to
       the user's home before git commands are executed. Used to authenticate

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -14,7 +14,27 @@ spec:
   params:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
+  - description: Execute the build with network isolation.
+    name: hermetic
+  - name: SOURCE_ARTIFACT
+    type: string
+    description: The source trusted artifact URI
+    default: ""
+  results:
+  - name: SOURCE_ARTIFACT
+    type: string
+    description: The produced source trusted artifact URI
+  - name: CACHI2_ARTIFACT
+    type: string
+    description: The produced prefetched dependencies trusted artifact URI
   steps:
+  - name: use-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+    args:
+      - use
+      - --store
+      - $(workspaces.source.path)
+      - $(params.SOURCE_ARTIFACT)=$(workspaces.source.path)/source
   - image: quay.io/redhat-appstudio/cachi2:0.4.0@sha256:001acfbad47e132a90998d45076a0dbe0d8beacf0bec12b4d9a5aa796f4a9cad
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
@@ -23,9 +43,18 @@ spec:
     env:
     - name: INPUT
       value: $(params.input)
+    - name: HERMETIC
+      value: $(params.hermetic)
     script: |
+      if [ "${HERMETIC}" != "true" ]
+      then
+        mkdir -p $(workspaces.source.path)/cachi2
+        echo "The build is not configured to be run hermetically (hermetic: ${HERMETIC})."
+        exit 0
+      fi
       if [ -z "${INPUT}" ]
       then
+        mkdir -p $(workspaces.source.path)/cachi2
         echo "Build will be executed with network isolation, but no content was configured to be prefetched."
         exit 0
       fi
@@ -42,6 +71,15 @@ spec:
 
       cachi2 inject-files $(workspaces.source.path)/cachi2/output \
       --for-output-dir=/cachi2/output
+
+  - name: create-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+    args:
+      - create
+      - --store
+      - $(workspaces.source.path)
+      - $(results.SOURCE_ARTIFACT.path)=$(workspaces.source.path)/source
+      - $(results.CACHI2_ARTIFACT.path)=$(workspaces.source.path)/cachi2
   workspaces:
   - name: source
     description: Workspace with the source code, cachi2 artifacts will be stored on the workspace as well

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -47,6 +47,13 @@ spec:
   - description: The platform to build on
     name: PLATFORM
     type: string
+  - name: SOURCE_ARTIFACT
+    type: string
+    description: The source trusted artifact URI
+    default: ""
+  - name: CACHI2_ARTIFACT
+    type: string
+    description: The prefetched dependencies trusted artifact URI
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -70,6 +77,14 @@ spec:
       value: $(params.BUILDER_IMAGE)
     computeResources: {}
   steps:
+  - name: use-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+    args:
+      - use
+      - --store
+      - $(workspaces.artifacts.path)
+      - $(params.SOURCE_ARTIFACT)=$(workspaces.source.path)/source
+      - $(params.CACHI2_ARTIFACT)=$(workspaces.source.path)/cachi2
   - env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
@@ -240,3 +255,5 @@ spec:
   workspaces:
   - description: Workspace containing the source code to build.
     name: source
+  - name: artifacts
+    description: The trusted artifact store

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -50,6 +50,14 @@ spec:
     description: The image is built from this commit.
     type: string
     default: ""
+  - name: SOURCE_ARTIFACT
+    type: string
+    description: The source trusted artifact URI
+    default: ""
+  - name: CACHI2_ARTIFACT
+    type: string
+    description: The prefetched dependencies trusted artifact URI
+    default: ""
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -79,6 +87,14 @@ spec:
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.IMAGE_EXPIRES_AFTER)
   steps:
+  - name: use-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+    args:
+      - use
+      - --store
+      - $(workspaces.artifacts.path)
+      - $(params.SOURCE_ARTIFACT)=$(workspaces.source.path)/source
+      - $(params.CACHI2_ARTIFACT)=$(workspaces.source.path)/cachi2
   - args:
     - |-
       echo "MAVEN_CLEAR_REPO=true" > env-file
@@ -277,3 +293,5 @@ spec:
   - mountPath: /workspace/source
     name: source
     description: Workspace containing the source code to build.
+  - name: artifacts
+    description: The trusted artifact store

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -52,6 +52,14 @@ spec:
     description: The image is built from this commit.
     type: string
     default: ""
+  - name: SOURCE_ARTIFACT
+    type: string
+    description: The source trusted artifact URI
+    default: ""
+  - name: CACHI2_ARTIFACT
+    type: string
+    description: The prefetched dependencies trusted artifact URI
+    default: ""
   stepTemplate:
     env:
     - name: BUILDAH_FORMAT
@@ -72,6 +80,14 @@ spec:
   - description: Digests of the base images used for build
     name: BASE_IMAGES_DIGESTS
   steps:
+  - name: use-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+    args:
+      - use
+      - --store
+      - $(workspaces.artifacts.path)
+      - $(params.SOURCE_ARTIFACT)=$(workspaces.source.path)/source
+      - $(params.CACHI2_ARTIFACT)=$(workspaces.source.path)/cachi2
   - name: generate
     image: registry.redhat.io/ocp-tools-4-tech-preview/source-to-image-rhel8@sha256:e518e05a730ae066e371a4bd36a5af9cedc8686fd04bd59648d20ea0a486d7e5
     command:
@@ -242,3 +258,5 @@ spec:
   - mountPath: /workspace/source
     name: source
     description: Workspace containing the source code to build.
+  - name: artifacts
+    description: The trusted artifact store

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -21,18 +21,29 @@ spec:
       type: string
       description: Append arguments.
       default: "--all-projects --exclude=test*,vendor,deps"
+    - name: SOURCE_ARTIFACT
+      type: string
+      description: The source trusted artifact URI
+      default: ""
   volumes:
     - name: snyk-secret
       secret:
         secretName: $(params.SNYK_SECRET)
         optional: true
   steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+      args:
+        - use
+        - --store
+        - $(workspaces.artifacts.path)
+        - $(params.SOURCE_ARTIFACT)=$(workspaces.source.path)/source
     - name: sast-snyk-check
       image: quay.io/redhat-appstudio/hacbs-test:v1.1.9@sha256:866675ee3064cf4768691ecca478063ce12f0556fb9d4f24ca95c98664ffbd43
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
-      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      workingDir: $(workspaces.source.path)/hacbs/$(context.task.name)
       volumeMounts:
         - name: snyk-secret
           mountPath: "/etc/secrets"
@@ -62,7 +73,7 @@ spec:
         fi
 
         SNYK_EXIT_CODE=0
-        SOURCE_CODE_DIR=$(workspaces.workspace.path)/source
+        SOURCE_CODE_DIR=$(workspaces.source.path)/source
         snyk code test $ARGS $SOURCE_CODE_DIR --sarif-file-output=sast_snyk_check_out.json 1>&2>> stdout.txt || SNYK_EXIT_CODE=$?
         test_not_skipped=0
         SKIP_MSG="We found 0 supported files"
@@ -85,4 +96,6 @@ spec:
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
   workspaces:
-  - name: workspace
+  - name: source
+  - name: artifacts
+    description: The trusted artifact store

--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -21,6 +21,14 @@ spec:
         to skip handling a base image.
       type: string
       default: ""
+    - name: SOURCE_ARTIFACT
+      type: string
+      description: The source trusted artifact URI
+      default: ""
+    - name: CACHI2_ARTIFACT
+      type: string
+      description: The prefetched dependencies trusted artifact URI
+      default: ""
   results:
     - name: BUILD_RESULT
       description: Build result.
@@ -29,12 +37,22 @@ spec:
     - name: SOURCE_IMAGE_DIGEST
       description: The source image digest.
   workspaces:
-    - name: workspace
+    - name: source
       description: The workspace where source code is included.
+    - name: artifacts
+      description: The trusted artifact store
   volumes:
     - name: source-build-work-place
       emptyDir: {}
   steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+      args:
+        - use
+        - --store
+        - $(workspaces.artifacts.path)
+        - $(params.SOURCE_ARTIFACT)=$(workspaces.source.path)/source
+        - $(params.CACHI2_ARTIFACT)=$(workspaces.source.path)/cachi2
     - name: build
       image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils@sha256:7521b6e85d881be625e0f39e4bbd65c29628e2a9f2431dd825fda0a47f9e171e
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
@@ -59,13 +77,13 @@ spec:
         - name: BINARY_IMAGE
           value: "$(params.BINARY_IMAGE)"
         - name: SOURCE_DIR
-          value: "$(workspaces.workspace.path)/source"
+          value: "$(workspaces.source.path)/source"
         - name: BASE_IMAGES
           value: "$(params.BASE_IMAGES)"
         - name: RESULT_FILE
           value: "$(results.BUILD_RESULT.path)"
         - name: CACHI2_ARTIFACTS_DIR
-          value: "$(workspaces.workspace.path)/cachi2"
+          value: "$(workspaces.source.path)/cachi2"
         - name: RESULT_SOURCE_IMAGE_URL
           value: "$(results.SOURCE_IMAGE_URL.path)"
         - name: RESULT_SOURCE_IMAGE_DIGEST

--- a/task/tkn-bundle/0.1/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.1/tkn-bundle.yaml
@@ -23,6 +23,14 @@ spec:
     type: string
     description: Value for the HOME environment variable.
     default: /tekton/home
+  - name: SOURCE_ARTIFACT
+    type: string
+    description: The source trusted artifact URI
+    default: ""
+  - name: CACHI2_ARTIFACT
+    type: string
+    description: The prefetched dependencies trusted artifact URI
+    default: ""
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -33,6 +41,14 @@ spec:
     - name: HOME
       value: "$(params.HOME)"
   steps:
+  - name: use-trusted-artifact
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:dbcf0102d0e9f21c2bcb06dcaa9af680cb9151f1984f5cec1fb397e1356ae771
+    args:
+      - use
+      - --store
+      - $(workspaces.artifacts.path)
+      - $(params.SOURCE_ARTIFACT)=$(workspaces.source.path)/source
+      - $(params.CACHI2_ARTIFACT)=$(workspaces.source.path)/cachi2
   - image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:5.0
     name: build
     env:
@@ -108,3 +124,5 @@ spec:
     workingDir: $(workspaces.source.path)
   workspaces:
   - name: source
+  - name: artifacts
+    description: The trusted artifact store


### PR DESCRIPTION
Adds the use of trusted artifacts[1] to the Tasks and Pipelines. The `prefetch-dependencies` Task is no longer skipped based on the `hermetic` parameter -- it needs to run always to produce the trusted artifacts as the build* tasks depend on these, so if it were skipped the build* tasks would be skipped as well.

This also includes one small bugfix in the `buildah` task, it no longer tries to pull the `scratch` image.

Ref: https://issues.redhat.com/browse/EC-251

[1] https://github.com/redhat-appstudio/build-trusted-artifacts
