### PR TITLE
fix: reorder conditions in init task to avoid kube API calls

### DIFF
--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -39,8 +39,9 @@ spec:
         echo
 
         echo "Determine if Image Already Exists"
-        # Build the image when image does not exists or rebuild is set to true
-        if ! oc image info $IMAGE_URL &>/dev/null || [ "$REBUILD" == "true" ] || [ "$SKIP_CHECKS" == "false" ]; then
+        # Build the image when rebuild is set to true or image does not exist
+        # The image check comes last to avoid unnecessary, slow API calls
+        if [ "$REBUILD" == "true" ] || [ "$SKIP_CHECKS" == "false" ] || ! oc image info $IMAGE_URL &>/dev/null; then
           echo -n "true" > $(results.build.path)
         else
           echo -n "false" > $(results.build.path)


### PR DESCRIPTION
We noticed that the `oc image info` call was executed regardless of whether the following conditions (REBUILD, SKIP_CHECKS) were set to echo `true` into the result.

This PR changes the order of evaluation so that the command execution is skipped if one of the other two parts already evaluates to true. 

This issue became apparent, when we changed the `image-url` to not include the tag part. `oc image info` will then return all images in the repository, e.g. all built images, all sbom and att images, which we'd like to avoid for sake of API server health & time. 

> # Before you complete this pull request ...

> Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.

#959 is open, but the picked changes are a refactoring and something with snapshotenvironment, IIUC unrelated to this change.