### PR TITLE
fix: reduce request.cpu to 10m since 1 cpu make build PLR fail

### DIFF
--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -45,7 +45,7 @@ spec:
           memory: 4Gi
         requests:
           memory: 512Mi
-          cpu: 1
+          cpu: 10m
       script: |
         #!/usr/bin/env bash
         set -euo pipefail


### PR DESCRIPTION
In https://github.com/redhat-appstudio/build-definitions/pull/698/files, we increase requests.cpu to 1, but 1 cpu makes build PLR fail, see slack https://redhat-internal.slack.com/archives/C02FANRBZQD/p1703051386118509?thread_ts=1703049812.456129&cid=C02FANRBZQD

So we have to reduce requests.cpu back to 10m and then find way later

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
