### PR TITLE
feat(STONEINTG-755): only warn about heurtistics in clamav

### DIFF
--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -24,7 +24,7 @@ spec:
 
   steps:
     - name: extract-and-scan-image
-      image: quay.io/redhat-appstudio/hacbs-test:v1.1.9@sha256:866675ee3064cf4768691ecca478063ce12f0556fb9d4f24ca95c98664ffbd43
+      image: quay.io/redhat-appstudio/hacbs-test:v1.2.0@sha256:73ff1801ceb0bb4c09f182f73d721e8f4aca31644c35e1f75c91550009ee5cf8
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
@@ -81,99 +81,27 @@ spec:
           --alert-phishing-ssl=yes --alert-phishing-cloak=yes --alert-partition-intersection=yes \
           | tee /tekton/home/clamscan-result.log || true
         echo "Executed-on: Scan was executed on version - $(clamscan --version)" | tee -a /tekton/home/clamscan-result.log
+
+        # OPA/EC requires structured data input, add clamAV log into json
+        jq -Rs '{ output: . }' /tekton/home/clamscan-result.log > /tekton/home/clamscan-result-log.json
+
+        EC_EXPERIMENTAL=1 ec test \
+          --namespace required_checks \
+          --policy /project/clamav/virus-check.rego \
+          -o json \
+          /tekton/home/clamscan-result-log.json || true
+
+        # workaround: due to a bug in ec-cli, we cannot generate json and appstudio output at the same time, running it again
+        EC_EXPERIMENTAL=1 ec test \
+          --namespace required_checks \
+          --policy /project/clamav/virus-check.rego \
+          -o appstudio \
+          /tekton/home/clamscan-result-log.json | tee $(results.TEST_OUTPUT.path) || true
       volumeMounts:
         - mountPath: /var/lib/clamav
           name: dbfolder
         - mountPath: /work
           name: work
-    - name: modify-clam-output-to-json
-      image: quay.io/redhat-appstudio/hacbs-test:v1.1.9@sha256:866675ee3064cf4768691ecca478063ce12f0556fb9d4f24ca95c98664ffbd43
-      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-      # the cluster will set imagePullPolicy to IfNotPresent
-      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
-      script: |
-        #!/usr/bin/env python3.9
-        import json
-        import dateutil.parser as parser
-        import os
-
-        clamscan_result = "/tekton/home/clamscan-result.log"
-        if not os.path.exists(clamscan_result) or os.stat(clamscan_result).st_size == 0:
-            print("clamscan-result.log file is empty, so compiled code not extracted. Parsing skipped.")
-            exit(0)
-
-        with open(clamscan_result, "r") as file:
-            clam_result_str = file.read()
-
-        def clam_result_str_to_json(clam_result_str):
-
-            clam_result_list = clam_result_str.split("\n")
-            clam_result_list.remove('')
-
-            results_marker = \
-                clam_result_list.index("----------- SCAN SUMMARY -----------")
-
-            hit_list = clam_result_list[:results_marker]
-            summary_list = clam_result_list[(results_marker + 1):]
-
-            r_dict = { "hits": hit_list }
-            for item in summary_list:
-                # in case of blank lines
-                if not item:
-                    continue
-                split_index = [c == ':' for c in item].index(True)
-                key = item[:split_index].lower()
-                key = key.replace(" ", "_")
-                value = item[(split_index + 1):].strip(" ")
-                if (key == "start_date" or key == "end_date"):
-                  isodate = parser.parse(value)
-                  value = isodate.isoformat()
-                r_dict[key] = value
-            print(json.dumps(r_dict))
-            with open('/tekton/home/clamscan-result.json', 'w') as f:
-              print(json.dumps(r_dict), file=f)
-
-        def main():
-            clam_result_str_to_json(clam_result_str)
-
-        if __name__ == "__main__":
-            main()
-    - name: store-hacbs-test-output-result
-      image: quay.io/redhat-appstudio/hacbs-test:v1.1.9@sha256:866675ee3064cf4768691ecca478063ce12f0556fb9d4f24ca95c98664ffbd43
-      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-      # the cluster will set imagePullPolicy to IfNotPresent
-      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
-      script: |
-        #!/usr/bin/env bash
-        set -euo pipefail
-        source /utils.sh
-        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
-
-        if [ -f /tekton/home/clamscan-result.json ];
-        then
-          cat /tekton/home/clamscan-result.json
-          INFECTED_FILES=$(jq -r '.infected_files' /tekton/home/clamscan-result.json || true )
-          WARNING_FILES=$(jq -r '.hits|length' /tekton/home/clamscan-result.json || true )
-          if [ -z "${INFECTED_FILES}" ]; then
-            echo "Failed to get number of infected files."
-            note="Task $(context.task.name) failed: Unable to get number of infected files from /tekton/home/clamscan-result.json. For details, check Tekton task log."
-          else
-            if [[ "${INFECTED_FILES}" -gt 0 ]]; then
-             RES="FAILURE";
-            elif [[ "${WARNING_FILES}" -gt 0 ]]; then
-              RES="WARNING";
-            else
-              RES="SUCCESS";
-            fi
-            note="Task $(context.task.name) completed: Check result for antivirus scan result."
-            TEST_OUTPUT=$(make_result_json -r "${RES}" -s 1 -f "${INFECTED_FILES}" -w "${WARNING_FILES}" -t "$note")
-          fi
-        else
-          note="Task $(context.task.name) failed: /tekton/home/clamscan-result.json doesn't exist. For details, check Tekton task log."
-        fi
-
-        ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
-        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
   # sidecar is rebuilt daily(is meant to be updated daily), hence the usage of the tag instead of digest
   # provides latest virus database for clamscan only
   # does not execute anything


### PR DESCRIPTION
A new policy `clamav/virus-check.rego` has been created which is able to parse results of clamav, detect heuristics checks and return only warnings for them

ec-cli is able to generate appstudio TEST_OUTPUT thus we don't need last 2 steps

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
