### PR TITLE
Allow prefetch to run without hermetic option

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -87,9 +87,9 @@ spec:
           workspace: git-auth
     - name: prefetch-dependencies
       when:
-      - input: $(params.hermetic)
-        operator: in
-        values: ["true"]
+      - input: $(params.prefetch-input)
+        operator: notin
+        values: [""]
       params:
         - name: input
           value: $(params.prefetch-input)

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -54,7 +54,8 @@ spec:
     script: |
       if [ -z "${INPUT}" ]
       then
-        echo "Build will be executed with network isolation, but no content was configured to be prefetched."
+        # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
+        echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
         exit 0
       fi
 


### PR DESCRIPTION
The prefetch-dependencies task has some value even without hermetic builds. It provides dependency sources for the source container that would otherwise be missing, and AIUI it lets the SBOM generator know more details about the dependencies. (I'm speaking about go module prefetching, but I expect it's probably similar for other types of dependencies supported by cachi2.)

Currently prefetch-dependency task is includes whenever the `hermetic` param is set to "true". In this patch the logic is changed to include the prefetch-dependency task whenever a non-blank the prefetch-input param is provided.

This makes it easier for users to enable the prefetch-dependencies task even if they're not ready for hermetic builds.

This also better supports the use case for hermetic builds that don't require depedencies to be prefetched, e.g. something with no dependencies or all dependencies vendored in to its own repo. In that scenario it's better not to run the prefetch-dependencies task at all.

Note that there is an impact for users who currently use hermetic builds without doing a prefetch. After this patch the prefetch task will be skipped entirely instead of running but doing nothing. The change in the task definition is related to that.

I didn't file a specific Jira for this, but it's tangentially related to [EC-585](https://issues.redhat.com/browse/EC-585).

This PR replaces an earlier version in #965.
