### PR TITLE
Control git push command output

### DIFF
--- a/task/update-deployment/0.1/update-deployment.yaml
+++ b/task/update-deployment/0.1/update-deployment.yaml
@@ -69,4 +69,9 @@ spec:
       git add .
       git commit -m "Update '${component_id}' component image to: ${PARAM_IMAGE}"
       git remote set-url origin $origin_with_auth
-      git push
+      git push 2> /dev/null || \
+      {
+        echo "Failed to push update to gitops repository: ${PARAM_GITOPS_REPO_URL}"
+        echo 'Do you have correct git credentials configured?'
+        exit 1
+      }


### PR DESCRIPTION
In case of push failure the task produces the following output:
```
step-patch-gitops
Cloning into 'testgo-gitops'...
[main 747a7b0] Update 'testgo' component image to: quay.io/user-org/rhdh-test:d719c735bdb7573482a9a24cee8442856885e36d@sha256:37607c61eec84d0ffefc8ec55dd859e688b10bb7391ec64a6f324e5e869eb7a9
 1 file changed, 1 insertion(+), 1 deletion(-)
Failed to push update to gitops repository: https://github.com/user-org/testgo-gitops
Do you have correct git credentials configured?
```