### PR TITLE
Pin ec-cli image in ec-checks Task

### DIFF
--- a/.tekton/tasks/ec-checks.yaml
+++ b/.tekton/tasks/ec-checks.yaml
@@ -24,7 +24,7 @@ spec:
       $(all_tasks_dir all_tasks-ec)
   - name: validate-all-tasks
     workingDir: "$(workspaces.source.path)/source"
-    image: quay.io/enterprise-contract/ec-cli:snapshot
+    image: quay.io/enterprise-contract/ec-cli:snapshot@sha256:aa20605cf7c47b4ee4935751b5dbdcf9c9af6658e205d9503ce79cca9075fa84
     script: |
       set -euo pipefail
 
@@ -38,7 +38,7 @@ spec:
       ec validate input --policy "${policy}" --output yaml --strict=true ${args[*]}
   - name: validate-build-tasks
     workingDir: "$(workspaces.source.path)/source"
-    image: quay.io/enterprise-contract/ec-cli:snapshot
+    image: quay.io/enterprise-contract/ec-cli:snapshot@sha256:aa20605cf7c47b4ee4935751b5dbdcf9c9af6658e205d9503ce79cca9075fa84
     script: |
       set -euo pipefail
 


### PR DESCRIPTION
By default OpenShift only fetches an image by a floating tag, e.g. `snapshot`, if the image is not yet available in the cluster. We can change this behaver with `imagePullPolicy: Always`. However, a better approach is to pin the image reference to a digest and let automation, i.e. renovate bot, bring in updates. This gives us more control over which code is actually executed in the CI.

I came across this when working on [EC-414](https://issues.redhat.com//browse/EC-414). The fix for that issue was not propagated as expected. Further investigation revealed that an older version of the EC CLI was still being executed.

This commit pins references to the EC CLI image to a digest.

Ref: https://issues.redhat.com/browse/EC-414

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
