### PR TITLE
feat(STONEINTG-875): allow brew.registry.redhat.io in fbc-validation

### DIFF
--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -58,6 +58,7 @@ spec:
         declare -a ALLOWED_BASE_IMAGES=(
           "registry.redhat.io/openshift4/ose-operator-registry"
           "registry.redhat.io/openshift4/ose-operator-registry-rhel9"
+          "brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9"
         )
 
         ### FBC base image check


### PR DESCRIPTION
* Add brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9 base image to the list of allowed base images in the fbc-validation check task

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
