### PR TITLE
chore(STONEINTG-612): deprecate deprecated-base-image-check v0.1, v0.2

### DIFF
--- a/task/deprecated-image-check/0.1/README.md
+++ b/task/deprecated-image-check/0.1/README.md
@@ -1,10 +1,15 @@
 # deprecated-image-check task
 
+## Deprecation notice
+
+This task version is deprecated, please use the latest version.
+Deprecation date: 2024-04-30
+
 ## Description:
 The deprecated-image-check checks for deprecated images that are no longer maintained and prone to security issues.
 It accomplishes this by verifying the data using Pyxis to query container image data and running Conftest using the
 supplied conftest policy. Conftest is an open-source tool that provides a way to enforce policies written
-in a high-level declarative language called Rego. 
+in a high-level declarative language called Rego.
 
 ## Params:
 

--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -43,6 +43,8 @@ spec:
         source /utils.sh
         trap 'handle_error' EXIT
 
+        echo "[WARNING] This task version is deprecated, please use the latest version. (Deprecation date: 2024-04-30)"
+
         readarray -t IMAGE_ARRAY < <(echo -n "$BASE_IMAGES_DIGESTS" | sed 's/\\n/\'$'\n''/g')
         for BASE_IMAGE in ${IMAGE_ARRAY[@]};
         do

--- a/task/deprecated-image-check/0.2/README.md
+++ b/task/deprecated-image-check/0.2/README.md
@@ -1,10 +1,15 @@
 # deprecated-image-check task
 
+## Deprecation notice
+
+This task version is deprecated, please use the latest version.
+Deprecation date: 2024-04-30
+
 ## Description:
 The deprecated-image-check checks for deprecated images that are no longer maintained and prone to security issues.
 It accomplishes this by verifying the data using Pyxis to query container image data and running Conftest using the
 supplied conftest policy. Conftest is an open-source tool that provides a way to enforce policies written
-in a high-level declarative language called Rego. 
+in a high-level declarative language called Rego.
 
 ## Params:
 

--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -43,6 +43,8 @@ spec:
         source /utils.sh
         trap 'handle_error' EXIT
 
+        echo "[WARNING] This task version is deprecated, please use the latest version. (Deprecation date: 2024-04-30)"
+
         readarray -t IMAGE_ARRAY < <(echo -n "$BASE_IMAGES_DIGESTS" | sed 's/\\n/\'$'\n''/g')
         for BASE_IMAGE in ${IMAGE_ARRAY[@]};
         do


### PR DESCRIPTION
Task deprecated-base-image-check in versions 0.1 and 0.2 is deprecated and support for it will be removed in near future. Use the version 0.3+

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
