### PR TITLE
RHTAPSRE-395: Add more cpus to buildah 24gb

### DIFF
--- a/task/buildah-24gb/0.1/patch.yaml
+++ b/task/buildah-24gb/0.1/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/memory
   value: 20Gi
+- op: replace
+  path: /spec/steps/0/computeResources/limits/cpu
+  value: "20"
+- op: replace
+  path: /spec/steps/0/computeResources/requests/cpu
+  value: "10"


### PR DESCRIPTION
The RHOAI team needs 10-20 CPUs to build their
component.

It also makes sense that if a build requires 24GB of RAM, it will also require a large amount of CPUs.

