### PR TITLE
remove the pipelines which are not included in 1.0

### DIFF
--- a/pipelines/rhtap/kustomization.yaml
+++ b/pipelines/rhtap/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../docker-build-rhtap
-- ../java-builder
-- ../nodejs-builder
-- ../docker-build
+- ../docker-build-rhtap 


### PR DESCRIPTION
This PR removes the pipelines referenced in the rhtap pipeline configuration to include only the docker-build-rhtap pipeline.

The other ones had been included as part of a PoC but are not planned for 1.0.

We need this to cleanup and remove unused components from the tssc-sample-pipelines 

