### PR TITLE
docker-build-rhtap: create a new show-sbom task compatible with RHDH

### DIFF
--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -135,3 +135,8 @@
     taskRef:
       kind: Task
       name: update-deployment
+- op: replace
+  path: /spec/finally/0/taskRef
+  value:
+    name: show-sbom-rhdh
+    version: "0.1"

--- a/task/show-sbom-rhdh/0.1/README.md
+++ b/task/show-sbom-rhdh/0.1/README.md
@@ -1,0 +1,10 @@
+# show-sbom-rhdh task
+
+Shows the Software Bill of Materials (SBOM) generated for the built image in CyloneDX JSON format.
+The 'task.*' annotations are processed by Red Hat Developer Hub (RHDH) so that the log content can be rendered in its UI.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE_URL|Fully qualified image name to show SBOM for.||true|
+

--- a/task/show-sbom-rhdh/0.1/show-sbom-rhdh.yaml
+++ b/task/show-sbom-rhdh/0.1/show-sbom-rhdh.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: show-sbom-rhdh
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: "docker"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "containers, rhtap"
+    task.results.format: application/text
+    task.results.key: LINK_TO_SBOM
+    task.output.location: results
+spec:
+  description: >-
+    Shows the Software Bill of Materials (SBOM) generated for the built image in CyloneDX JSON format.
+    The 'task.*' annotations are processed by Red Hat Developer Hub (RHDH) so that the log content can be rendered in its UI.
+  params:
+    - name: IMAGE_URL
+      description: Fully qualified image name to show SBOM for.
+      type: string
+  results:
+  - description: Placeholder result meant to make RHDH identify this task as the producer of the SBOM logs.
+    name: LINK_TO_SBOM
+  steps:
+  - name: annotate-task
+    image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c
+    script: |
+      #!/usr/bin/env bash
+
+      # When this task is used in a pipelineRun triggered by Pipelines as Code, the annotations will be cleared,
+      # so we're re-adding them here
+      oc annotate taskrun $(context.taskRun.name) task.results.format=application/text
+      oc annotate taskrun $(context.taskRun.name) task.results.key=LINK_TO_SBOM
+      oc annotate taskrun $(context.taskRun.name) task.output.location=results
+  - name: show-sbom
+    image: registry.redhat.io/rhtas-tech-preview/cosign-rhel9@sha256:151f4a1e721b644bafe47bf5bfb8844ff27b95ca098cc37f3f6cbedcda79a897
+    env:
+    - name: IMAGE_URL
+      value: $(params.IMAGE_URL)
+    script: |
+      #!/busybox/sh
+      status=-1
+      max_try=5
+      wait_sec=2
+      for run in $(seq 1 $max_try); do
+        status=0
+        cosign download sbom $IMAGE_URL 2>>err
+        status=$?
+        if [ "$status" -eq 0 ]; then
+          break
+        fi
+        sleep $wait_sec
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to get SBOM after ${max_try} tries" >&2
+          cat err >&2
+      fi
+
+      # This result will be ignored by RHDH, but having it set is actually necessary for the task to be properly
+      # identified. For now, we're adding the image URL to the result so it won't be empty.
+      echo -n "$IMAGE_URL" > $(results.LINK_TO_SBOM.path)

--- a/task/show-sbom-rhdh/OWNERS
+++ b/task/show-sbom-rhdh/OWNERS
@@ -1,0 +1,1 @@
+Stonesoup Build Team


### PR DESCRIPTION
Previous title: emit the LINK_TO_SBOM result

~This result contains the URL to the OCI artifact that stores the SBOM. It is meant primarily to be consumed by [RHDH](https://github.com/janus-idp/backstage-plugins/issues/988) and [ODC](https://github.com/openshift/console/pull/13314). The URl follows the format:~

~registry.io/user/image:sha256-hash.sbom~

~Note that this URL is not meant to be used with cosign, as it automatically resolves it when performing a "cosign download sbom registry.io/user/image:actual-tag".~

This PR was changed based on the comments on this [thread](https://github.com/redhat-appstudio/build-definitions/pull/876#discussion_r1522576564). We need to annotate the `show-sbom` task instead of `buildah-rhtap`. But since Pipelines as Code will clear the annotations, they need to be re-added using a dedicated step in the task.

To avoid breaking the Konflux pipeline, we're temporarily splitting the `show-sbom` into a new `show-sbom-rhdh` so that the latter can have all the necessary changes for the RHDH integration.

