### PR TITLE
Use a newer version of ec in task definition

### DIFF
--- a/task/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/task/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -111,12 +111,12 @@ spec:
 
   steps:
     - name: version
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:1.0.alpha
+      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
       command: [ec]
       args:
         - version
     - name: initialize-tuf
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:1.0.alpha
+      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
       script: |-
         set -euo pipefail
 
@@ -132,7 +132,7 @@ spec:
         - name: TUF_MIRROR
           value: "$(params.TUF_MIRROR)"
     - name: validate
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:1.0.alpha
+      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
       command: [ec]
       args:
         - validate
@@ -180,23 +180,23 @@ spec:
         limits:
           memory: 2Gi
     - name: report
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:1.0.alpha
+      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
       command: [cat]
       args:
         - "$(params.HOMEDIR)/report.yaml"
     - name: report-json
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:1.0.alpha
+      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
       command: [cat]
       args:
         - "$(params.HOMEDIR)/report-json.json"
     - name: summary
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:1.0.alpha
+      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
       command: [jq]
       args:
         - "."
         - "$(results.TEST_OUTPUT.path)"
     - name: assert
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:1.0.alpha
+      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
       command: [jq]
       args:
         - "--argjson"


### PR DESCRIPTION
This should not be merged until *after*
[EC-518](https://issues.redhat.com/browse/EC-518) is resolved, since right now there are not v0.2 images of ec pushed out to registry.redhat.io. (Long story.)

It's expected this will resolve the root cause of
[RHTAPBUGS-1212](https://issues.redhat.com/browse/RHTAPBUGS-1212)

I'm aware of the dire warning at the top of this file, but IIUC this PR to change ref does indeed belong here.
