### PR TITLE
Add a buildah task step that generates base images sbom

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -294,6 +294,9 @@ spec:
         fi
       done
 
+      # Needed to generate base images SBOM
+      echo "$BASE_IMAGES" > /workspace/base_images_from_dockerfile
+
       buildah push "$IMAGE" oci:rhtap-final-image
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
@@ -431,6 +434,17 @@ spec:
 
       with open("sbom-purl.json", "w") as output_file:
         json.dump(purl_content, output_file, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources: {}
+    env:
+    - name: BASE_IMAGES_DIGESTS_PATH
+      value: $(results.BASE_IMAGES_DIGESTS.path)
+    image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
+    name: create-base-images-sbom
+    script: |
+      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=/workspace/base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
     securityContext:
       runAsUser: 0
     workingDir: $(workspaces.source.path)

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -245,6 +245,9 @@ spec:
         fi
       done
 
+      # Needed to generate base images SBOM
+      echo "$BASE_IMAGES" > /workspace/base_images_from_dockerfile
+
     securityContext:
       capabilities:
         add:
@@ -346,6 +349,17 @@ spec:
 
       with open("sbom-purl.json", "w") as output_file:
         json.dump(purl_content, output_file, indent=4)
+    workingDir: $(workspaces.source.path)
+    securityContext:
+      runAsUser: 0
+
+  - name: create-base-images-sbom
+    image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
+    env:
+    - name: BASE_IMAGES_DIGESTS_PATH
+      value: $(results.BASE_IMAGES_DIGESTS.path)
+    script: |
+      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=/workspace/base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
     workingDir: $(workspaces.source.path)
     securityContext:
       runAsUser: 0


### PR DESCRIPTION
This steps uses a python script for creating the sbom
https://github.com/redhat-appstudio/build-tasks-dockerfiles/tree/main/base-images-sbom-script

It expects 3 arguments:
1. path to the sbom file that will be updated in place with base images data
2. path to a file containing base images as taken from from the dockerfile (with preserved order)
3. path to a file containing base images with digests, generated from the output of buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}'.
The dockerfile order must be preserved as well

For more information, please read the script README

[STONEBLD-2042](https://issues.redhat.com//browse/STONEBLD-2042)
