### PR TITLE
Get changed task files for git resolvers

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -34,8 +34,10 @@ spec:
             value: $(params.git-url)
           - name: revision
             value: "$(params.revision)"
+          # the task "build-acceptable-bundles" uses git diff-tree which needs history to compare the current
+          # revision to, so this must be set to 0 or > 1 for the task to work
           - name: depth
-            value: "0"
+            value: "2"
         taskRef:
           name: git-clone
         workspaces:
@@ -132,40 +134,24 @@ spec:
           steps:
             - name: build-bundles
               image: quay.io/redhat-appstudio/appstudio-utils:{{ revision }}
+              env:
+              - name: REVISION
+                value: "$(params.revision)"
+              - name: GIT_URL
+                value: "$(params.git-url)"
               # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
               # the cluster will set imagePullPolicy to IfNotPresent
               # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
               script: |-
                 #!/usr/bin/env bash
-                set -euo pipefail
 
-                BUNDLES=(
+                export BUNDLES=(
                   $(workspaces.artifacts.path)/source/task-bundle-list
                   $(workspaces.artifacts.path)/source/pipeline-bundle-list
                 )
-                touch ${BUNDLES[@]}
-                echo "Bundles to be added:"
-                cat ${BUNDLES[@]}
-                BUNDLES_PARAM=($(cat ${BUNDLES[@]} | awk '{ print "--bundle=" $0 }'))
 
-                # The OPA data bundle is tagged with the current timestamp. This has two main
-                # advantages. First, it prevents the image from accidentally not having any tags,
-                # and getting garbage collected. Second, it helps us create a timeline of the
-                # changes done to the data over time.
-                TAG="$(date '+%s')"
-                DATA_BUNDLE_REPO='quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles'
+                .tekton/scripts/build-acceptable-bundles.sh
 
-                # Update the OPA data bundle.
-                ec track bundle --debug \
-                  --input "oci:${DATA_BUNDLE_REPO}:latest" \
-                  --output "oci:${DATA_BUNDLE_REPO}:${TAG}" \
-                  --timeout "15m0s" \
-                  --freshen \
-                  --prune \
-                  ${BUNDLES_PARAM[@]}
-
-                # To facilitate usage in some contexts, tag the image with the floating "latest" tag.
-                skopeo copy "docker://${DATA_BUNDLE_REPO}:${TAG}" "docker://${DATA_BUNDLE_REPO}:latest"
               volumeMounts:
                 - mountPath: /root/.docker/config.json
                   subPath: .dockerconfigjson

--- a/.tekton/scripts/build-acceptable-bundles.sh
+++ b/.tekton/scripts/build-acceptable-bundles.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# helps with debugging
+DATA_BUNDLE_REPO="${DATA_BUNDLE_REPO:-quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles}"
+BUNDLES=${BUNDLES:-()}
+
+# store a list of changed task files
+task_records=()
+# loop over all changed files
+for path in $(git diff-tree -c --name-only --no-commit-id -r ${REVISION}); do
+    # check that the file modified is the task file
+    if [[ "${path}" == task/*/*/*.yaml ]]; then
+    IFS='/' read -r -a path_array <<< "${path}"
+    dir_name_after_task="${path_array[1]}"
+    file_name=$(basename "${path_array[-1]}" ".yaml")
+
+    if [[ "${dir_name_after_task}" == "${file_name}" ]]; then
+        # GIT_URL is the repo_url from PAC (https://hostname/org/repo)
+        task_records+=("git+${GIT_URL}.git//${path}@${REVISION}")
+    fi
+    fi
+done
+
+echo "${task_records[@]}"
+
+touch ${BUNDLES[@]}
+echo "Bundles to be added:"
+cat ${BUNDLES[@]}
+
+# The OPA data bundle is tagged with the current timestamp. This has two main
+# advantages. First, it prevents the image from accidentally not having any tags,
+# and getting garbage collected. Second, it helps us create a timeline of the
+# changes done to the data over time.
+TAG="$(date '+%s')"
+
+# task_records can be empty if a task wasn't changed
+TASK_PARAM=()
+if [ "${#task_records[@]}" -gt 0 ]; then
+    TASK_PARAM=($(printf "%s\n" "${task_records[@]}" | awk '{ print "--git=" $0 }'))
+fi
+
+BUNDLES_PARAM=($(cat ${BUNDLES[@]} | awk '{ print "--bundle=" $0 }'))
+
+PARAMS=("${TASK_PARAM[@]}" "${BUNDLES_PARAM[@]}")
+ec track bundle --debug \
+    --input "oci:${DATA_BUNDLE_REPO}:latest" \
+    --output "oci:${DATA_BUNDLE_REPO}:${TAG}" \
+    --timeout "15m0s" \
+    --freshen \
+    --prune \
+    ${PARAMS[@]}
+
+# To facilitate usage in some contexts, tag the image with the floating "latest" tag.
+skopeo copy "docker://${DATA_BUNDLE_REPO}:${TAG}" "docker://${DATA_BUNDLE_REPO}:latest"


### PR DESCRIPTION
After a merge, collect any changed task files then add them to a data bundle for policy evaluation.

https://issues.redhat.com/browse/EC-387
