### PR TITLE
Clean image pullspecs

### DIFF
--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -74,12 +74,21 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
 
+        # buildah task output tag from pulled images directly even if
+        # latest is specified or tag is not specified in FROM instruction.
+        parent_images=$(
+          echo "$BASE_IMAGES" | \
+            sed \
+              -e "s/^\(.\+\):latest\(@sha256:[0-9a-f]\+\)$/\1\2/" \
+              -e "s/^\(.\+\):<none>\(@sha256:[0-9a-f]\+\)$/\1\2/"
+        )
+
         app_dir=/opt/source_build
         ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \
           --output-binary-image "$BINARY_IMAGE" \
           --workspace /var/source-build \
           --source-dir "$SOURCE_DIR" \
-          --base-images "$BASE_IMAGES" \
+          --base-images "$parent_images" \
           --write-result-to "$RESULT_FILE" \
           --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR"
 


### PR DESCRIPTION
Relates to [STONEBLD-1874](https://issues.redhat.com//browse/STONEBLD-1874)

Remove invalid tag from image pullspecs in environment variable BASE_IMAGES_DIGESTS.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
