### PR TITLE
Revert "Environment variables for `hack/build-and-push.sh`"

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -142,9 +142,9 @@ spec:
                 value: "$(params.revision)"
               - name: GIT_URL
                 value: "$(params.git-url)"
-              - name: OUTPUT_TASK_BUNDLE_LIST
+              - name: TASK_BUNDLE_LIST
                 value: $(workspaces.artifacts.path)/task-bundle-list
-              - name: OUTPUT_PIPELINE_BUNDLE_LIST
+              - name: PIPELINE_BUNDLE_LIST
                 value: $(workspaces.artifacts.path)/pipeline-bundle-list
               # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
               # the cluster will set imagePullPolicy to IfNotPresent


### PR DESCRIPTION
Reverts redhat-appstudio/build-definitions#978

The change was on the wrong Task, in fact the variables were originally typed correctly. It has been a long day.