### PR TITLE
Revert "Dummy change to get the new Task bundle built"

### DIFF
--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -28,6 +28,7 @@ spec:
   results:
     - description: Tekton task test output.
       name: TEST_OUTPUT
+
   steps:
     - name: check-images
       image: quay.io/redhat-appstudio/hacbs-test:v1.4.0@sha256:54d49b37c9a2e280d42961a57e4f7a16c171d6b065559f1329b548db85300bea


### PR DESCRIPTION
Reverts redhat-appstudio/build-definitions#980

We need the `hack/build-and-push.sh` script to pass the Task bundle OCI reference via the `task-bundle-list` file to the `build-acceptable-bundles`, and it will not do this unless a new tag is generated for the Task, for `deprecated-image-check` the git commit id of the file will be used as it is not built using Kustomize. So this forces this to happen.