### PR TITLE
fix issue with source build when rpm-ostree is used

### DIFF
--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -82,6 +82,12 @@ spec:
         registry.redhat.io
         "
 
+        ## This is needed for the builds performed by the rpm-ostree task
+        ## otherwise, we can see this error:
+        ## "fatal: detected dubious ownership in repository at '/workspace/workspace/source'"
+        ##
+        git config --global --add safe.directory $SOURCE_DIR
+
         ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \
           --output-binary-image "$BINARY_IMAGE" \
           --workspace /var/source-build \


### PR DESCRIPTION
- This fix is needed for the builds performed by the rpm-ostree task otherwise, we can see this error:

"fatal: detected dubious ownership in repository at '/workspace/workspace/source'"
