### PR TITLE
task/rpm-ostree: Use --entrypoint bash

### DIFF
--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -129,7 +129,7 @@ spec:
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
       rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
-      ssh $SSH_ARGS "$SSH_HOST" podman run --mount type=bind,source=$BUILD_DIR/tmp,target=/var/tmp,relabel=shared --privileged -e CONTEXT="$CONTEXT" -e IMAGE_FILE="$IMAGE_FILE" -e CONFIG_FILE="$CONFIG_FILE" -e IMAGE="$IMAGE" -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" -e COMMIT_SHA="$COMMIT_SHA"  --rm  -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z"  -v $BUILD_DIR/scripts:/script:Z --user=0  "$BUILDER_IMAGE" /script/script-build.sh
+      ssh $SSH_ARGS "$SSH_HOST" podman run --mount type=bind,source=$BUILD_DIR/tmp,target=/var/tmp,relabel=shared --privileged -e CONTEXT="$CONTEXT" -e IMAGE_FILE="$IMAGE_FILE" -e CONFIG_FILE="$CONFIG_FILE" -e IMAGE="$IMAGE" -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" -e COMMIT_SHA="$COMMIT_SHA"  --rm  -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z"  -v $BUILD_DIR/scripts:/script:Z --user=0 --entrypoint bash "$BUILDER_IMAGE" /script/script-build.sh
       rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
       cp -r rhtap-final-image /var/lib/containers/rhtap-final-image
       buildah pull oci:rhtap-final-image


### PR DESCRIPTION
Required for https://github.com/CentOS/centos-bootc/pull/277

I am planning to potentially change to use bootc-image-builder for this, but it has a non-`bash` entrypoint.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
