### PR TITLE
Do not run update-deployment task on pull request

### DIFF
--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -15,6 +15,13 @@
     type: string
     default: "rox-api-token"
 - op: add
+  path: /spec/params/-
+  value:
+    name: event-type
+    type: string
+    default: "push"
+    description: "Event that triggered the pipeline run, e.g. push, pull_request"
+- op: add
   path: /spec/results/-
   value:
     name: ACS_SCAN_OUTPUT
@@ -27,16 +34,16 @@
 - op: add
   path: /spec/tasks/3/params
   value:
-  - name: IMAGE
-    value: $(params.output-image)
-  - name: DOCKERFILE
-    value: $(params.dockerfile)
-  - name: CONTEXT
-    value: $(params.path-context)
-  - name: IMAGE_EXPIRES_AFTER
-    value: "$(params.image-expires-after)"
-  - name: COMMIT_SHA
-    value: "$(tasks.clone-repository.results.commit)"
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: IMAGE_EXPIRES_AFTER
+      value: "$(params.image-expires-after)"
+    - name: COMMIT_SHA
+      value: "$(tasks.clone-repository.results.commit)"
 # Remove tasks
 # Example - yq .spec.tasks.[].name ../build-definitions/pipelines/template-build/template-build.yaml | nl -v 0
 # to compute offsets
@@ -75,14 +82,14 @@
   value:
     name: acs-image-check
     params:
-    - name: rox-secret-name
-      value: $(params.stackrox-secret)
-    - name: image
-      value: $(params.output-image)
-    - name: insecure-skip-tls-verify
-      value: "true"
-    - name: image-digest
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: rox-secret-name
+        value: $(params.stackrox-secret)
+      - name: image
+        value: $(params.output-image)
+      - name: insecure-skip-tls-verify
+        value: "true"
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
     runAfter:
       - build-container
     taskRef:
@@ -92,16 +99,16 @@
   value:
     name: acs-image-scan
     params:
-    - name: rox-secret-name
-      value: $(params.stackrox-secret)
-    - name: image
-      value: $(params.output-image)
-    - name: insecure-skip-tls-verify
-      value: "true"
-    - name: image-digest
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: rox-secret-name
+        value: $(params.stackrox-secret)
+      - name: image
+        value: $(params.output-image)
+      - name: insecure-skip-tls-verify
+        value: "true"
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
     runAfter:
-    - build-container
+      - build-container
     taskRef:
       kind: Task
       name: acs-image-scan
@@ -110,14 +117,18 @@
   value:
     name: acs-deploy-check
     params:
-    - name: rox-secret-name
-      value: $(params.stackrox-secret)
-    - name: gitops-repo-url
-      value: $(params.git-url)-gitops
-    - name: insecure-skip-tls-verify
-      value: "true"
+      - name: rox-secret-name
+        value: $(params.stackrox-secret)
+      - name: gitops-repo-url
+        value: $(params.git-url)-gitops
+      - name: insecure-skip-tls-verify
+        value: "true"
     runAfter:
-    - update-deployment
+      - update-deployment
+    when:
+      - input: "pull_request"
+        operator: notin
+        values: ["$(params.event-type)"]
     taskRef:
       kind: Task
       name: acs-deploy-check
@@ -132,6 +143,10 @@
         value: $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
     runAfter:
       - build-container
+    when:
+      - input: "pull_request"
+        operator: notin
+        values: ["$(params.event-type)"]
     taskRef:
       kind: Task
       name: update-deployment

--- a/task/update-deployment/0.1/update-deployment.yaml
+++ b/task/update-deployment/0.1/update-deployment.yaml
@@ -22,56 +22,56 @@ spec:
         secretName: $(params.gitops-auth-secret-name)
         optional: true
   steps:
