### PR TITLE
fix: remove --alert-broken and --alert-broken-media from clamscan

### DIFF
--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -76,7 +76,7 @@ spec:
           --max-scantime=0 --max-files=0 --max-recursion=1000 --max-dir-recursion=20000 --max-embeddedpe=4095M \
           --max-htmlnormalize=4095M --max-htmlnotags=4095M --max-scriptnormalize=4095M --max-ziptypercg=4095M \
           --max-partitions=50000 --max-iconspe=100000 --max-rechwp3=20000 --pcre-match-limit=100000000 --pcre-recmatch-limit=2000000 \
-          --pcre-max-filesize=4095M --alert-broken=yes --alert-exceeds-max=yes --alert-broken-media=yes \
+          --pcre-max-filesize=4095M --alert-exceeds-max=yes \
           --alert-encrypted=yes --alert-encrypted-archive=yes --alert-encrypted-doc=yes --alert-macros=yes \
           --alert-phishing-ssl=yes --alert-phishing-cloak=yes --alert-partition-intersection=yes \
           | tee /tekton/home/clamscan-result.log || true


### PR DESCRIPTION
* Remove --alert-broken from clamav scan args since this cause false positive alert

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
