### PR TITLE
add ACS_SCAN_OUTPUT to pipeline run results

### DIFF
--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -14,6 +14,11 @@
     name: stackrox-secret
     type: string
     default: "rox-api-token"
+- op: add
+  path: /spec/results/-
+  value:
+    name: ACS_SCAN_OUTPUT
+    value: $(tasks.acs-image-scan.results.SCAN_OUTPUT)
 - op: replace
   path: /spec/tasks/3/taskRef
   value:


### PR DESCRIPTION
 
This PR adds the SCAN_OUTPUT to the PipelineRun results which enables the Tekton plugin to show the vulnerabilities in the Pipelines iew 

<img width="248" alt="image" src="https://github.com/redhat-appstudio/build-definitions/assets/7844190/dbf6f20b-5d19-4ace-a4d1-77d2d053a6bb">

