### PR TITLE
feat: skip CI when the PR is in draft

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -4,7 +4,7 @@ kind: PipelineRun
 metadata:
   name: build-definitions-pull-request
   annotations:
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main") || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && body.pull_request.draft == false) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
     pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, .tekton/tasks/yaml-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.1/sast-snyk-check.yaml]"
     pipelinesascode.tekton.dev/task-2: "yaml-lint"
     pipelinesascode.tekton.dev/max-keep-runs: "5"

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -4,7 +4,7 @@ kind: PipelineRun
 metadata:
   name: build-definitions-pull-request
   annotations:
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && body.pull_request.draft == false) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && ( !has(body.pull_request) || body.pull_request.draft == false) ) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
     pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, .tekton/tasks/yaml-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.1/sast-snyk-check.yaml]"
     pipelinesascode.tekton.dev/task-2: "yaml-lint"
     pipelinesascode.tekton.dev/max-keep-runs: "5"

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -4,7 +4,7 @@ kind: PipelineRun
 metadata:
   name: build-definitions-pull-request
   annotations:
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && ( !has(body.pull_request) || body.pull_request.draft == false) ) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && ( !has(body.pull_request) || !body.pull_request.draft) ) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
     pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, .tekton/tasks/yaml-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.1/sast-snyk-check.yaml]"
     pipelinesascode.tekton.dev/task-2: "yaml-lint"
     pipelinesascode.tekton.dev/max-keep-runs: "5"


### PR DESCRIPTION
### Why
To reduce the load on the prod cluster, let's skip running CI when the PR is WIP (draft)

### Notes
* It is still possible to trigger CI test by commenting `/test` or `/retest` even when PR is WIP
* Since [PaC currently does not support event](https://pipelinesascode.com/docs/guide/authoringprs/#advanced-event-matching) `ready_for_review`, after converting a PR to "Ready for review" it's required to add a `test` comment (as mentioned above) to trigger CI