### PR TITLE
Update the cachi2 image to 0.5.0 manually

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -374,7 +374,7 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/redhat-appstudio/cachi2:0.4.0@sha256:001acfbad47e132a90998d45076a0dbe0d8beacf0bec12b4d9a5aa796f4a9cad
+    image: quay.io/redhat-appstudio/cachi2:0.5.0@sha256:d4707478075bc1e746dacc640138b60f776e2d8f9d5b7f2433340decfa32611b
     name: merge-cachi2-sbom
     script: |
       if [ -n "${PREFETCH_INPUT}" ]; then

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -305,7 +305,7 @@ spec:
       runAsUser: 0
 
   - name: merge-cachi2-sbom
-    image: quay.io/redhat-appstudio/cachi2:0.4.0@sha256:001acfbad47e132a90998d45076a0dbe0d8beacf0bec12b4d9a5aa796f4a9cad
+    image: quay.io/redhat-appstudio/cachi2:0.5.0@sha256:d4707478075bc1e746dacc640138b60f776e2d8f9d5b7f2433340decfa32611b
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -15,7 +15,7 @@ spec:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
   steps:
-  - image: quay.io/redhat-appstudio/cachi2:0.4.0@sha256:001acfbad47e132a90998d45076a0dbe0d8beacf0bec12b4d9a5aa796f4a9cad
+  - image: quay.io/redhat-appstudio/cachi2:0.5.0@sha256:d4707478075bc1e746dacc640138b60f776e2d8f9d5b7f2433340decfa32611b
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.


### PR DESCRIPTION
The Renovate PR pairs the cachi2 update with a syft update. The latter breaks the pipeline (changes needed in the SBOM merge script: https://github.com/containerbuildsystem/cachi2/pull/452)

Extract the cachi2 update into a separate PR to unblock it.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
