### PR TITLE
Remove unused parameters and result

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -34,10 +34,6 @@ spec:
       name: skip-checks
       type: string
       default: "false"
-    - description: Skip optional checks, set false if you want to run optional checks
-      name: skip-optional
-      type: string
-      default: "true"
     - description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -66,15 +62,9 @@ spec:
           value: "$(params.rebuild)"
         - name: skip-checks
           value: "$(params.skip-checks)"
-        - name: skip-optional
-          value: "$(params.skip-optional)"
-        - name: pipelinerun-name
-          value: "$(context.pipelineRun.name)"
-        - name: pipelinerun-uid
-          value: "$(context.pipelineRun.uid)"
       taskRef:
         name: init
-        version: "0.1"
+        version: "0.2"
     - name: clone-repository
       when:
       - input: $(tasks.init.results.build)

--- a/task/init/0.2/MIGRATION.md
+++ b/task/init/0.2/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration from 0.1 to 0.2
+
+The parameters `skip-optional`, `pipelinerun-name` and ` pipelinerun-uid` used by `init` task were removed.
+
+## Action from users
+
+Update files in Pull-Request created by RHTAP bot:
+- Search for the task named `init`
+- Remove the `skip-optional`, `pipelinerun-name` and ` pipelinerun-uid` parameters from the params section

--- a/task/init/0.2/README.md
+++ b/task/init/0.2/README.md
@@ -1,0 +1,15 @@
+# init task
+
+Initialize Pipeline Task, include flags for rebuild and auth. Generates image repository secret used by the PipelineRun.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|image-url|Image URL for build by PipelineRun||true|
+|rebuild|Rebuild the image if exists|false|false|
+|skip-checks|Skip checks against built image|false|false|
+
+## Results
+|name|description|
+|---|---|
+|build|Defines if the image in param image-url should be built|

--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio, hacbs"
+  name: init
+spec:
+  description: >-
+    Initialize Pipeline Task, include flags for rebuild and auth. Generates image repository secret used by the PipelineRun.
+  params:
+    - name: image-url
+      description: Image URL for build by PipelineRun
+    - name: rebuild
+      description: Rebuild the image if exists
+      default: "false"
+    - name: skip-checks
+      description: Skip checks against built image
+      default: "false"
+  results:
+    - name: build
+      description: Defines if the image in param image-url should be built
+
+  steps:
+    - name: init
+      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: REBUILD
+          value: $(params.rebuild)
+        - name: SKIP_CHECKS
+          value: $(params.skip-checks)
+      script: |
+        #!/bin/bash
+        echo "Build Initialize: $IMAGE_URL"
+        echo
+
+        echo "Determine if Image Already Exists"
+        # Build the image when image does not exists or rebuild is set to true
+        if ! oc image info $IMAGE_URL &>/dev/null || [ "$REBUILD" == "true" ] || [ "$SKIP_CHECKS" == "false" ]; then
+          echo -n "true" > $(results.build.path)
+        else
+          echo -n "false" > $(results.build.path)
+        fi


### PR DESCRIPTION
The parameters skip-optional, pipelinerun-name and pipelinerun-uid are no longer used in init task and neither is the container-registry-secret result.
New version for init task was created together with the migration doc and the reference was updated in the pipeline

[STONEBLD-2000](https://issues.redhat.com//browse/STONEBLD-2000)
