### PR TITLE
Introduce `TARGET_STAGE` build parameter

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -69,6 +69,11 @@ spec:
     description: Target path on the container in which yum repository files should
       be made available
     name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -112,6 +117,8 @@ spec:
       value: $(params.YUM_REPOS_D_FETCHED)
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
     - name: BUILDER_IMAGE
       value: $(params.BUILDER_IMAGE)
   steps:
@@ -197,8 +204,10 @@ spec:
       # Setting new namespace to run buildah - 2^32-2
       echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
 
+      BUILDAH_ARGS=()
+
       if [ "${HERMETIC}" == "true" ]; then
-        BUILDAH_ARGS="--pull=never"
+        BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS="--net"
         for image in $(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}'); do
           if [ "${image}" != "scratch" ]; then
@@ -206,6 +215,10 @@ spec:
           fi
         done
         echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
       fi
 
       if [ -n "${PREFETCH_INPUT}" ]; then
@@ -239,7 +252,7 @@ spec:
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah build \
         $VOLUME_MOUNTS \
-        $BUILDAH_ARGS \
+        ${BUILDAH_ARGS[@]} \
         ${LABELS[@]} \
         --tls-verify=$TLSVERIFY --no-cache \
         --ulimit nofile=4096:4096 \
@@ -274,6 +287,7 @@ spec:
        -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
        -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
        -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
+       -e TARGET_STAGE="$TARGET_STAGE" \
        -e COMMIT_SHA="$COMMIT_SHA" \
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -66,6 +66,10 @@ spec:
   - name: YUM_REPOS_D_TARGET
     description: Target path on the container in which yum repository files should be made available
     default: /etc/yum.repos.d
+  - name: TARGET_STAGE
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.
+    type: string
+    default: ""
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -104,6 +108,8 @@ spec:
       value: $(params.YUM_REPOS_D_FETCHED)
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
   steps:
   - image: $(params.BUILDER_IMAGE)
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
@@ -166,6 +172,10 @@ spec:
           fi
         done
         echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
       fi
 
       if [ -n "${PREFETCH_INPUT}" ]; then

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -155,8 +155,10 @@ spec:
       # Setting new namespace to run buildah - 2^32-2
       echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
 
+      BUILDAH_ARGS=()
+
       if [ "${HERMETIC}" == "true" ]; then
-        BUILDAH_ARGS="--pull=never"
+        BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS="--net"
         for image in $(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}'); do
           if [ "${image}" != "scratch" ]; then
@@ -197,7 +199,7 @@ spec:
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah build \
         $VOLUME_MOUNTS \
-        $BUILDAH_ARGS \
+        ${BUILDAH_ARGS[@]} \
         ${LABELS[@]} \
         --tls-verify=$TLSVERIFY --no-cache \
         --ulimit nofile=4096:4096 \


### PR DESCRIPTION
In RHACS, we have multiple "slim" containers that are the same as their non-slim counterparts with just few things absent. These are `collector-slim`-`collector`, `scanner-slim`-`scanner`, `scanner-db-slim`-`scanner-db`.

It is natural for these cases to have a single Dockerfile for both "slim" and non-slim containers done in the following way

```Dockerfile
FROM some-base AS slim

# common build for slim and non-slim

FROM slim AS full

# extra stuff specific to non-slim
```

Both `docker build` and `buildah build` support specifying target stage to build. This way, building something-slim would be
```bash
$ buildah build --target=slim ...
```
Building something non-slim would go simply without the `--target` argument because the Dockerfile is built entirely by default
```bash
$ buildah build ...
```

Not having an option to select target forces us to have two dockerfiles for slim&non-slim pair with mostly identical content. This is inconvenient and creates maintenance overhead.

This change would allow us reuse code when building in Konflux.

I don't know what's the process to test this change for regressions and hope you can advise.