### PR TITLE
STONEBLD-1936: Added retry mechanism and don't fail the pipeline on show-sbom task failure

### DIFF
--- a/task/show-sbom/0.1/show-sbom.yaml
+++ b/task/show-sbom/0.1/show-sbom.yaml
@@ -25,11 +25,20 @@ spec:
     - name: IMAGE_URL
       value: $(params.IMAGE_URL)
     script: |
-       #!/busybox/sh
-       cosign download sbom $IMAGE_URL 2>err
-       RET=$?
-       if [ $RET -ne 0 ]; then
-         echo Failed to get SBOM >&2
-         cat err >&2
-       fi
-       exit $RET
+      #!/busybox/sh
+      status=-1
+      max_try=5
+      wait_sec=2
+      for run in $(seq 1 $max_try); do
+        status=0
+        cosign download sbom $IMAGE_URL 2>>err
+        status=$?
+        if [ "$status" -eq 0 ]; then
+          break
+        fi
+        sleep $wait_sec
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to get SBOM after ${max_try} tries" >&2
+          cat err >&2
+      fi


### PR DESCRIPTION
Addresses: https://issues.redhat.com/browse/STONEBLD-1936
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
