### PR TITLE
Disable PR EC checks

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -201,14 +201,15 @@ spec:
         workspaces:
           - name: source
             workspace: workspace
-      - name: ec-task-checks
-        runAfter:
-          - fetch-repository
-        taskRef:
-          name: ec-checks
-        workspaces:
-          - name: source
-            workspace: workspace
+      # This will be re-enabled as part of https://issues.redhat.com/browse/EC-332
+      # - name: ec-task-checks
+      #   runAfter:
+      #     - fetch-repository
+      #   taskRef:
+      #     name: ec-checks
+      #   workspaces:
+      #     - name: source
+      #       workspace: workspace
       - name: check-task-migration-md
         runAfter:
           - fetch-repository


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/EC-356, a check was added to ensure Task steps use images from reputable registries. However, some existing Tasks do not meet this criteria. This will be addressed in https://issues.redhat.com/browse/KONFLUX-2034. This effort is being tracked by the Epic https://issues.redhat.com/browse/EC-332.

Also, the existing check uses `ec validate definition` which doesn't fully allow customization of which policies are executed. It just runs all of the ones from the "task" namespace.

Finally, the previous rules basically checks that a Task has the kind attribute set to "Task", which is not very valuable.

For now, let's disable the EC checks altogether. They will be properly re-enabled as part of the epic EC-332.

