### PR TITLE
Fix yamllint

### DIFF
--- a/.tekton/tasks/yaml-lint.yaml
+++ b/.tekton/tasks/yaml-lint.yaml
@@ -40,7 +40,7 @@ spec:
       script: |
         #!/bin/bash
         for task in $(find task -name '*.yaml'); do
-          if yq '.spec.steps[] | .script' $task | grep -q 'params\.'; then
+          if yq '.spec?.steps[] | .script' $task | grep -q 'params\.'; then
             FAILED_TASKS="$FAILED_TASKS $task"
           fi
         done

--- a/task/tkn-bundle/0.1/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.1/tkn-bundle.yaml
@@ -44,6 +44,8 @@ spec:
     env:
     - name: CONTEXT
       value: $(params.CONTEXT)
+    - name: STEPS_IMAGE
+      value: $(params.STEPS_IMAGE)
     script: |
       #!/bin/env bash
       set -o errexit
@@ -100,9 +102,9 @@ spec:
         fi
       done
 
-      if [[ -n "$(params.STEPS_IMAGE)" ]]; then
+      if [[ -n "${STEPS_IMAGE}" ]]; then
         for f in "${FILES[@]}"; do
-          yq e '(.spec.steps[] | select(has("image")).image) = "$(params.STEPS_IMAGE)"' -i $f
+          yq e '(.spec.steps[] | select(has("image")).image) = "env(STEPS_IMAGE)"' -i $f
         done
       fi
 


### PR DESCRIPTION
```
Ignore files without spec in yamllint

This commit modifies the `ensure-params-not-in-script` step of the
yaml-lint task to not emit an error when processing YAML files that do
not contain a `.spec` attribute.

The functionality is unchanged. The only change is that `yq` quits early
instead of failing.
```

```
Fix yaml lint violation on tkn-bundle task

The task was merged at the same time as the yaml lint checks were
enabled.
```