### PR TITLE
Update test repos for source container build

### DIFF
--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -31,7 +31,7 @@ spec:
       - name: APP_SUFFIX
         value: "$(params.app_suffix)"
       - name: COMPONENT_REPO_URLS
-        value: "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic,https://github.com/redhat-appstudio-qe/retrodep,https://github.com/cachito-testing/pip-e2e-test,https://github.com/redhat-appstudio-qe/fbc-sample-repo,https://github.com/redhat-appstudio-qe/nodejs-no-dockerfile,https://github.com/redhat-appstudio-qe/maven-hello-world,https://github.com/redhat-appstudio-qe/e2e-tests-parent-image-with-both-tag-digest,https://github.com/redhat-appstudio-qe/e2e-tests-parent-image-with-digest-only,https://github.com/redhat-appstudio-qe/e2e-tests-use-latest-parent-image,https://github.com/redhat-appstudio-qe/e2e-tests-parent-image-from-registry-rh-io"
+        value: "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic,https://github.com/redhat-appstudio-qe/retrodep,https://github.com/cachito-testing/pip-e2e-test,https://github.com/redhat-appstudio-qe/fbc-sample-repo,https://github.com/redhat-appstudio-qe/nodejs-no-dockerfile,https://github.com/redhat-appstudio-qe/maven-hello-world,https://github.com/redhat-appstudio-qe/source-build-parent-image-with-digest-only,https://github.com/redhat-appstudio-qe/source-build-parent-image-with-both-tag-digest,https://github.com/redhat-appstudio-qe/source-build-use-latest-parent-image,https://github.com/redhat-appstudio-qe/source-build-parent-image-from-registry-rh-io"
       - name: QUAY_E2E_ORGANIZATION
         value: redhat-appstudio
       - name: E2E_APPLICATIONS_NAMESPACE


### PR DESCRIPTION
Names of the test repos created in tha past match the cleanup rule
defined in e2e-tests, which causes those repos were removed from
redhat-appstudio-qe organization. As of this update, the test repos have
been recovered with new names already.