### PR TITLE
fix(STONEBLD-2265): increase the default timeout of pull-request-type PLR & e2e-tests Task to 2hrs

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -182,6 +182,8 @@ spec:
           - build-bundles
         taskRef:
           name: e2e-test
+        # Added a timeout due to https://issues.redhat.com/browse/STONEBLD-2265
+        timeout: "2h"
       - name: check-task-pipeline-repo-existence
         runAfter:
           - build-bundles
@@ -259,6 +261,9 @@ spec:
                 # Perform cleanup of resources created by gitops service
                 oc delete --ignore-not-found deployment --all -n $(params.e2e_test_namespace)
                 oc delete --ignore-not-found eventlisteners --all -n $(params.e2e_test_namespace)
+  # Added a timeout due to https://issues.redhat.com/browse/STONEBLD-2265
+  timeouts:
+    pipeline: "2h"
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -18,7 +18,7 @@ spec:
       type: string
   steps:
     - name: e2e-test
-      image: quay.io/redhat-appstudio/e2e-tests:c18b86ccadcc8818d8d0e6e07d2dd4e98c7b5af8
+      image: quay.io/redhat-appstudio/e2e-tests:13ba743f0ae3fe85502a598ea2a9d7da91164b61
       # a la infra-deployment updates, when PRs merge in e2e-tests, PRs will be opened
       # against build-definitions to update this tag
       args: [


### PR DESCRIPTION
* This change increases the default timeout (60mins) of the PR-type PLR and the 'e2e-tests' Task to 90 mins.
* This is a temporary change, please see: https://github.com/redhat-appstudio/e2e-tests/pull/1091
* Since the chains controller is overwhelmed, we had to increase the test timeout value to 90mins.
* So this current PR increases the timeout values for PLR and a Task to the same timeout value used by test, 90m.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
