### PR TITLE
Change the shebang in the show-sbom-rhdh task

### DIFF
--- a/task/show-sbom-rhdh/0.1/show-sbom-rhdh.yaml
+++ b/task/show-sbom-rhdh/0.1/show-sbom-rhdh.yaml
@@ -40,7 +40,7 @@ spec:
     - name: IMAGE_URL
       value: $(params.IMAGE_URL)
     script: |
-      #!/busybox/sh
+      #!/bin/bash
       status=-1
       max_try=5
       wait_sec=2


### PR DESCRIPTION
The current shebang (/busybox/sh) does not exist in the RHTAS image, and will cause the taskRun to fail.