### PR TITLE
Support prefetch-dependencies without hermetic

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -87,9 +87,7 @@ spec:
           workspace: git-auth
     - name: prefetch-dependencies
       when:
-      - input: $(params.hermetic)
-        operator: in
-        values: ["true"]
+      - cel: "'$(params.prefetch-input) != '' || '$(params.hermetic)' == 'true'"
       params:
         - name: input
           value: $(params.prefetch-input)


### PR DESCRIPTION
IIUC there is some value in doing a prefetch-dependencies even if you're not quite ready to enable a hermetic build. This change makes it easier and more intuitive for people who want to do that.

For a pipeline with a non-empty value for prefetch-input, let's assume that the intention is to run the prefetch-dependencies task.

(This is a fast patch for an idea that occurred to me while working on https://issues.redhat.com/browse/EC-585 . Not sure how/where to test it. If the idea seems reasonable I'd be happy to create a fresh Jira for it and take some advice on what kind of testing it should have.)
