### PR TITLE
Support replacing the step image in task bundles

### DIFF
--- a/.github/workflows/check-buildah-remote.yaml
+++ b/.github/workflows/check-buildah-remote.yaml
@@ -1,5 +1,5 @@
 name: Validate PR - buildah-remote
-on:
+'on':
   pull_request:
     branches: [main]
 jobs:

--- a/hack/test-shellspec.sh
+++ b/hack/test-shellspec.sh
@@ -20,6 +20,7 @@ function cleanup() {
 trap cleanup EXIT
 readarray CHANGED_FILES < <({ if [[ -n "${GITHUB_ACTIONS:-}" ]]; then git diff HEAD~1 --name-only; else git diff .."${REF}" --name-only; git status --porcelain=v1 | cut -c 4-; fi; }| uniq)
 
+BIN_BASH=`which bash`
 for CHANGED in "${CHANGED_FILES[@]}"; do
     CHANGED_DIR="${ROOT}/$(dirname "${CHANGED}")"
     for SPEC_DIR in "${SPEC_DIRS[@]}"; do
@@ -29,7 +30,7 @@ for CHANGED in "${CHANGED_FILES[@]}"; do
             SPEC_DIRS=("${SPEC_DIRS[@]/${SPEC_DIR}}")
             [[ -n "${GITHUB_ACTIONS:-}" ]] && echo "::group::Shellspec test in ${SPEC_DIR}"
             echo -e "Detected changes in \033[1m${CHANGED_DIR}\033[0m, running tests"
-            PARAMS=(--chdir "${SPEC_DIR}" --shell /usr/bin/bash)
+            PARAMS=(--chdir "${SPEC_DIR}" --shell $BIN_BASH)
             [[ -n "${GITHUB_ACTIONS:-}" ]] && PARAMS+=(--format github -I "${ROOT}/hack/shellspec")
             if ! command -v shellspec &> /dev/null; then
                 curl -fsSL https://git.io/shellspec | sh -s -- --yes

--- a/task/tkn-bundle/0.1/spec/test1.yaml
+++ b/task/tkn-bundle/0.1/spec/test1.yaml
@@ -2,3 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: test1
+spec:
+  steps:
+    - name: test1-step
+      image: ubuntu

--- a/task/tkn-bundle/0.1/spec/test2.yml
+++ b/task/tkn-bundle/0.1/spec/test2.yml
@@ -2,3 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: test2
+spec:
+  steps:
+    - name: test2-step
+      image: ubuntu

--- a/task/tkn-bundle/0.1/spec/test3.yaml
+++ b/task/tkn-bundle/0.1/spec/test3.yaml
@@ -2,3 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: test3
+spec:
+  steps:
+    - name: test3-step
+      image: ubuntu

--- a/task/tkn-bundle/0.1/spec/tkn-bundle_spec.sh
+++ b/task/tkn-bundle/0.1/spec/tkn-bundle_spec.sh
@@ -54,7 +54,7 @@ spec:
 ' | kubectl apply -f -
 
     # Image to run the setup pod with, taken from the Task definition
-    IMAGE="$(kubectl get task tkn-bundle -o=jsonpath='{.spec.steps[0].image}')"
+    IMAGE="$(kubectl get task tkn-bundle -o=jsonpath='{.spec.steps[1].image}')"
     # Semi-random name for the setup Pod
     SETUP_POD="setup-$(date +%s)"
     # Run the pod with the volume mounted at /source, the container is blocking

--- a/task/tkn-bundle/0.1/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.1/tkn-bundle.yaml
@@ -23,6 +23,10 @@ spec:
     type: string
     description: Value for the HOME environment variable.
     default: /tekton/home
+  - name: STEPS_IMAGE
+    type: string
+    description: An optional image to configure task steps with in the bundle
+    default: ""
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -32,17 +36,16 @@ spec:
     env:
     - name: HOME
       value: "$(params.HOME)"
+    - name: TASK_FILE
+      value: tekton_task_files
   steps:
-  - image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:5.0
-    name: build
+  - image: registry.access.redhat.com/ubi9/toolbox@sha256:7391628396216c011ed3a310f1fa54c6a9221e36f7fa59c94ae7796de51e7a25
+    name: modify-task-files
     env:
     - name: CONTEXT
       value: $(params.CONTEXT)
-    - name: IMAGE
-      value: $(params.IMAGE)
     script: |
       #!/bin/env bash
-
       set -o errexit
       set -o pipefail
       set -o nounset
@@ -96,15 +99,43 @@ spec:
           done
         fi
       done
+
+      if [[ -n "$(params.STEPS_IMAGE)" ]]; then
+        for f in "${FILES[@]}"; do
+          yq e '(.spec.steps[] | select(has("image")).image) = "$(params.STEPS_IMAGE)"' -i $f
+        done
+      fi
+
+      printf "%s\n" "${FILES[@]}" > "${TASK_FILE}"
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:5.0
+    name: build
+    env:
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    script: |
+      #!/bin/env bash
+
+      set -o errexit
+      set -o pipefail
+      set -o nounset
+
+      mapfile -t FILES < "${TASK_FILE}"
       [[ ${#FILES[@]} -eq 0 ]] \
         && echo "No YAML files matched by \"$CONTEXT\" in \"$(workspaces.source.path)\", aborting the build" \
         && exit 1
       exec 3>&1;
+
       OUT="$(tkn bundle push "$IMAGE" \
         $(printf ' -f %s' "${FILES[@]}") \
         |tee /proc/self/fd/3)"
       echo -n "$IMAGE" > $(results.IMAGE_URL.path)
       echo -n "${OUT#*Pushed Tekton Bundle to *@}" > $(results.IMAGE_DIGEST.path)
+
+      # cleanup task file
+      [[ -f "${TASK_FILE}" ]] && rm -f "${TASK_FILE}"
     workingDir: $(workspaces.source.path)
   workspaces:
   - name: source


### PR DESCRIPTION
This change introduces a new parameter called STEPS_IMAGE, which allows you to include a custom image for each step in the bundled tasks. 
https://issues.redhat.com/browse/EC-35