### PR TITLE
Dummy change to get the new Task bundle built

### DIFF
--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -28,7 +28,6 @@ spec:
   results:
     - description: Tekton task test output.
       name: TEST_OUTPUT
-
   steps:
     - name: check-images
       image: quay.io/redhat-appstudio/hacbs-test:v1.4.0@sha256:54d49b37c9a2e280d42961a57e4f7a16c171d6b065559f1329b548db85300bea


### PR DESCRIPTION
We need this change to get in so the Task bundle for 0.4 gets built and the new bundle is tracked by `ec track bundle` to get the 0.4 version of the Task in acceptable bundles