### PR TITLE
chore(RHTAPWATCH-697): support mounting repofiles to buildah build

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -59,6 +59,16 @@ spec:
     description: The image is built from this commit.
     name: COMMIT_SHA
     type: string
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -96,6 +106,12 @@ spec:
       value: $(params.TLSVERIFY)
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
       value: $(params.BUILDER_IMAGE)
   steps:
@@ -200,6 +216,19 @@ spec:
         echo "Prefetched content will be made available"
       fi
 
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}"
+      fi
+
       LABELS=(
         "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
         "--label" "architecture=$(uname -m)"
@@ -242,6 +271,9 @@ spec:
        -e IMAGE="$IMAGE" \
        -e TLSVERIFY="$TLSVERIFY" \
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
+       -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
+       -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
+       -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
        -e COMMIT_SHA="$COMMIT_SHA" \
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -17,6 +17,9 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
+|YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
+|YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -57,6 +57,15 @@ spec:
     description: The image is built from this commit.
     type: string
     default: ""
+  - name: YUM_REPOS_D_SRC
+    description: Path in the git repository in which yum repository files are stored
+    default: repos.d
+  - name: YUM_REPOS_D_FETCHED
+    description: Path in source workspace where dynamically-fetched repos are present
+    default: fetched.repos.d
+  - name: YUM_REPOS_D_TARGET
+    description: Target path on the container in which yum repository files should be made available
+    default: /etc/yum.repos.d
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -89,6 +98,12 @@ spec:
       value: $(params.TLSVERIFY)
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
   steps:
   - image: $(params.BUILDER_IMAGE)
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
@@ -157,6 +172,19 @@ spec:
         VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
         sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
         echo "Prefetched content will be made available"
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}"
       fi
 
       LABELS=(


### PR DESCRIPTION
This change allows mounting repofiles inside the image being built so those can be used by the buildah build process.

The repofiles can be stored together with the code, or generated on-the-fly using the generate-odcs-compose task, similarly to what's done here:
https://github.com/redhat-appstudio/tekton-tools/pull/22/files
