### PR TITLE
e2e-test: Set ginkgo timeout to 2 hours

### DIFF
--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -23,7 +23,8 @@ spec:
       # against build-definitions to update this tag
       args: [
         "--ginkgo.label-filter=build-templates-e2e",
-        "--ginkgo.no-color"
+        "--ginkgo.no-color",
+        "--ginkgo.timeout=2h"
       ]
       securityContext:
         runAsUser: 1000


### PR DESCRIPTION
In d07462a6068ca7f6f086c2b734c2cdfb97e902e5, the timeout for the test
pipelineRun was increased to 2 hours (see the commit message for
reasoning.)
    
However, ginkgo has its own timeout which defaults to 1 hour. Increase
to 2 hours correspondingly.