### PR TITLE
Use GA repo for the EC task ref used by RHTAP

### DIFF
--- a/task/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/task/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -111,12 +111,12 @@ spec:
 
   steps:
     - name: version
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+      image: registry.redhat.io/rhtas/ec-rhel9:0.2
       command: [ec]
       args:
         - version
     - name: initialize-tuf
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+      image: registry.redhat.io/rhtas/ec-rhel9:0.2
       script: |-
         set -euo pipefail
 
@@ -132,7 +132,7 @@ spec:
         - name: TUF_MIRROR
           value: "$(params.TUF_MIRROR)"
     - name: validate
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+      image: registry.redhat.io/rhtas/ec-rhel9:0.2
       command: [ec]
       args:
         - validate
@@ -180,23 +180,23 @@ spec:
         limits:
           memory: 2Gi
     - name: report
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+      image: registry.redhat.io/rhtas/ec-rhel9:0.2
       command: [cat]
       args:
         - "$(params.HOMEDIR)/report.yaml"
     - name: report-json
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+      image: registry.redhat.io/rhtas/ec-rhel9:0.2
       command: [cat]
       args:
         - "$(params.HOMEDIR)/report-json.json"
     - name: summary
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+      image: registry.redhat.io/rhtas/ec-rhel9:0.2
       command: [jq]
       args:
         - "."
         - "$(results.TEST_OUTPUT.path)"
     - name: assert
-      image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+      image: registry.redhat.io/rhtas/ec-rhel9:0.2
       command: [jq]
       args:
         - "--argjson"


### PR DESCRIPTION
_NOTE: As noted mentioned in the comments in the of the file, this change has no impact on Konflux since Konflux uses the upstream task definition, not this one._

Since EC has been declared GA, it's now able to push to the normal repo rather than the tech preview repo. So let's update the image reference in the verify-enterprise-contract task accordingly.

There's a similar change in the related task definition in the tssc-sample-pipelines repo, see https://github.com/redhat-appstudio/tssc-sample-pipelines/pull/39 .

Ref: [EC-571](https://issues.redhat.com/browse/EC-571)

Before you complete this pull request: Look for any open pull requests in the repository with the title "e2e-tests update" and  see if there are recent e2e-tests updates that will be applicable to your change.
