### PR TITLE
New buildah task for RHTAP

### DIFF
--- a/pipelines/docker-build-dance/patch.yaml
+++ b/pipelines/docker-build-dance/patch.yaml
@@ -23,7 +23,7 @@
 - op: replace
   path: /spec/tasks/3/taskRef
   value:
-    name: buildah
+    name: buildah-rhtap
     version: "0.1"
 - op: add
   path: /spec/tasks/3/params
@@ -34,10 +34,6 @@
     value: $(params.dockerfile)
   - name: CONTEXT
     value: $(params.path-context)
-  - name: HERMETIC
-    value: "$(params.hermetic)"
-  - name: PREFETCH_INPUT
-    value: "$(params.prefetch-input)"
   - name: IMAGE_EXPIRES_AFTER
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -61,9 +61,6 @@ spec:
         exit 1
       fi
 
-      # Fixing group permission on /var/lib/containers
-      chown root:root /var/lib/containers
-
       buildah build \
         --tls-verify=$TLSVERIFY \
         --ulimit nofile=4096:4096 \
@@ -71,10 +68,10 @@ spec:
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /workspace/container_path
-      echo $container > /workspace/container_name
     securityContext:
       capabilities:
         add:
+          # this is needed so that buildah can write to the mounted /var/lib/containers directory
           - SETFCAP
     volumeMounts:
     - mountPath: /var/lib/containers
@@ -84,12 +81,16 @@ spec:
   - name: generate-sboms
     image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
     script: |
-      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=/tmp/files/sbom-source.json
+
       find $(cat /workspace/container_path) -xtype l -delete
-      syft dir:$(cat /workspace/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+
+      syft dir:$(cat /workspace/container_path) --output cyclonedx-json=/tmp/files/sbom-image.json
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
+    - mountPath: /tmp/files
+      name: tmpfiles
 
   - name: merge-sboms
     image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
@@ -122,9 +123,10 @@ spec:
       # write the CycloneDX unified SBOM
       with open("./sbom-cyclonedx.json", "w") as f:
         json.dump(image_sbom, f, indent=4)
-    workingDir: $(workspaces.source.path)
-    securityContext:
-      runAsUser: 0
+    volumeMounts:
+    - mountPath: /tmp/files
+      name: tmpfiles
+    workingDir: /tmp/files
 
   - name: push-image
     image: registry.access.redhat.com/ubi9/buildah@sha256:04fde77ea72c25b56efb3f71db809c5d7b09938130df2da9175a3c888b94043d
@@ -152,7 +154,6 @@ spec:
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
     securityContext:
-      runAsUser: 0
       capabilities:
         add:
           - SETFCAP
@@ -171,11 +172,16 @@ spec:
       - --type
       - cyclonedx
       - $(params.IMAGE)
-    workingDir: $(workspaces.source.path)
+    volumeMounts:
+    - mountPath: /tmp/files
+      name: tmpfiles
+    workingDir: /tmp/files
 
   volumes:
   - emptyDir: {}
     name: varlibcontainers
+  - emptyDir: {}
+    name: tmpfiles
   workspaces:
   - name: source
     description: Workspace containing the source code to build.

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -6,22 +6,17 @@ metadata:
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: "image-build, appstudio, hacbs"
-  name: buildah
+    tekton.dev/tags: "containers, rhtap"
+  name: buildah-rhtap
 spec:
   description: |-
     Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
     In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
-    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
-    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
   - description: Reference of the image buildah will produce.
     name: IMAGE
     type: string
   - default: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
@@ -37,26 +32,6 @@ spec:
     description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
     name: TLSVERIFY
     type: string
-  - description: unused, should be removed in next task version
-    name: DOCKER_AUTH
-    type: string
-    default: ""
-  - default: "false"
-    description: Determines if build will be executed without network access.
-    name: HERMETIC
-    type: string
-  - default: ""
-    description: In case it is not empty, the prefetched content should be made available to the build.
-    name: PREFETCH_INPUT
-    type: string
-  - default: ""
-    description: Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
-    name: IMAGE_EXPIRES_AFTER
-    type: string
-  - name: COMMIT_SHA
-    description: The image is built from this commit.
-    type: string
-    default: ""
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -64,21 +39,10 @@ spec:
     name: IMAGE_URL
   - description: Digests of the base images used for build
     name: BASE_IMAGES_DIGESTS
-  - name: SBOM_JAVA_COMPONENTS_COUNT
-    description: The counting of Java components by publisher in JSON format
-    type: string
-  - name: JAVA_COMMUNITY_DEPENDENCIES
-    description: The Java dependencies that came from community sources such as Maven central.
   stepTemplate:
     env:
-    - name: BUILDAH_FORMAT
-      value: oci
     - name: STORAGE_DRIVER
       value: vfs
-    - name: HERMETIC
-      value: $(params.HERMETIC)
-    - name: PREFETCH_INPUT
-      value: $(params.PREFETCH_INPUT)
     - name: CONTEXT
       value: $(params.CONTEXT)
     - name: DOCKERFILE
@@ -87,101 +51,31 @@ spec:
       value: $(params.IMAGE)
     - name: TLSVERIFY
       value: $(params.TLSVERIFY)
-    - name: IMAGE_EXPIRES_AFTER
-      value: $(params.IMAGE_EXPIRES_AFTER)
   steps:
-  - image: $(params.BUILDER_IMAGE)
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent; our default param above specifies a digest
-    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
-    name: build
-    computeResources:
-      limits:
-        memory: 4Gi
-      requests:
-        memory: 512Mi
-        cpu: 250m
-    env:
-    - name: COMMIT_SHA
-      value: $(params.COMMIT_SHA)
+  - name: build
+    image: $(params.BUILDER_IMAGE)
     script: |
       SOURCE_CODE_DIR=source
       if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
         dockerfile_path="$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$SOURCE_CODE_DIR/$DOCKERFILE"
-      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
-        echo "Fetch Dockerfile from $DOCKERFILE"
-        dockerfile_path=$(mktemp --suffix=-Dockerfile)
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ $http_code != 200 ]; then
-          echo "No Dockerfile is fetched. Server responds $http_code"
-          exit 1
-        fi
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ $http_code = 200 ]; then
-          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
-        fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
         exit 1
