### PR TITLE
Update Cachi2 to 0.4.0

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -360,7 +360,7 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/redhat-appstudio/cachi2:0.3.0@sha256:46097f22b57e4d48a3fce96d931e08ccfe3a3e6421362d5f9353961279078eef
+    image: quay.io/redhat-appstudio/cachi2:0.4.0@sha256:001acfbad47e132a90998d45076a0dbe0d8beacf0bec12b4d9a5aa796f4a9cad
     name: merge-cachi2-sbom
     script: |
       if [ -n "${PREFETCH_INPUT}" ]; then

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -293,7 +293,7 @@ spec:
       runAsUser: 0
 
   - name: merge-cachi2-sbom
-    image: quay.io/redhat-appstudio/cachi2:0.3.0@sha256:46097f22b57e4d48a3fce96d931e08ccfe3a3e6421362d5f9353961279078eef
+    image: quay.io/redhat-appstudio/cachi2:0.4.0@sha256:001acfbad47e132a90998d45076a0dbe0d8beacf0bec12b4d9a5aa796f4a9cad
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -15,7 +15,7 @@ spec:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
   steps:
-  - image: quay.io/redhat-appstudio/cachi2:0.3.0@sha256:46097f22b57e4d48a3fce96d931e08ccfe3a3e6421362d5f9353961279078eef
+  - image: quay.io/redhat-appstudio/cachi2:0.4.0@sha256:001acfbad47e132a90998d45076a0dbe0d8beacf0bec12b4d9a5aa796f4a9cad
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.


### PR DESCRIPTION
This change is done manually here since the combined PR created by renovate (#722) also bumps Syft's version, which would bring breaking changes from CycloneDX 1.5. Those will be handled in follow up patches.