### PR TITLE
tasks/acs*: don't fail when ACS is not configured

### DIFF
--- a/task/acs-deploy-check/0.1/acs-deploy-check.yaml
+++ b/task/acs-deploy-check/0.1/acs-deploy-check.yaml
@@ -133,4 +133,6 @@ spec:
           mountPath: /workspace/repository
       script: |
         #!/usr/bin/env bash
-        cat /workspace/repository/acs-deploy-check.json
+        if [ -f /workspace/repository/acs-deploy-check.json ]; then
+          cat /workspace/repository/acs-deploy-check.json
+        fi

--- a/task/acs-image-check/0.1/acs-image-check.yaml
+++ b/task/acs-image-check/0.1/acs-image-check.yaml
@@ -127,4 +127,6 @@ spec:
           mountPath: /steps-shared-folder
       script: |
         #!/usr/bin/env bash
-        cat /steps-shared-folder/acs-image-check.json
+        if [ -f  /steps-shared-folder/acs-image-check.json ]; then
+          cat /steps-shared-folder/acs-image-check.json
+        fi

--- a/task/acs-image-scan/0.1/acs-image-scan.yaml
+++ b/task/acs-image-scan/0.1/acs-image-scan.yaml
@@ -95,6 +95,7 @@ spec:
           echo "rox API endpoint is not set, demo will exit with success"
           echo "TODO: configure the pipeline with your ACS server domain. Set your ACS endpoint under 'rox-api-endpoint' key in the secret specified in rox-secret-name parameter. For example: 'rox.stackrox.io:443'"
           set_test_output_result SKIPPED "Task $(context.task.name) skipped: ACS API enpoint not specified"
+          touch $(results.SCAN_OUTPUT.path)
           exit 0
         fi
 
@@ -105,6 +106,7 @@ spec:
           echo "rox API token is not set, demo will exit with success"
           echo "TODO: configure the pipeline to have access to ROXCTL. Set you ACS token under 'rox-api-token' key in the secret specified in rox-secret-name parameter."
           set_test_output_result SKIPPED "Task $(context.task.name) skipped: ACS API token not provided"
+          touch $(results.SCAN_OUTPUT.path)
           exit 0
         fi
 
@@ -166,4 +168,6 @@ spec:
           mountPath: /steps-shared-folder
       script: |
         #!/usr/bin/env bash
-        cat /steps-shared-folder/acs-image-scan.json
+        if [ -f /steps-shared-folder/acs-image-scan.json ]; then
+          cat /steps-shared-folder/acs-image-scan.json
+        fi


### PR DESCRIPTION
* The report step in all tasks now cats the file only if it exists
* The image-scan task writes an empty SCAN_OUTPUT when skipped
  * Otherwise the pipeline fails because the ACS_SCAN_OUTPUT result references a non-existent task result

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
