### PR TITLE
Show source image URL in summary

### DIFF
--- a/pipelines/tekton-bundle-builder/kustomization.yaml
+++ b/pipelines/tekton-bundle-builder/kustomization.yaml
@@ -31,6 +31,8 @@ patches:
       path: /spec/tasks/4  # build-source-image
     - op: remove
       path: /spec/finally/0  # show-sbom
+    - op: remove
+      path: /spec/finally/0/params/4  # source-image-url param
   target:
     kind: Pipeline
     name: template-build

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -118,9 +118,6 @@ spec:
         - input: $(tasks.init.results.build)
           operator: in
           values: ["true"]
-        - input: $(params.build-source-image)
-          operator: in
-          values: ["true"]
       runAfter:
         - build-container
       taskRef:
@@ -131,6 +128,8 @@ spec:
           value: "$(params.output-image)"
         - name: BASE_IMAGES
           value: "$(tasks.build-container.results.BASE_IMAGES_DIGESTS)"
+        - name: BUILD_SOURCE_IMAGE
+          value: "$(params.build-source-image)"
       workspaces:
         - name: workspace
           workspace: workspace
@@ -240,6 +239,8 @@ spec:
         value: $(params.output-image)
       - name: build-task-status
         value: $(tasks.build-container.status)
+      - name: source-image-url
+        value: "$(tasks.build-source-image.results.SOURCE_IMAGE_URL)"
   results:
     - name: IMAGE_URL
       value: "$(tasks.build-container.results.IMAGE_URL)"

--- a/task/source-build/0.2/MIGRATION.md
+++ b/task/source-build/0.2/MIGRATION.md
@@ -1,0 +1,24 @@
+# Migration from 0.1 to 0.2
+
+Apply the following diff to task `build-source-image` inside PipelineRun YAML created by Konflux Bot:
+
+```diff
+         - input: $(tasks.init.results.build)
+           operator: in
+           values: ["true"]
+-        - input: $(params.build-source-image)
+-          operator: in
+-          values: ["true"]
+       runAfter:
+         - build-container
+       taskRef:
+@@ -131,6 +128,8 @@ spec:
+           value: "$(params.output-image)"
+         - name: BASE_IMAGES
+           value: "$(tasks.build-container.results.BASE_IMAGES_DIGESTS)"
++        - name: BUILD_SOURCE_IMAGE
++          value: "$(params.build-source-image)"
+       workspaces:
+         - name: workspace
+           workspace: workspace
+```

--- a/task/source-build/0.2/README.md
+++ b/task/source-build/0.2/README.md
@@ -1,0 +1,22 @@
+# source-build task
+
+Source image build.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|BINARY_IMAGE|Binary image name from which to generate the source image name.||true|
+|BASE_IMAGES|Base images used to build the binary image. Each image per line in the same order of FROM instructions specified in a multistage Dockerfile. Default to an empty string, which means to skip handling a base image.|""|false|
+|BUILD_SOURCE_IMAGE|Specify whether to start building the source image or not. Pass false to skip the build.|true|false|
+
+## Results
+|name|description|
+|---|---|
+|BUILD_RESULT|Build result.|
+|SOURCE_IMAGE_URL|The source image url.|
+|SOURCE_IMAGE_DIGEST|The source image digest.|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|workspace|The workspace where source code is included.|false|

--- a/task/source-build/0.2/source-build.yaml
+++ b/task/source-build/0.2/source-build.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: source-build
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio"
+spec:
+  description: Source image build.
+  params:
+    - name: BINARY_IMAGE
+      description: Binary image name from which to generate the source image name.
+      type: string
+    - name: BASE_IMAGES
+      description: >-
+        Base images used to build the binary image. Each image per line in the same order of FROM
+        instructions specified in a multistage Dockerfile. Default to an empty string, which means
+        to skip handling a base image.
+      type: string
+      default: ""
+    - name: BUILD_SOURCE_IMAGE
+      description: Specify whether to start building the source image. Pass false to skip the build.
+      default: "true"
+  results:
+    - name: BUILD_RESULT
+      description: Build result.
+    - name: SOURCE_IMAGE_URL
+      description: The source image url.
+    - name: SOURCE_IMAGE_DIGEST
+      description: The source image digest.
+  workspaces:
+    - name: workspace
+      description: The workspace where source code is included.
+  volumes:
+    - name: source-build-work-place
+      emptyDir: {}
+  steps:
+    - name: build
+      image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils@sha256:e5865a663af8faa4816802b449e3f9988db00dc93918f55397fea7139e03a6a9
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 512Mi
+          cpu: 250m
+      workingDir: "/var/source-build"
+      securityContext:
+        runAsUser: 0
+        capabilities:
+          add:
+            - SETFCAP
+      volumeMounts:
+        - name: source-build-work-place
+          mountPath: /var/source-build
+      env:
+        - name: BUILD_SOURCE_IMAGE
+          value: "$(params.BUILD_SOURCE_IMAGE)"
+        - name: BINARY_IMAGE
+          value: "$(params.BINARY_IMAGE)"
+        - name: SOURCE_DIR
+          value: "$(workspaces.workspace.path)/source"
+        - name: BASE_IMAGES
+          value: "$(params.BASE_IMAGES)"
+        - name: RESULT_FILE
+          value: "$(results.BUILD_RESULT.path)"
+        - name: CACHI2_ARTIFACTS_DIR
+          value: "$(workspaces.workspace.path)/cachi2"
+        - name: RESULT_SOURCE_IMAGE_URL
+          value: "$(results.SOURCE_IMAGE_URL.path)"
+        - name: RESULT_SOURCE_IMAGE_DIGEST
+          value: "$(results.SOURCE_IMAGE_DIGEST.path)"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [ "$BUILD_SOURCE_IMAGE" != "true" ]; then
+          echo "{}" >"$RESULT_FILE"
+          echo -n "" >"$RESULT_SOURCE_IMAGE_URL"
+          echo -n "" >"$RESULT_SOURCE_IMAGE_DIGEST"
+          echo "Source image build is not enabled for this build."
+          exit 0
+        fi
+
+        app_dir=/opt/source_build
+        registry_allowlist="
+        registry.access.redhat.com
+        registry.redhat.io
+        "
+
+        ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \
+          --output-binary-image "$BINARY_IMAGE" \
+          --workspace /var/source-build \
+          --source-dir "$SOURCE_DIR" \
+          --base-images "$BASE_IMAGES" \
+          --write-result-to "$RESULT_FILE" \
+          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
+          --registry-allowlist="$registry_allowlist"
+
+        cat "$RESULT_FILE" | jq -r ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
+        cat "$RESULT_FILE" | jq -r ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"

