### PR TITLE
fix(STONEINTG-821): allow ose-operator-registry-rhel9

### DIFF
--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -55,7 +55,10 @@ spec:
         source /utils.sh
         trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
-        declare -a ALLOWED_BASE_IMAGES=("registry.redhat.io/openshift4/ose-operator-registry")
+        declare -a ALLOWED_BASE_IMAGES=(
+          "registry.redhat.io/openshift4/ose-operator-registry"
+          "registry.redhat.io/openshift4/ose-operator-registry-rhel9"
+        )
 
         ### FBC base image check
         if [ -z "${BASE_IMAGE}" ]; then


### PR DESCRIPTION
A new version of ose-operator-registry based on rhel9 has been released, allow users to use it.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
