### PR TITLE
prefetch-dependencies: enable basic git auth

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -105,6 +105,8 @@ spec:
       workspaces:
         - name: source
           workspace: workspace
+        - name: git-basic-auth
+          workspace: git-auth
     - name: build-container
       when:
       - input: $(tasks.init.results.build)

--- a/task/prefetch-dependencies/0.1/README.md
+++ b/task/prefetch-dependencies/0.1/README.md
@@ -8,8 +8,12 @@ See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
 |---|---|---|---|
 |input|Configures project packages that will have their dependencies prefetched.||true|
 |dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
+|log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 
 ## Workspaces
 |name|description|optional|
 |---|---|---|
 |source|Workspace with the source code, cachi2 artifacts will be stored on the workspace as well|false|
+|git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -19,6 +19,9 @@ spec:
       notice. Use at your own risk.
     name: dev-package-managers
     default: "false"
+  - description: Set cachi2 log level (debug, info, warning, error)
+    name: log-level
+    default: "info"
   - name: caTrustConfigMapName
     type: string
     description: The name of the ConfigMap to read CA bundle data from.
@@ -38,6 +41,8 @@ spec:
       value: $(params.input)
     - name: DEV_PACKAGE_MANAGERS
       value: $(params.dev-package-managers)
+    - name: LOG_LEVEL
+      value: $(params.log-level)
     - name: WORKSPACE_GIT_AUTH_BOUND
       value: $(workspaces.git-basic-auth.bound)
     - name: WORKSPACE_GIT_AUTH_PATH
@@ -84,18 +89,18 @@ spec:
         update-ca-trust
       fi
 
-      cachi2 fetch-deps \
+      cachi2 --log-level="$LOG_LEVEL" fetch-deps \
       $dev_pacman_flag \
       --source=$(workspaces.source.path)/source \
       --output=$(workspaces.source.path)/cachi2/output \
       "${INPUT}"
 
-      cachi2 generate-env $(workspaces.source.path)/cachi2/output \
+      cachi2 --log-level="$LOG_LEVEL" generate-env $(workspaces.source.path)/cachi2/output \
       --format env \
       --for-output-dir=/cachi2/output \
       --output $(workspaces.source.path)/cachi2/cachi2.env
 
-      cachi2 inject-files $(workspaces.source.path)/cachi2/output \
+      cachi2 --log-level="$LOG_LEVEL" inject-files $(workspaces.source.path)/cachi2/output \
       --for-output-dir=/cachi2/output
   workspaces:
   - name: source

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -38,6 +38,10 @@ spec:
       value: $(params.input)
     - name: DEV_PACKAGE_MANAGERS
       value: $(params.dev-package-managers)
+    - name: WORKSPACE_GIT_AUTH_BOUND
+      value: $(workspaces.git-basic-auth.bound)
+    - name: WORKSPACE_GIT_AUTH_PATH
+      value: $(workspaces.git-basic-auth.path)
     volumeMounts:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
@@ -53,6 +57,24 @@ spec:
         dev_pacman_flag=--dev-package-managers
       else
         dev_pacman_flag=""
+      fi
+
+      # Copied from https://github.com/redhat-appstudio/build-definitions/blob/main/task/git-clone/0.1/git-clone.yaml
+      if [ "${WORKSPACE_GIT_AUTH_BOUND}" = "true" ] ; then
+        if [ -f "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" ]; then
+          cp "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" "${HOME}/.git-credentials"
+          cp "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" "${HOME}/.gitconfig"
+        # Compatibility with kubernetes.io/basic-auth secrets
+        elif [ -f "${WORKSPACE_GIT_AUTH_PATH}/username" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/password" ]; then
+          HOSTNAME=$(cd "$(workspaces.source.path)/source" && git remote get-url origin | awk -F/ '{print $3}')
+          echo "https://$(cat ${WORKSPACE_GIT_AUTH_PATH}/username):$(cat ${WORKSPACE_GIT_AUTH_PATH}/password)@$HOSTNAME" > "${HOME}/.git-credentials"
+          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${HOME}/.gitconfig"
+        else
+          echo "Unknown git-basic-auth workspace format"
+          exit 1
+        fi
+        chmod 400 "${HOME}/.git-credentials"
+        chmod 400 "${HOME}/.gitconfig"
       fi
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
@@ -78,6 +100,13 @@ spec:
   workspaces:
   - name: source
     description: Workspace with the source code, cachi2 artifacts will be stored on the workspace as well
+  - name: git-basic-auth
+    description: |
+      A Workspace containing a .gitconfig and .git-credentials file or username and password.
+      These will be copied to the user's home before any cachi2 commands are run. Any
+      other files in this Workspace are ignored. It is strongly recommended
+      to bind a Secret to this Workspace over other volume types.
+    optional: true
   volumes:
     - name: trusted-ca
       configMap:


### PR DESCRIPTION
[KFLUXBUGS-1215](https://issues.redhat.com//browse/KFLUXBUGS-1215)

Cachi2 may fetch git tags from the source repository and/or clone other git repositories. Those may be private. Give the user a way to authenticate.

The basic-auth mechanism is copy-pasted from the git-clone task.

---

To fully replace #944, also

**prefetch-dependencies: expose log-level option**