### PR TITLE
Dummy change to the deprecated-image-check 0.4

### DIFF
--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:


### PR DESCRIPTION
This is to get the the rebuild of the Task bundle so that the acceptable bundles are updated with this and previous versions.