-      fi
-      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_path"; then
-        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_path"
-        touch /var/lib/containers/java
       fi
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
 
-      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
-
-      # Setting new namespace to run buildah - 2^32-2
-      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
-
-      if [ "${HERMETIC}" == "true" ]; then
-        BUILDAH_ARGS="--pull=never"
-        UNSHARE_ARGS="--net"
-        for image in $(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}'); do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
-        done
-        echo "Build will be executed with network isolation"
-      fi
-
-      if [ -n "${PREFETCH_INPUT}" ]; then
-        cp -r cachi2 /tmp/
-        chmod -R go+rwX /tmp/cachi2
-        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-        sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
-        echo "Prefetched content will be made available"
-      fi
-
-      LABELS=(
-        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
-        "--label" "architecture=$(uname -m)"
-        "--label" "vcs-type=git"
-      )
-      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
-      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
-
-      unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah build \
-        $VOLUME_MOUNTS \
-        $BUILDAH_ARGS \
-        ${LABELS[@]} \
-        --tls-verify=$TLSVERIFY --no-cache \
+      buildah build \
+        --tls-verify=$TLSVERIFY \
         --ulimit nofile=4096:4096 \
         -f "$dockerfile_path" -t $IMAGE $SOURCE_CODE_DIR/$CONTEXT
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /workspace/container_path
       echo $container > /workspace/container_name
-
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
-      if [ -n "${PREFETCH_INPUT}" ]; then
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
-      fi
-
     securityContext:
       capabilities:
         add:
@@ -191,11 +85,8 @@ spec:
       name: varlibcontainers
     workingDir: $(workspaces.source.path)
 
-  - name: sbom-syft-generate
+  - name: generate-sboms
     image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     script: |
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
       find $(cat /workspace/container_path) -xtype l -delete
@@ -203,29 +94,9 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
-  - name: analyse-dependencies-java-sbom
-    image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:1d417e6f1f3e68c6c537333b5759796eddae0afc
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
-    script: |
-      if [ -f /var/lib/containers/java ]; then
-        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /workspace/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
-        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
-      else
-        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
-      fi
-    volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
-    securityContext:
-      runAsUser: 0
 
