### PR TITLE
buildah-rhtap: use productized Syft image

### DIFF
--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -97,7 +97,7 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: generate-sboms
-    image: quay.io/redhat-appstudio/syft:v0.105.0@sha256:32a9d2007f2b042ceec4ef32fa1d90b8d28141822e7d9748f240da9d55c56601
+    image: registry.redhat.io/rh-syft-tech-preview/syft-rhel9:0.105.0@sha256:8d34c03188cf294a77339b2a733b1f6811263a369b309e6b170d9b489abc0334
     script: |
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json@1.5=/tmp/files/sbom-source.json
       syft oci-dir:/tmp/files/image --output cyclonedx-json@1.5=/tmp/files/sbom-image.json


### PR DESCRIPTION
RHTAP tasks must use productized images. Replace the previous Syft image with one that was recently released to registry.redhat.io.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
