### PR TITLE
rpm-ostree: merge Cachi2 SBOM with Syft SBOM

### DIFF
--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -214,27 +214,6 @@ spec:
     volumeMounts:
       - mountPath: /var/lib/containers
         name: varlibcontainers
-  - image: registry.access.redhat.com/ubi9/python-39:1-165@sha256:4da8ddb12096a31d8d50e58ea479ba2fe2f252f215fbaf5bf90923a1827463ba
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
-    name: create-purl-sbom
-    computeResources: {}
-    script: |
-      #!/bin/python3
-      import json
-
-      with open("./sbom-cyclonedx.json") as f:
-        cyclonedx_sbom = json.load(f)
-
-      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
-      purl_content = {"image_contents": {"dependencies": purls}}
-
-      with open("sbom-purl.json", "w") as output_file:
-        json.dump(purl_content, output_file, indent=4)
-    securityContext:
-      runAsUser: 0
-    workingDir: $(workspaces.source.path)
   - image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -214,6 +214,20 @@ spec:
     volumeMounts:
       - mountPath: /var/lib/containers
         name: varlibcontainers
+  - name: merge-cachi2-sbom
+    image: quay.io/redhat-appstudio/cachi2:0.6.0@sha256:15d0513ed891b1d34fc46e56fdc9f6b457c90fbfd34f6a8c8fce6d3400ddc4a7
+    script: |
+      cachi2_sbom=./cachi2/output/bom.json
+      if [ -f "$cachi2_sbom" ]; then
+        echo "Merging contents of $cachi2_sbom into sbom-cyclonedx.json"
+        /src/utils/merge_syft_sbom.py "$cachi2_sbom" sbom-cyclonedx.json > sbom-temp.json
+        mv sbom-temp.json sbom-cyclonedx.json
+      else
+        echo "Skipping step since no Cachi2 SBOM was produced"
+      fi
+    workingDir: $(workspaces.source.path)
+    securityContext:
+      runAsUser: 0
   - image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent


### PR DESCRIPTION
[STONEBLD-2281](https://issues.redhat.com//browse/STONEBLD-2281)

If the prefetch task has generated an SBOM, merge it with the one
generated by Syft.

Copy-paste the step from the buildah task, just modify the condition:
check the existence of the SBOM file rather than checking the
PREFETCH_INPUT param (the rpm-ostree task doesn't have it).
