### PR TITLE
fix typo, missing quoted string

### DIFF
--- a/task/update-deployment/0.1/update-deployment.yaml
+++ b/task/update-deployment/0.1/update-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         fi
       else
         echo "git credentials to push into gitops repository $(params.gitops-repo-url) is not configured."
-        echo "gitops repository is not updated automatically.
+        echo "gitops repository is not updated automatically."
         echo "You can update gitops repository with the new image: $(params.image) manually"
         echo "TODO: configure git credentials to update gitops repository."
         exit 0


### PR DESCRIPTION
This PR fixes an type in a string which is missing the end quote for the new update-deployment.yaml task
