### PR TITLE
Pin Syft's output format to CycloneDX 1.4

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -303,9 +303,9 @@ spec:
     image: quay.io/redhat-appstudio/syft:v0.98.0@sha256:4d3856e6a2622700b9a9d5d74d9aaf5d8a55671653f80bf6c636677658680ede
     name: sbom-syft-generate
     script: |
-      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json@1.4=$(workspaces.source.path)/sbom-source.json
       find $(cat /workspace/container_path) -xtype l -delete
-      syft dir:$(cat /workspace/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+      syft dir:$(cat /workspace/container_path) --output cyclonedx-json@1.4=$(workspaces.source.path)/sbom-image.json
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -230,9 +230,9 @@ spec:
     # the cluster will set imagePullPolicy to IfNotPresent
     # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     script: |
-      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json@1.4=$(workspaces.source.path)/sbom-source.json
       find $(cat /workspace/container_path) -xtype l -delete
-      syft dir:$(cat /workspace/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+      syft dir:$(cat /workspace/container_path) --output cyclonedx-json@1.4=$(workspaces.source.path)/sbom-image.json
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -145,7 +145,7 @@ spec:
       requests:
         memory: 6Gi
     script: |
-      syft oci-dir:/var/lib/containers/rhtap-final-image --output cyclonedx-json=$(workspaces.source.path)/sbom-cyclonedx.json
+      syft oci-dir:/var/lib/containers/rhtap-final-image --output cyclonedx-json@1.4=$(workspaces.source.path)/sbom-cyclonedx.json
     volumeMounts:
       - mountPath: /var/lib/containers
         name: varlibcontainers

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -154,9 +154,9 @@ spec:
     # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: sbom-syft-generate
     script: |
-      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json@1.4=$(workspaces.source.path)/sbom-source.json
       find $(cat /workspace/container_path) -xtype l -delete
-      syft dir:$(cat /workspace/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+      syft dir:$(cat /workspace/container_path) --output cyclonedx-json@1.4=$(workspaces.source.path)/sbom-image.json
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -135,9 +135,9 @@ spec:
     # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: sbom-syft-generate
     script: |
-      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json@1.4=$(workspaces.source.path)/sbom-source.json
       find $(cat /workspace/container_path) -xtype l -delete
-      syft dir:$(cat /workspace/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+      syft dir:$(cat /workspace/container_path) --output cyclonedx-json@1.4=$(workspaces.source.path)/sbom-image.json
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers


### PR DESCRIPTION
Newer versions of Syft may default to newer versions of CycloneDX (as observed in the recent [0.99.0](https://github.com/anchore/syft/tree/v0.99.0) version). The problem is that the schema is bound to change between CycloneDX versions, which can bring breaking changes to the pipelines, specially to the scripts that merge different SBOMS.

This patch unblocks the update of Syft to `>=0.99` (#722).