### PR TITLE
Add platform specificity to the show-sbom task

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -224,6 +224,8 @@ spec:
       params:
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
+      - name: PLATFORM
+        value: linux/amd64
     - name: show-summary
       taskRef:
         name: summary

--- a/task/show-sbom/0.1/show-sbom.yaml
+++ b/task/show-sbom/0.1/show-sbom.yaml
@@ -15,15 +15,20 @@ spec:
     - name: IMAGE_URL
       description: Fully qualified image name to show SBOM for.
       type: string
+    - name: PLATFORM
+      description: Architecture to display for the sbom
+      type: linux/amd64
   steps:
   - name: show-sbom
     image: quay.io/redhat-appstudio/cosign:v2.1.1
     env:
     - name: IMAGE_URL
       value: $(params.IMAGE_URL)
+    - name: PLATFORM
+      value: $(params.PLATFORM)
     script: |
        #!/busybox/sh
-       cosign download sbom $IMAGE_URL 2>err
+       cosign download sbom --platform $PLATFORM $IMAGE_URL 2>err
        RET=$?
        if [ $RET -ne 0 ]; then
          echo Failed to get SBOM >&2


### PR DESCRIPTION
I noticed in the logs of the show-sbom task for a multiarch image, the following error:

```
[show-sbom] This multiarch image does not have an SBOM attached at the index level.
[show-sbom] Try using --platform with one of the following architectures:
[show-sbom] linux/amd64, linux/arm64
[show-sbom] 
[show-sbom] Error: no SBOM found attached to image index
[show-sbom] main.go:74: error during command execution: no SBOM found attached to image index
```

This should make the show-sbom task default to linux/amd64, but give the user a way to show other architecture by setting params in their pipeline or adding additional show-sbom tasks, one per architecture, if that is important to them.