### PR TITLE
RHTAPBUGS-1095: changed the default value of verbose param to false

### DIFF
--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -61,7 +61,7 @@ spec:
     description: Opt out of proxying HTTP/HTTPS requests.
     name: noProxy
     type: string
-  - default: "true"
+  - default: "false"
     description: Log the commands that are executed during `git-clone`'s operation.
     name: verbose
     type: string


### PR DESCRIPTION
Setting the verbose value to true causing the user private github tokens to be printed in the task run logs, changed it to be by default false

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
