### PR TITLE
Fix acceptable bundles build

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -142,19 +142,20 @@ spec:
                 value: "$(params.revision)"
               - name: GIT_URL
                 value: "$(params.git-url)"
+              - name: TASK_BUNDLE_LIST
+                value: $(workspaces.artifacts.path)/task-bundle-list
+              - name: PIPELINE_BUNDLE_LIST
+                value: $(workspaces.artifacts.path)/pipeline-bundle-list
               # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
               # the cluster will set imagePullPolicy to IfNotPresent
               # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
               script: |-
                 #!/usr/bin/env bash
+                set -o errexit
+                set -o nounset
+                set -o pipefail
 
-                export BUNDLES=(
-                  $(workspaces.artifacts.path)/task-bundle-list
-                  $(workspaces.artifacts.path)/pipeline-bundle-list
-                )
-
-                .tekton/scripts/build-acceptable-bundles.sh
-
+                .tekton/scripts/build-acceptable-bundles.sh "${TASK_BUNDLE_LIST}"  "${PIPELINE_BUNDLE_LIST}"
               volumeMounts:
                 - mountPath: /root/.docker/config.json
                   subPath: .dockerconfigjson

--- a/.tekton/scripts/build-acceptable-bundles.sh
+++ b/.tekton/scripts/build-acceptable-bundles.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # helps with debugging
 DATA_BUNDLE_REPO="${DATA_BUNDLE_REPO:-quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles}"
-BUNDLES=${BUNDLES:-()}
+mapfile -t BUNDLES < <(cat "$@")
 
 # store a list of changed task files
 task_records=()
 # loop over all changed files
-for path in $(git log -m -1 --name-only --pretty="format:" ${REVISION}); do
+for path in $(git log -m -1 --name-only --pretty="format:" "${REVISION}"); do
     # check that the file modified is the task file
     if [[ "${path}" == task/*/*/*.yaml ]]; then
         IFS='/' read -r -a path_array <<< "${path}"
@@ -22,12 +24,11 @@ for path in $(git log -m -1 --name-only --pretty="format:" ${REVISION}); do
     fi
 done
 
-echo "Tasks to be added"
-echo "${task_records[@]}"
+echo "Tasks to be added:"
+printf '%s\n' "${task_records[@]}"
 
-touch ${BUNDLES[@]}
 echo "Bundles to be added:"
-cat ${BUNDLES[@]}
+printf '%s\n' "${BUNDLES[@]}"
 
 # The OPA data bundle is tagged with the current timestamp. This has two main
 # advantages. First, it prevents the image from accidentally not having any tags,
@@ -37,11 +38,10 @@ TAG="$(date '+%s')"
 
 # task_records can be empty if a task wasn't changed
 TASK_PARAM=()
-if [ "${#task_records[@]}" -gt 0 ]; then
-    TASK_PARAM=($(printf "%s\n" "${task_records[@]}" | awk '{ print "--git=" $0 }'))
+if [ ${#task_records[@]} -gt 0 ]; then
+  mapfile -t -d ' ' TASK_PARAM < <(printf -- '--git=%s ' "${task_records[@]}")
 fi
-
-BUNDLES_PARAM=($(cat ${BUNDLES[@]} | awk '{ print "--bundle=" $0 }'))
+mapfile -t -d ' ' BUNDLES_PARAM < <(printf -- '--bundle=%s ' "${BUNDLES[@]}")
 
 PARAMS=("${TASK_PARAM[@]}" "${BUNDLES_PARAM[@]}")
 
@@ -51,7 +51,7 @@ ec track bundle --debug \
     --timeout "15m0s" \
     --freshen \
     --prune \
-    ${PARAMS[@]}
+    "${PARAMS[@]}"
 
 # To facilitate usage in some contexts, tag the image with the floating "latest" tag.
 skopeo copy "docker://${DATA_BUNDLE_REPO}:${TAG}" "docker://${DATA_BUNDLE_REPO}:latest"


### PR DESCRIPTION
Passing arrays via environment variables (i.e. using `export`) is not supported, this leads to the `BUNDLES` variable to be undefined in the `build-acceptable-bundles.sh` script.

This also adds error handling and prefers to use `mapfile` instead of `awk` to generate command line parameters.