### PR TITLE
Save base_images_from_dockerfile to /workspaces/source

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -295,7 +295,7 @@ spec:
       done
 
       # Needed to generate base images SBOM
-      echo "$BASE_IMAGES" > /workspace/base_images_from_dockerfile
+      echo "$BASE_IMAGES" > $(workspaces.source.path)/base_images_from_dockerfile
 
       buildah push "$IMAGE" oci:rhtap-final-image
       REMOTESSHEOF
@@ -444,7 +444,7 @@ spec:
     image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
     name: create-base-images-sbom
     script: |
-      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=/workspace/base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
+      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
     securityContext:
       runAsUser: 0
     workingDir: $(workspaces.source.path)

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -246,7 +246,7 @@ spec:
       done
 
       # Needed to generate base images SBOM
-      echo "$BASE_IMAGES" > /workspace/base_images_from_dockerfile
+      echo "$BASE_IMAGES" > $(workspaces.source.path)/base_images_from_dockerfile
 
     securityContext:
       capabilities:
@@ -359,7 +359,7 @@ spec:
     - name: BASE_IMAGES_DIGESTS_PATH
       value: $(results.BASE_IMAGES_DIGESTS.path)
     script: |
-      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=/workspace/base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
+      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
     workingDir: $(workspaces.source.path)
     securityContext:
       runAsUser: 0


### PR DESCRIPTION
The reason is that this was failing in buildah remote task because the line

echo "$BASE_IMAGES" > /workspace/base_images_from_dockerfile

was executed on a VM via SSH and it was not restored afterwards. However, /workspaces/source is actually restored via

rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/" 
https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah-remote/0.1/buildah-remote.yaml#L326

So storing it in /workspaces/source should make it available in the end.