-  - name: patch-gitops
-    image: quay.io/redhat-appstudio/task-toolset@sha256:931a9f7886586391ccb38d33fd15a47eb03568f9b19512b0a57a56384fa52a3c
-    volumeMounts:
-      - name: gitops-auth-secret
-        mountPath: /gitops-auth-secret
-    env:
-      - name: PARAM_GITOPS_REPO_URL
-        value: $(params.gitops-repo-url)
-      - name: PARAM_IMAGE
-        value: $(params.image)
-    script: |
-      if test -f /gitops-auth-secret/password ; then
-        gitops_repo_url=${PARAM_GITOPS_REPO_URL}
-        remote_without_protocol=${gitops_repo_url#'https://'}
+    - name: patch-gitops
+      image: quay.io/redhat-appstudio/task-toolset@sha256:931a9f7886586391ccb38d33fd15a47eb03568f9b19512b0a57a56384fa52a3c
+      volumeMounts:
+        - name: gitops-auth-secret
+          mountPath: /gitops-auth-secret
+      env:
+        - name: PARAM_GITOPS_REPO_URL
+          value: $(params.gitops-repo-url)
+        - name: PARAM_IMAGE
+          value: $(params.image)
+      script: |
+        if test -f /gitops-auth-secret/password ; then
+          gitops_repo_url=${PARAM_GITOPS_REPO_URL}
+          remote_without_protocol=${gitops_repo_url#'https://'}
 
-        password=$(cat /gitops-auth-secret/password)
-        if test -f /gitops-auth-secret/username ; then
-          username=$(cat /gitops-auth-secret/username)
-          echo "https://${username}:${password})@${hostname}" > "${HOME}/.git-credentials"
-          origin_with_auth=https://${username}:${password}@${remote_without_protocol}.git
+          password=$(cat /gitops-auth-secret/password)
+          if test -f /gitops-auth-secret/username ; then
+            username=$(cat /gitops-auth-secret/username)
+            echo "https://${username}:${password})@${hostname}" > "${HOME}/.git-credentials"
+            origin_with_auth=https://${username}:${password}@${remote_without_protocol}.git
+          else
+            origin_with_auth=https://${password}@${remote_without_protocol}.git
+          fi
         else
-          origin_with_auth=https://${password}@${remote_without_protocol}.git
+          echo "git credentials to push into gitops repository ${PARAM_GITOPS_REPO_URL} is not configured."
+          echo "gitops repository is not updated automatically."
+          echo "You can update gitops repository with the new image: ${PARAM_IMAGE} manually"
+          echo "TODO: configure git credentials to update gitops repository."
+          exit 0
         fi
-      else
-        echo "git credentials to push into gitops repository ${PARAM_GITOPS_REPO_URL} is not configured."
-        echo "gitops repository is not updated automatically."
-        echo "You can update gitops repository with the new image: ${PARAM_IMAGE} manually"
-        echo "TODO: configure git credentials to update gitops repository."
-        exit 0
-      fi
 
-      # https://github.com/user-org/test-component-gitops => test-component
-      gitops_repo_name=$(basename ${PARAM_GITOPS_REPO_URL})
-      component_id=${gitops_repo_name%'-gitops'}
-      deployment_patch_filepath="components/${component_id}/overlays/development/deployment-patch.yaml"
+        # https://github.com/user-org/test-component-gitops => test-component
+        gitops_repo_name=$(basename ${PARAM_GITOPS_REPO_URL})
+        component_id=${gitops_repo_name%'-gitops'}
+        deployment_patch_filepath="components/${component_id}/overlays/development/deployment-patch.yaml"
 
-      git config --global user.email "rhtap@noreplay.com"
-      git config --global user.name "gitops-update"
+        git config --global user.email "rhtap@noreplay.com"
+        git config --global user.name "gitops-update"
 
-      git clone ${PARAM_GITOPS_REPO_URL}
-      cd ${gitops_repo_name}
+        git clone ${PARAM_GITOPS_REPO_URL}
+        cd ${gitops_repo_name}
 
-      sed -i "s| image: .*| image: ${PARAM_IMAGE}|" $deployment_patch_filepath
+        sed -i "s| image: .*| image: ${PARAM_IMAGE}|" $deployment_patch_filepath
 
-      git add .
-      git commit -m "Update '${component_id}' component image to: ${PARAM_IMAGE}"
-      git remote set-url origin $origin_with_auth
-      git push 2> /dev/null || \
-      {
-        echo "Failed to push update to gitops repository: ${PARAM_GITOPS_REPO_URL}"
-        echo 'Do you have correct git credentials configured?'
-        exit 1
-      }
+        git add .
+        git commit -m "Update '${component_id}' component image to: ${PARAM_IMAGE}"
+        git remote set-url origin $origin_with_auth
+        git push 2> /dev/null || \
+        {
+          echo "Failed to push update to gitops repository: ${PARAM_GITOPS_REPO_URL}"
+          echo 'Do you have correct git credentials configured?'
+          exit 1
+        }


### PR DESCRIPTION
Prevents running update deployment task if pipeline was trigerred by pull_request event.
Also, fixes some formatting.
https://github.com/redhat-appstudio/tssc-sample-pipelines/pull/24 adds `event-type` parameter to the RHTAP pipeline run.