### PR TITLE
Fix pull-request pipeline for the GH merge queue

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -176,7 +176,11 @@ spec:
           - name: e2e_test_namespace
             value: $(params.e2e_test_namespace)
           - name: app_suffix
-            value: "{{ pull_request_number }}"
+            value: "ref-{{ revision }}"
+          - name: ec_pipelines_repo_url
+            value: "{{ source_url }}"
+          - name: ec_pipelines_repo_revision
+            value: "{{ revision }}"
         runAfter:
           - build-bundles
         taskRef:

--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -16,6 +16,10 @@ spec:
       type: string
     - name: app_suffix
       type: string
+    - name: ec_pipelines_repo_url
+      type: string
+    - name: ec_pipelines_repo_revision
+      type: string
   steps:
     - name: e2e-test
       image: quay.io/redhat-appstudio/e2e-tests:aee2181831ab240041e83f1c9036532415f45ccf
@@ -46,3 +50,7 @@ spec:
             key: token
       - name: MY_GITHUB_ORG
         value: redhat-appstudio-appdata
+      - name: EC_PIPELINES_REPO_URL
+        value: $(params.ec_pipelines_repo_url)
+      - name: EC_PIPELINES_REPO_REVISION
+        value: $(params.ec_pipelines_repo_revision)


### PR DESCRIPTION
The pipeline used to pass APP_SUFFIX={{ pull_request_number }} to e2e tests. When a pull request enters the merge queue, it does so via a push event, not a pull request event. Pipelines as Code therefore does not expand the {{ pull_request_number }} placeholder, causing e2e tests to create Kubernetes objects with invalid names:

    "test-app-{{ pull_request_number }}" is invalid: metadata.name: ...

The pull request number in the APP_SUFFIX is also used by e2e test code to determine the source url and revision for the pull request [1].

To fix the issues:
- use the {{ revision }} instead of the {{ pull_request_number }} for the suffix
- pass the source url and revision to the e2e tests directly instead of relying on the APP_SUFFIX [2]
- use ref-{{ revision }} as the suffix to make absolutely sure e2e tests won't try to interpret the revision as a pull request number

[1]: https://github.com/redhat-appstudio/e2e-tests/blob/c4f5822caebb5b5119eedc4e1ab836eb7e6237f1/tests/build/build_templates.go#L519-L525
[2]: https://github.com/redhat-appstudio/e2e-tests/blob/c4f5822caebb5b5119eedc4e1ab836eb7e6237f1/tests/build/build_templates.go#L534-L537

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
