### PR TITLE
Emit SBOM_BLOB_URL result on rpm-ostree task

### DIFF
--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -59,6 +59,8 @@ spec:
     name: IMAGE_URL
   - description: Digests of the base images used for build
     name: BASE_IMAGES_DIGESTS
+  - name: SBOM_BLOB_URL
+    description: Reference, including digest to the SBOM blob
   stepTemplate:
     env:
     - name: CONTEXT
@@ -221,6 +223,12 @@ spec:
 
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee $(results.SBOM_BLOB_URL.path)
     securityContext:
       capabilities:
         add:


### PR DESCRIPTION
This changes the rpm-ostree task to emit a new task result, SBOM_BLOB_URL. This result includes an image reference by digest to the SBOM of the image.

![Знімок екрана 2024-03-27 о 13 45 56](https://github.com/redhat-appstudio/build-definitions/assets/1614429/2e445a0d-0ec5-4e5c-81bb-af49d649cedc)


Context https://issues.redhat.com/browse/STONEBLD-2269 