### PR TITLE
chore(STONEINTG-758): deprecate old ver of deprecated-image-check

### DIFF
--- a/task/deprecated-image-check/0.1/README.md
+++ b/task/deprecated-image-check/0.1/README.md
@@ -3,7 +3,7 @@
 ## Deprecation notice
 
 This task version is deprecated, please use the latest version.
-Deprecation date: 2024-04-30
+Deprecation date: 2024-06-01
 
 ## Description:
 The deprecated-image-check checks for deprecated images that are no longer maintained and prone to security issues.

--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "appstudio, hacbs"
+    build.appstudio.redhat.com/expires-on: "2024-06-01T00:00:00Z"
   name: deprecated-image-check
 spec:
   description: >-

--- a/task/deprecated-image-check/0.2/README.md
+++ b/task/deprecated-image-check/0.2/README.md
@@ -3,7 +3,7 @@
 ## Deprecation notice
 
 This task version is deprecated, please use the latest version.
-Deprecation date: 2024-04-30
+Deprecation date: 2024-06-01
 
 ## Description:
 The deprecated-image-check checks for deprecated images that are no longer maintained and prone to security issues.

--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "appstudio, hacbs"
+    build.appstudio.redhat.com/expires-on: "2024-06-01T00:00:00Z"
   name: deprecated-image-check
 spec:
   description: >-


### PR DESCRIPTION
v1 and v2 of deprecated-image-check are deprecated (for real now) and after deprecation date EC will start failing build verifications.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