-  - name: merge-syft-sboms
+  - name: merge-sboms
     image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     script: |
       #!/bin/python3
       import json
@@ -259,57 +130,11 @@ spec:
     securityContext:
       runAsUser: 0
 
-  - name: merge-cachi2-sbom
-    image: quay.io/redhat-appstudio/cachi2:0.3.0@sha256:46097f22b57e4d48a3fce96d931e08ccfe3a3e6421362d5f9353961279078eef
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
-    script: |
-      if [ -n "${PREFETCH_INPUT}" ]; then
-        echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
-        /src/utils/merge_syft_sbom.py sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
-        mv sbom-temp.json sbom-cyclonedx.json
-      else
-        echo "Skipping step since no Cachi2 SBOM was produced"
-      fi
-    workingDir: $(workspaces.source.path)
-    securityContext:
-      runAsUser: 0
-
-  - name: create-purl-sbom
-    image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
-    script: |
-      #!/bin/python3
-      import json
-
-      with open("./sbom-cyclonedx.json") as f:
-        cyclonedx_sbom = json.load(f)
-
-      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
-      purl_content = {"image_contents": {"dependencies": purls}}
-
-      with open("sbom-purl.json", "w") as output_file:
-        json.dump(purl_content, output_file, indent=4)
-    workingDir: $(workspaces.source.path)
-    securityContext:
-      runAsUser: 0
-
-  - name: inject-sbom-and-push
+  - name: push-image
     image: $(params.BUILDER_IMAGE)
-    computeResources: {}
     script: |
       # Expose base image digests
       buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
-
-      base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
-      base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
-      container=$(buildah from --pull-never $IMAGE)
-      buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
-      buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
-      buildah commit $container $IMAGE
 
       status=-1
       max_run=5
@@ -317,20 +142,19 @@ spec:
       for run in $(seq 1 $max_run); do
         status=0
         [ "$run" -gt 1 ] && sleep $sleep_sec
-        echo "Pushing sbom image to registry"
+        echo "Pushing image to registry"
         buildah push \
           --tls-verify=$TLSVERIFY \
           --digestfile $(workspaces.source.path)/image-digest $IMAGE \
           docker://$IMAGE && break || status=$?
       done
       if [ "$status" -ne 0 ]; then
-          echo "Failed to push sbom image to registry after ${max_run} tries"
+          echo "Failed to push image to registry after ${max_run} tries"
           exit 1
       fi
 
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-
     securityContext:
       runAsUser: 0
       capabilities:
@@ -343,9 +167,6 @@ spec:
 
   - name: upload-sbom
     image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     args:
       - attach
       - sbom

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -72,12 +72,12 @@ spec:
       buildah push \
         --tls-verify=$TLSVERIFY \
         --retry=5 \
-        --digestfile ./image-digest $IMAGE \
+        --digestfile /tmp/files/image-digest $IMAGE \
         docker://$IMAGE
 
       # Set task results
       buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
-      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      cat /tmp/files/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
 
       # Save the image so it can be used in the generate-sbom step

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -111,29 +111,37 @@ spec:
       #!/bin/python3
       import json
 
-      # load SBOMs
+      ### load SBOMs ###
+
       with open("./sbom-image.json") as f:
         image_sbom = json.load(f)
 
       with open("./sbom-source.json") as f:
         source_sbom = json.load(f)
 
-      # fetch unique components from available SBOMs
-      def get_identifier(component):
-        return component["name"] + '@' + component.get("version", "")
 
-      image_sbom_components = image_sbom.get("components", [])
-      existing_components = [get_identifier(component) for component in image_sbom_components]
+      ### attempt to deduplicate components ###
 
-      source_sbom_components = source_sbom.get("components", [])
-      for component in source_sbom_components:
-        if get_identifier(component) not in existing_components:
-          image_sbom_components.append(component)
-          existing_components.append(get_identifier(component))
+      component_list = image_sbom.get("components", [])
+      existing_purls = [c["purl"] for c in component_list if "purl" in c]
 
