### PR TITLE
Properly handle GitLab merge request event in RHTAP pipeline

### DIFF
--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -133,9 +133,9 @@
     runAfter:
       - update-deployment
     when:
-      - input: "pull_request"
+      - input: "$(params.event-type)"
         operator: notin
-        values: ["$(params.event-type)"]
+        values: ["pull_request", "Merge Request"]
     taskRef:
       kind: Task
       name: acs-deploy-check
@@ -153,9 +153,9 @@
     runAfter:
       - build-container
     when:
-      - input: "pull_request"
+      - input: "$(params.event-type)"
         operator: notin
-        values: ["$(params.event-type)"]
+        values: ["pull_request", "Merge Request"]
     taskRef:
       kind: Task
       name: update-deployment


### PR DESCRIPTION
Update deployment task should be skipped in pull request pipeline.
Pipelines as Code has different name of the event for GitHub and GitLab. Take both into account.
