### PR TITLE
chore: sync tasks from tekton tools

### DIFF
--- a/task/generate-odcs-compose/0.1/README.md
+++ b/task/generate-odcs-compose/0.1/README.md
@@ -1,0 +1,56 @@
+# generate-odcs-compose task
+
+## Description:
+This task generates compose (yum repository) files that can be later on mounted during
+build tasks and used for installing RPMs. It uses ODCS (On Demand Compose Service) for
+generating composes.
+
+The task takes inputs in [structure][input structure] defined by the ODCS Python client.
+
+It stores the generated compose inside a directory provided as input, that can later on
+be mounted during a build task.
+
+The input is provided inside a YAML file with its root containing a single element
+named `composes`. This element is a list in which each entry is to be converted
+into inputs for a single call to ODCS.
+
+Element fields:
+
+* kind: Corresponds to sub-types of [`ComposeSourceGeneric`][input structure].
+* spec: keyword arguments related to the compose source
+* additional_args: flat-list of additional compose keyword arguments.
+
+Example:
+
+composes:
+    - kind: ComposeSourceModule
+      spec:
+        modules:
+          - squid:4:8090020231130092412:a75119d5
+      additional_args: {}
+
+[input structure]: https://pagure.io/odcs/blob/master/f/client/odcs/client/odcs.py#_115
+
+
+## Params:
+
+| name            | description                                                       |
+|-----------------|-------------------------------------------------------------------|
+| IMAGE           | Image used for running the tasks's script                         |
+| COMPOSE_INPUTS  | relative path from workdir workspace to the compose inputs file   |
+| COMPOSE_OUTPUTS | relative path from workdir workspace to store compose output files|
+| KT_PATH         | Path to mount keytab to be used for authentication with ODCS      |
+| KRB_CACHE_PATH  | Path to store Kerberos cache                                      |
+
+
+## Results:
+
+| name              | description                                  |
+|-------------------|----------------------------------------------|
+| repodir_path      | Directory to write the resulting .repo files |
+
+## Source repository for image:
+https://github.com/redhat-appstudio/tools
+
+## Source repository for task:
+https://github.com/redhat-appstudio/tekton-tools

--- a/task/generate-odcs-compose/0.1/generate-odcs-compose.yaml
+++ b/task/generate-odcs-compose/0.1/generate-odcs-compose.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: generate-odcs-compose
+spec:
+  params:
+    - name: IMAGE
+      type: string
+      description: The image to use for this task
+    - name: KT_PATH
+      type: string
+      description: path to mount keytab
+      default: /tmp/kt
+    - name: KRB_CACHE_PATH
+      description: path to krb cache
+      default: /tmp/krb5ccname
+    - name: COMPOSE_INPUTS
+      description: relative path from workdir workspace to the compose inputs file
+      default: compose_inputs.yaml
+    - name: COMPOSE_OUTPUTS
+      description: relative path from workdir workspace to store compose output files
+      default: repos
+  workspaces:
+    - name: workdir
+      description: |
+        Working directory that will be used for reading configuration files
+        and writing the output
+    - name: keytab-secret
+      description: for storing keytab secret
+      mountPath: "$(params.KT_PATH)"
+    - name: krb-cache
+      description: location of krb cache
+      mountPath: "$(params.KRB_CACHE_PATH)"
+  results:
+    - name: repodir_path
+      description: Directory to write the result .repo files.
+  steps:
+    - name: generate-odcs-compose
+      image: "$(params.IMAGE)"
+      env:
+        - name: KRB5CCNAME
+          value: "$(params.KRB_CACHE_PATH)/krb5ccname"
+        - name: KRB5_CLIENT_KTNAME
+          value: "$(params.KT_PATH)/keytab"
+      script: |
+        #!/bin/bash
+        set -ex
+
+        repodir_path="$(workspaces.workdir.path)/$(params.COMPOSE_OUTPUTS)"
+
+        cd "$(workspaces.workdir.path)"
+
+        odcs_compose_generator \
+          --compose-input-yaml-path $(params.COMPOSE_INPUTS) \
+          --compose-dir-path "${repodir_path}"
+
+        echo "$repodir_path" > $(results.repodir_path.path)

--- a/task/generate-odcs-compose/OWNERS
+++ b/task/generate-odcs-compose/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- yftacherzog
+- avi-biton
+- gbenhaim

--- a/task/verify-signed-rpms/0.1/README.md
+++ b/task/verify-signed-rpms/0.1/README.md
@@ -1,0 +1,30 @@
+# verify-signed-rpms.yaml task
+
+## Description:
+This tasks checks whether the images it is provided with contain any unsigned RPMs.
+
+It can be used in two modes. Depending on the value of parameter `FAIL_UNSIGNED`, it
+will either fail any run that find unsigned RPMs, or only report its finding without
+failing (the latter is useful when running inside a build pipeline which tests the use of RPMs before their official release).
+
+## Params:
+
+| name            | description                                                       |
+|-----------------|-------------------------------------------------------------------|
+| IMAGE           | Image used for running the tasks's script                         |
+| INPUT           | AppStudio snapshot or a reference to a container image            |
+| FAIL_UNSIGNED   | [true \| false] If true fail if unsigned RPMs were found          |
+| WORKDIR         | directory for storing temporary files                             |
+
+
+## Results:
+
+| name              | description                               |
+|-------------------|-------------------------------------------|
+| repodir_path      | Directory to write the resulting .repo files |
+
+## Source repository for image:
+https://github.com/redhat-appstudio/tools
+
+## Source repository for task:
+https://github.com/redhat-appstudio/tekton-tools

--- a/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
+++ b/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: verify-signed-rpms
+spec:
+  params:
+    - name: IMAGE
+      type: string
+      description: The image to use for this task
+      default: ""
+    - name: INPUT
+      type: string
+      description: "AppStudio snapshot or a reference to a container image"
+    - name: FAIL_UNSIGNED
+      type: string
+      description: "[true | false] If true fail if unsigned RPMs were found"
+      default: ""
+    - name: WORKDIR
+      type: string
+      default: /tmp
+      description: |
+        Directory that will be used for storing temporary
+        files produced by this task.
+  results:
+    - name: verification-output
+      description: script output
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  steps:
+    - name: verify-signed-rpms
+      image: "$(params.IMAGE)"
+      volumeMounts:
+        - name: workdir
+          mountPath: "$(params.WORKDIR)"
+      script: |
+        #!/bin/bash
+        set -ex
+        set -o pipefail
+
+        rpm_verifier \
+          --input '$(params.INPUT)' \
+          --fail-unsigned "$(params.FAIL_UNSIGNED)" \
+          --workdir "$(params.WORKDIR)" 2>&1 \
+          | tee $(results.verification-output.path)

--- a/task/verify-signed-rpms/OWNERS
+++ b/task/verify-signed-rpms/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- yftacherzog
+- avi-biton
+- gbenhaim


### PR DESCRIPTION
This PR copying two new tasks coming from repo
https://github.com/redhat-appstudio/tekton-tools
In the future, this sort of sync will happen automatically upon changes to the tasks, but we're still working on the automation.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
