### PR TITLE
Remove usage of task-toolset image

### DIFF
--- a/task/summary/0.2/summary.yaml
+++ b/task/summary/0.2/summary.yaml
@@ -27,7 +27,7 @@ spec:
       optional: true
   steps:
     - name: appstudio-summary
-      image: quay.io/redhat-appstudio/task-toolset@sha256:931a9f7886586391ccb38d33fd15a47eb03568f9b19512b0a57a56384fa52a3c
+      image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.


### PR DESCRIPTION
This PR removes last usage of `quay.io/redhat-appstudio/task-toolset` image by replacing it with `uay.io/redhat-appstudio/appstudio-utils` image that has needed tools installed and already used in other tasks, so we reduce number of used images by 1.