--- a/task/summary/0.2/MIGRATION.md
+++ b/task/summary/0.2/MIGRATION.md
@@ -1,0 +1,14 @@
+# Migration from 0.1 to 0.2
+
+Apply the following diff to task `show-summary` inside PipelineRun YAML created by Konflux Bot:
+
+```diff
+         value: $(params.output-image)
+       - name: build-task-status
+         value: $(tasks.build-container.status)
++      - name: source-image-url
++        value: "$(tasks.build-source-image.results.SOURCE_IMAGE_URL)"
+   results:
+     - name: IMAGE_URL
+       value: "$(tasks.build-container.results.IMAGE_URL)"
+```

--- a/task/summary/0.2/README.md
+++ b/task/summary/0.2/README.md
@@ -1,0 +1,13 @@
+# summary task
+
+Summary Pipeline Task. Prints PipelineRun information, removes image repository secret used by the PipelineRun.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|pipelinerun-name|pipeline-run to annotate||true|
+|git-url|Git URL||true|
+|image-url|Image URL||true|
+|build-task-status|State of build task in pipelineRun|Succeeded|false|
+|source-image-url|Source image URL.|""|false|
+

--- a/task/summary/0.2/summary.yaml
+++ b/task/summary/0.2/summary.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio, hacbs"
+  name: summary
+spec:
+  description: >-
+    Summary Pipeline Task. Prints PipelineRun information, removes image repository secret used by the PipelineRun.
+  params:
+    - name: pipelinerun-name
+      description: pipeline-run to annotate
+    - name: git-url
+      description: Git URL
+    - name: image-url
+      description: Image URL
+    - name: build-task-status
+      description: State of build task in pipelineRun
+      # Default Succeeded for backward compatibility
+      default: Succeeded
+    - name: source-image-url
+      description: Source image URL.
+      default: ""
+  steps:
+    - name: appstudio-summary
+      image: registry.access.redhat.com/ubi9/ubi-minimal:9.3-1552@sha256:06d06f15f7b641a78f2512c8817cbecaa1bf549488e273f5ac27ff1654ed33f0
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+      env:
+        - name: GIT_URL
+          value: $(params.git-url)
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: PIPELINERUN_NAME
+          value: $(params.pipelinerun-name)
+        - name: BUILD_TASK_STATUS
+          value: $(params.build-task-status)
+        - name: SOURCE_IMAGE_URL
+          value: $(params.source-image-url)
+      script: |
+        #!/usr/bin/env bash
+        echo
+        echo "Build Summary:"
+        echo
+        echo "Build repository: $GIT_URL"
+        if [ "$BUILD_TASK_STATUS" == "Succeeded" ]; then
+          echo "Generated Image is in : $IMAGE_URL"
+        fi
+        if [ -n "$SOURCE_IMAGE_URL" ]; then
+          echo "Generated source image is in : $SOURCE_IMAGE_URL"
+        fi
+        echo
+        echo End Summary


### PR DESCRIPTION
[STONEBLD-1608](https://issues.redhat.com//browse/STONEBLD-1608)

source-build task now always runs but checks the input param
BUILD_SOURCE_IMAGE to determine whether to start the build. Task summary
accepts a new param of source image URL.

Both task source-build and summary have change to the parameters, then
new versions are made and migration documents are prepared for updating
the existing PipelineRun YAML files.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

