### PR TITLE
Skip the pipeline-bundles when ec track bundle

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -134,10 +134,17 @@ spec:
                 #!/usr/bin/env bash
                 set -euo pipefail
 
+                # Quick fix for timeout causing the acceptable bundles push to
+                # fail, see https://issues.redhat.com/browse/EC-351
+                # and https://issues.redhat.com/browse/EC-236
+                #BUNDLES=(
+                #  $(workspaces.artifacts.path)/source/task-bundle-list
+                #  $(workspaces.artifacts.path)/source/pipeline-bundle-list
+                #)
                 BUNDLES=(
                   $(workspaces.artifacts.path)/source/task-bundle-list
-                  $(workspaces.artifacts.path)/source/pipeline-bundle-list
                 )
+
                 touch ${BUNDLES[@]}
                 echo "Bundles to be added:"
                 cat ${BUNDLES[@]}


### PR DESCRIPTION
Tracking the pipeline bundles causes 845 queries to quay, which (we believe) is contributing to timeout problems causing the acceptable bundles image update to fail, which then causes bogus EC failures saying that tasks are using an unacceptable digest.

This is a quick minimal fix aimed at getting the "Red Hat Trusted App Pipeline / build-definitions-bundle-push" CI working again.

Ref: [EC-236](https://issues.redhat.com/browse/EC-236)
Ref: [EC-351](https://issues.redhat.com/browse/EC-351)
