### PR TITLE
Don't run e2e tests in verbose mode

### DIFF
--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -23,7 +23,6 @@ spec:
       # against build-definitions to update this tag
       args: [
         "--ginkgo.label-filter=build-templates-e2e",
-        "--ginkgo.v",
         "--ginkgo.no-color"
       ]
       securityContext:


### PR DESCRIPTION
Running tests in verbose mode makes it nearly impossible to troubleshoot test failures. This disables it. Rationale: when running in verbose mode the test using the `GinkgoWriter` will cause immediate output to the stdout/log, for the build tests in particular this causes logging excessive amounts of Task logs from the SBOM task[1]. The difference when not running in verbose mode is that that output is buffered and only written to stdout/log IF the test fails[2]. Given that PipelineRuns are garbage collected almost immediately up on execution, the only resource available is to search for the CI logs through Splunk. This fails short because we can only page through the first 100 pages of logs, which in all certainty will not contain the test failure, just the excessive JSON output from the SBOM task.

Example in [3]

[1] https://github.com/redhat-appstudio/e2e-tests/blob/96a7c40d440d86b2d4c3b95c000ed73b1d81ea4b/tests/build/build_templates.go#L169
[2] https://pkg.go.dev/github.com/onsi/ginkgo#pkg-variables
[3] https://rhcorporate.splunkcloud.com/en-US/app/search/build_definitions_ci_logs?form.commit=173f46c912da493095b47e0b37972544ccd57617