### PR TITLE
Environment variables for `hack/build-and-push.sh`

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -142,9 +142,9 @@ spec:
                 value: "$(params.revision)"
               - name: GIT_URL
                 value: "$(params.git-url)"
-              - name: TASK_BUNDLE_LIST
+              - name: OUTPUT_TASK_BUNDLE_LIST
                 value: $(workspaces.artifacts.path)/task-bundle-list
-              - name: PIPELINE_BUNDLE_LIST
+              - name: OUTPUT_PIPELINE_BUNDLE_LIST
                 value: $(workspaces.artifacts.path)/pipeline-bundle-list
               # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
               # the cluster will set imagePullPolicy to IfNotPresent


### PR DESCRIPTION
The environment variables used in `hack/build-and-push.sh` start with `OUTPUT_`, this fixes the wrong variable names.
