### PR TITLE
Enable step_image_registries check for Tasks

### DIFF
--- a/.tekton/tasks/ec-checks.yaml
+++ b/.tekton/tasks/ec-checks.yaml
@@ -33,7 +33,7 @@ spec:
       args=${files[*]/#/--file }
       echo "[DEBUG] Files parameter: ${args[*]}"
 
-      policy='enterprise-contract-service/redhat-trusted-tasks'
+      policy='./policies/all-tasks.yaml'
 
       ec validate input --policy "${policy}" --output yaml --strict=true ${args[*]}
   - name: validate-build-tasks

--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -1,0 +1,19 @@
+---
+# These policies are meant to be applied to all of the Tasks in this repo.
+sources:
+  - policy:
+      - oci::quay.io/enterprise-contract/ec-task-policy:latest
+    data:
+      - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+      - github.com/release-engineering/rhtap-ec-policy//data
+    config:
+      include:
+        - kind
+        - step_image_registries
+      exclude:
+        # https://issues.redhat.com/browse/KFLUXBUGS-1111
+        - step_image_registries.step_images_permitted:generate-odcs-compose/noversion
+        # https://issues.redhat.com/browse/EC-425
+        - step_image_registries.step_images_permitted:tkn-bundle/0.1
+        # https://issues.redhat.com/browse/KFLUXBUGS-1110
+        - step_image_registries.step_images_permitted:verify-signed-rpms/noversion

--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -18,7 +18,7 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |httpsProxy|HTTPS proxy server for SSL requests.|""|false|
 |noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
 |verbose|Log the commands that are executed during `git-clone`'s operation.|true|false|
-|gitInitImage|The image providing the git-init binary that this Task runs.|registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8|false|
+|gitInitImage|Deprecated. Has no effect. Will be removed in the future.|""|false|
 |userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden the gitInitImage param with an image containing custom user configuration. |/tekton/home|false|
 |enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.|true|false|
 |fetchTags|Fetch all tags for the repo.|false|false|

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -65,16 +65,13 @@ spec:
     description: Log the commands that are executed during `git-clone`'s operation.
     name: verbose
     type: string
-  - default: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    description: The image providing the git-init binary that this Task runs.
+  - default: ""
+    description: Deprecated. Has no effect. Will be removed in the future.
     name: gitInitImage
     type: string
   - default: /tekton/home
     description: |
-      Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
-      the gitInitImage param with an image containing custom user configuration.
+      Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
     name: userHome
     type: string
   - default: "true"
@@ -126,6 +123,8 @@ spec:
       value: $(params.userHome)
     - name: PARAM_FETCH_TAGS
       value: $(params.fetchTags)
+    - name: PARAM_GIT_INIT_IMAGE
+      value: $(params.gitInitImage)
     - name: WORKSPACE_OUTPUT_PATH
       value: $(workspaces.output.path)
     - name: WORKSPACE_SSH_DIRECTORY_BOUND
@@ -136,7 +135,7 @@ spec:
       value: $(workspaces.basic-auth.bound)
     - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
       value: $(workspaces.basic-auth.path)
-    image: $(params.gitInitImage)
+    image: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8
     computeResources: {}
     securityContext:
       runAsUser: 0
@@ -146,6 +145,10 @@ spec:
 
       if [ "${PARAM_VERBOSE}" = "true" ] ; then
         set -x
+      fi
+
+      if [ -n "${PARAM_GIT_INIT_IMAGE}" ]; then
+        echo "WARNING: provided deprecated gitInitImage parameter has no effect."
       fi
 
       if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then


### PR DESCRIPTION
This PR includes two commits:

1. Enable step_image_registries check for Tasks
    > This commit effectively enables the step_image_registries[1] policy rules on the Task definitions in this repo.
    > Since some Tasks do not yet comply with some of those policy rules, exceptions are added for those cases. 
    > Enabling this check now should help prevent new violations from being introduced.
    >
    > Since the policy now includes a very specific exclusion list for this
    > repo, the policy itself is now defined here.
    > 
    > Ref: https://issues.redhat.com/browse/EC-374
    > 
    > [1] https://enterprisecontract.dev/docs/ec-policies/task_policy.html#step_image_registries_package
2. Disable gitInitImage param from git-clone Task
    > This was missed in [STONEBLD-2109](https://issues.redhat.com/browse/STONEBLD-2109).