-      image_sbom_components.sort(key=lambda c: get_identifier(c))
+      for component in source_sbom.get("components", []):
+        if "purl" in component:
+          if component["purl"] not in existing_purls:
+            component_list.append(component)
+            existing_purls.append(component["purl"])
+        else:
+          # We won't try to deduplicate components that lack a purl.
+          # This should only happen with operating-system type components,
+          # which are only reported in the image SBOM.
+          component_list.append(component)
 
-      # write the CycloneDX unified SBOM
+      component_list.sort(key=lambda c: c["type"] + c["name"])
+      image_sbom["components"] = component_list
+
+
+      ### write the CycloneDX unified SBOM ###
+
       with open("./sbom-cyclonedx.json", "w") as f:
         json.dump(image_sbom, f, indent=4)
     volumeMounts:

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -82,8 +82,8 @@ spec:
   - name: generate-sboms
     image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
     script: |
-      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=/tmp/files/sbom-source.json
-      syft oci-dir:/tmp/files/image --output cyclonedx-json=/tmp/files/sbom-image.json
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json@1.5=/tmp/files/sbom-source.json
+      syft oci-dir:/tmp/files/image --output cyclonedx-json@1.5=/tmp/files/sbom-image.json
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -1,0 +1,364 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: "docker"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "image-build, appstudio, hacbs"
+  name: buildah
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+    description: The location of the buildah builder image.
+    name: BUILDER_IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    name: TLSVERIFY
+    type: string
+  - description: unused, should be removed in next task version
+    name: DOCKER_AUTH
+    type: string
+    default: ""
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - name: COMMIT_SHA
+    description: The image is built from this commit.
+    type: string
+    default: ""
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository where the built image was pushed
+    name: IMAGE_URL
+  - description: Digests of the base images used for build
+    name: BASE_IMAGES_DIGESTS
+  - name: SBOM_JAVA_COMPONENTS_COUNT
+    description: The counting of Java components by publisher in JSON format
+    type: string
+  - name: JAVA_COMMUNITY_DEPENDENCIES
+    description: The Java dependencies that came from community sources such as Maven central.
+  stepTemplate:
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: STORAGE_DRIVER
+      value: vfs
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: PREFETCH_INPUT
+      value: $(params.PREFETCH_INPUT)
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+  steps:
+  - image: $(params.BUILDER_IMAGE)
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent; our default param above specifies a digest
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+    name: build
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 512Mi
+        cpu: 250m
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    script: |
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ $http_code != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ $http_code = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_path"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_path"
+        touch /var/lib/containers/java
+      fi
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
+
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS="--pull=never"
+        UNSHARE_ARGS="--net"
+        for image in $(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}'); do
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${PREFETCH_INPUT}" ]; then
+        cp -r cachi2 /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
+        sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+        echo "Prefetched content will be made available"
+      fi
+
+      LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah build \
+        $VOLUME_MOUNTS \
+        $BUILDAH_ARGS \
+        ${LABELS[@]} \
+        --tls-verify=$TLSVERIFY --no-cache \
+        --ulimit nofile=4096:4096 \
+        -f "$dockerfile_path" -t $IMAGE $SOURCE_CODE_DIR/$CONTEXT
+
+      container=$(buildah from --pull-never $IMAGE)
+      buildah mount $container | tee /workspace/container_path
+      echo $container > /workspace/container_name
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -n "${PREFETCH_INPUT}" ]; then
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+    securityContext:
+      capabilities:
+        add:
+          - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+
+  - name: sbom-syft-generate
+    image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+    script: |
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      find $(cat /workspace/container_path) -xtype l -delete
+      syft dir:$(cat /workspace/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+  - name: analyse-dependencies-java-sbom
+    image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:1d417e6f1f3e68c6c537333b5759796eddae0afc
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /workspace/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
+      else
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    securityContext:
+      runAsUser: 0
+
+  - name: merge-syft-sboms
+    image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+    script: |
+      #!/bin/python3
+      import json
+
+      # load SBOMs
+      with open("./sbom-image.json") as f:
+        image_sbom = json.load(f)
+
+      with open("./sbom-source.json") as f:
+        source_sbom = json.load(f)
+
+      # fetch unique components from available SBOMs
+      def get_identifier(component):
+        return component["name"] + '@' + component.get("version", "")
+
+      image_sbom_components = image_sbom.get("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
+
+      source_sbom_components = source_sbom.get("components", [])
+      for component in source_sbom_components:
+        if get_identifier(component) not in existing_components:
+          image_sbom_components.append(component)
+          existing_components.append(get_identifier(component))
+
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
+
+      # write the CycloneDX unified SBOM
+      with open("./sbom-cyclonedx.json", "w") as f:
+        json.dump(image_sbom, f, indent=4)
+    workingDir: $(workspaces.source.path)
+    securityContext:
+      runAsUser: 0
+
+  - name: merge-cachi2-sbom
+    image: quay.io/redhat-appstudio/cachi2:0.3.0@sha256:46097f22b57e4d48a3fce96d931e08ccfe3a3e6421362d5f9353961279078eef
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+    script: |
+      if [ -n "${PREFETCH_INPUT}" ]; then
+        echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
+        /src/utils/merge_syft_sbom.py sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
+        mv sbom-temp.json sbom-cyclonedx.json
+      else
+        echo "Skipping step since no Cachi2 SBOM was produced"
+      fi
+    workingDir: $(workspaces.source.path)
+    securityContext:
+      runAsUser: 0
+
+  - name: create-purl-sbom
+    image: registry.access.redhat.com/ubi9/python-39:1-158@sha256:967000729b17efdea309e297f4b1961c38b902a1ef18f6d886b8086c2a12f01f
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+    script: |
+      #!/bin/python3
+      import json
+
+      with open("./sbom-cyclonedx.json") as f:
+        cyclonedx_sbom = json.load(f)
+
+      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
+      purl_content = {"image_contents": {"dependencies": purls}}
+
+      with open("sbom-purl.json", "w") as output_file:
+        json.dump(purl_content, output_file, indent=4)
+    workingDir: $(workspaces.source.path)
+    securityContext:
+      runAsUser: 0
+
+  - name: inject-sbom-and-push
+    image: $(params.BUILDER_IMAGE)
+    computeResources: {}
+    script: |
+      # Expose base image digests
+      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
+
+      base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
+      base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
+      container=$(buildah from --pull-never $IMAGE)
+      buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
+      buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
+      buildah commit $container $IMAGE
+
+      status=-1
+      max_run=5
+      sleep_sec=10
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec
+        echo "Pushing sbom image to registry"
+        buildah push \
+          --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          docker://$IMAGE && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to push sbom image to registry after ${max_run} tries"
+          exit 1
+      fi
+
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+
+    securityContext:
+      runAsUser: 0
+      capabilities:
+        add:
+          - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+
+  - name: upload-sbom
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+    args:
+      - attach
+      - sbom
+      - --sbom
+      - sbom-cyclonedx.json
+      - --type
+      - cyclonedx
+      - $(params.IMAGE)
+    workingDir: $(workspaces.source.path)
+
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  workspaces:
+  - name: source
+    description: Workspace containing the source code to build.

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -66,8 +66,7 @@ spec:
         --ulimit nofile=4096:4096 \
         -f "$dockerfile_path" -t $IMAGE $SOURCE_CODE_DIR/$CONTEXT
 
-      container=$(buildah from --pull-never $IMAGE)
-      buildah mount $container | tee /workspace/container_path
+      buildah push "$IMAGE" oci:/tmp/files/image
     securityContext:
       capabilities:
         add:
@@ -76,16 +75,15 @@ spec:
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers
+    - mountPath: /tmp/files
+      name: tmpfiles
     workingDir: $(workspaces.source.path)
 
   - name: generate-sboms
     image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
     script: |
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=/tmp/files/sbom-source.json
-
-      find $(cat /workspace/container_path) -xtype l -delete
-
-      syft dir:$(cat /workspace/container_path) --output cyclonedx-json=/tmp/files/sbom-image.json
+      syft oci-dir:/tmp/files/image --output cyclonedx-json=/tmp/files/sbom-image.json
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -16,10 +16,6 @@ spec:
   - description: Reference of the image buildah will produce.
     name: IMAGE
     type: string
-  - default: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
-    description: The location of the buildah builder image.
-    name: BUILDER_IMAGE
-    type: string
   - default: ./Dockerfile
     description: Path to the Dockerfile to build.
     name: DOCKERFILE
@@ -53,7 +49,7 @@ spec:
       value: $(params.TLSVERIFY)
   steps:
   - name: build
-    image: $(params.BUILDER_IMAGE)
+    image: registry.access.redhat.com/ubi9/buildah@sha256:04fde77ea72c25b56efb3f71db809c5d7b09938130df2da9175a3c888b94043d
     script: |
       SOURCE_CODE_DIR=source
       if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
@@ -131,7 +127,7 @@ spec:
       runAsUser: 0
 
   - name: push-image
-    image: $(params.BUILDER_IMAGE)
+    image: registry.access.redhat.com/ubi9/buildah@sha256:04fde77ea72c25b56efb3f71db809c5d7b09938130df2da9175a3c888b94043d
     script: |
       # Expose base image digests
       buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -51,6 +51,7 @@ spec:
   - name: build
     image: registry.access.redhat.com/ubi9/buildah@sha256:04fde77ea72c25b56efb3f71db809c5d7b09938130df2da9175a3c888b94043d
     script: |
+      # Check if the Dockerfile exists
       SOURCE_CODE_DIR=source
       if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
         dockerfile_path="$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
@@ -61,11 +62,25 @@ spec:
         exit 1
       fi
 
+      # Build the image
       buildah build \
         --tls-verify=$TLSVERIFY \
         --ulimit nofile=4096:4096 \
         -f "$dockerfile_path" -t $IMAGE $SOURCE_CODE_DIR/$CONTEXT
 
+      # Push the image
+      buildah push \
+        --tls-verify=$TLSVERIFY \
+        --retry=5 \
+        --digestfile ./image-digest $IMAGE \
+        docker://$IMAGE
+
+      # Set task results
+      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+
+      # Save the image so it can be used in the generate-sbom step
       buildah push "$IMAGE" oci:/tmp/files/image
     securityContext:
       capabilities:
@@ -125,40 +140,6 @@ spec:
     - mountPath: /tmp/files
       name: tmpfiles
     workingDir: /tmp/files
-
-  - name: push-image
-    image: registry.access.redhat.com/ubi9/buildah@sha256:04fde77ea72c25b56efb3f71db809c5d7b09938130df2da9175a3c888b94043d
-    script: |
-      # Expose base image digests
-      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
-
-      status=-1
-      max_run=5
-      sleep_sec=10
-      for run in $(seq 1 $max_run); do
-        status=0
-        [ "$run" -gt 1 ] && sleep $sleep_sec
-        echo "Pushing image to registry"
-        buildah push \
-          --tls-verify=$TLSVERIFY \
-          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
-          docker://$IMAGE && break || status=$?
-      done
-      if [ "$status" -ne 0 ]; then
-          echo "Failed to push image to registry after ${max_run} tries"
-          exit 1
-      fi
-
-      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
-      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-    securityContext:
-      capabilities:
-        add:
-          - SETFCAP
-    volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
-    workingDir: $(workspaces.source.path)
 
   - name: upload-sbom
     image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5

--- a/task/buildah-rhtap/OWNERS
+++ b/task/buildah-rhtap/OWNERS
@@ -1,0 +1,1 @@
+Konflux Build Team


### PR DESCRIPTION
This PR proposes a new simplified and improved buildah task to be used for the new RHTAP docker build  pipeline.

Compared to the current Konflux buildah task, this task:
- Removes all the Konflux-specific features that are not needed in RHTAP
- Uses a productized version of the buildah image
- Removes root access from all steps
- Sets the correct Syft catalogers when scanning the built image
- Pins the output CycloneDX version
- Avoids littering the source code workspace with temporary files
- Improves the SBOM merge algorithm (dedup by PURL)
- Add a the SBOM OCI artifact URL as a task result
- Changes the tags