### PR TITLE
Give write permission to e2e-tests task

### DIFF
--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -26,7 +26,9 @@ spec:
         "--ginkgo.no-color"
       ]
       securityContext:
-        runAsUser: 1000
+        capabilities:
+          add:
+          - SETFCAP
       env:
       - name: APP_SUFFIX
         value: "$(params.app_suffix)"


### PR DESCRIPTION
[STONEBLD-1832](https://issues.redhat.com//browse/STONEBLD-1832)

Pull secret is required to be available for the e2e tests in order to
fetch image data from registry.redhat.io. The task needs the capability
in order to write the registry authentication credential into auth file.
