### PR TITLE
fix: update args max of htmlnormalize scriptnormalize  from clamac-scan task

### DIFF
--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -74,7 +74,7 @@ spec:
         echo "Scanning image. This operation may take a while."
         clamscan -ri --max-scansize=4095M --max-filesize=4095M \
           --max-scantime=0 --max-files=0 --max-recursion=1000 --max-dir-recursion=20000 --max-embeddedpe=4095M \
-          --max-htmlnormalize=4095M --max-htmlnotags=4095M --max-scriptnormalize=4095M --max-ziptypercg=4095M \
+          --max-htmlnormalize=10M --max-htmlnotags=4095M --max-scriptnormalize=5M --max-ziptypercg=4095M \
           --max-partitions=50000 --max-iconspe=100000 --max-rechwp3=20000 --pcre-match-limit=100000000 --pcre-recmatch-limit=2000000 \
           --pcre-max-filesize=4095M --alert-exceeds-max=yes \
           --alert-encrypted=yes --alert-encrypted-archive=yes --alert-encrypted-doc=yes --alert-macros=yes \


### PR DESCRIPTION
Update max-htmlnormalize max-scriptnormalize from clamav-scan task because they have not worked well.

They cause the issue in https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1706699932388599 and https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1704986484024359

I test scanning users's image quay.io/redhat-user-workloads/rh-acs-tenant/acs/scanner:on-pr-2554e4fa14648ce3dadfa75c7f15d105bf214f7f mentioned [here](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1704986484024359) but it times out after 1 hour, and then it works if I remove these two args.
So let's remove these two args for now

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
