### PR TITLE
Fix recording of pushed bundles

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -92,6 +92,10 @@ spec:
                   value: "1"
                 - name: SKIP_INSTALL
                   value: "1"
+                - name: OUTPUT_TASK_BUNDLE_LIST
+                  value: $(workspaces.source.path)/task-bundle-list
+                - name: OUTPUT_PIPELINE_BUNDLE_LIST
+                  value: $(workspaces.source.path)/pipeline-bundle-list
               volumeMounts:
                 - mountPath: /root/.docker/config.json
                   subPath: .dockerconfigjson
@@ -145,8 +149,8 @@ spec:
                 #!/usr/bin/env bash
 
                 export BUNDLES=(
-                  $(workspaces.artifacts.path)/source/task-bundle-list
-                  $(workspaces.artifacts.path)/source/pipeline-bundle-list
+                  $(workspaces.artifacts.path)/task-bundle-list
+                  $(workspaces.artifacts.path)/pipeline-bundle-list
                 )
 
                 .tekton/scripts/build-acceptable-bundles.sh


### PR DESCRIPTION
The `hack/build-and-push.sh` script if `OUTPUT_TASK_BUNDLE_LIST` and `OUTPUT_PIPELINE_BUNDLE_LIST` variables are not defined default to generating the list of Task and Pipeline bundles pushed relative to `SCRIPTDIR` which is the base directory where `build-and-push.sh` script resides, i.e. `$(workspaces.source.path)/source/hack`. This is in contrast to what the `build-acceptable-bundles` Task expects, i.e. that files with the list of Task and Pipeline bundles pushed is in `$(workspaces.artifacts.path)/source/`.
This leads to missing new versions of the Tasks and Pipelines in the `quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles` image, and EC policy violations with code
`attestation_task_bundle.task_ref_bundles_trusted`, and error messages such as:

```
Pipeline task 'deprecated-base-image-check' uses an untrusted task bundle 'quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4@sha256:dd1b8b5b2652b24dc823aa83ebbf5e7ad52ade3cf6c7fa4993b8d0f9e0761189'
```

This changes the Pipeline to explicitly provide the paths to the list of Task and Pipeline bundles pushed via `OUTPUT_TASK_BUNDLE_LIST` and `OUTPUT_PIPELINE_BUNDLE_LIST` variables, and correspondingly adjusts to that path in the `build-acceptable-bundles` Task.
