### PR TITLE
Store the base image digests in the correct order

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -218,10 +218,11 @@ spec:
 
       BUILDAH_ARGS=()
 
+      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}')
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS="--net"
-        for image in $(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}'); do
+        for image in $BASE_IMAGES; do
           if [ "${image}" != "scratch" ]; then
             unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
           fi
@@ -287,7 +288,11 @@ spec:
       fi
 
       # Expose base image digests
-      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
+      for image in $BASE_IMAGES; do
+        if [ "${image}" != "scratch" ]; then
+          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)
+        fi
+      done
 
       buildah push "$IMAGE" oci:rhtap-final-image
       REMOTESSHEOF

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -169,10 +169,11 @@ spec:
 
       BUILDAH_ARGS=()
 
+      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}')
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS="--net"
-        for image in $(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}'); do
+        for image in $BASE_IMAGES; do
           if [ "${image}" != "scratch" ]; then
             unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
           fi
@@ -238,7 +239,11 @@ spec:
       fi
 
       # Expose base image digests
-      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
+      for image in $BASE_IMAGES; do
+        if [ "${image}" != "scratch" ]; then
+          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)
+        fi
+      done
 
     securityContext:
       capabilities:


### PR DESCRIPTION
Previously the base image digest were not guaranteed to be in the correct order because the output was generated just from the output of "buildah images". The output of that command is sorted according to the creation date of the image, which is not what we want.

The new approach outputs the digests in the order in which they were found in the dockerfile.

[STONEBLD-2203](https://issues.redhat.com//browse/STONEBLD-2203)

The "FROM scratch" problem is not yet resolved here. It will be dealt with in another story/PR as that might be solved on the source-build task side.