### PR TITLE
export the quay token to push bundles during e2e tests

### DIFF
--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -48,6 +48,11 @@ spec:
           secretKeyRef:
             name: github
             key: token
+      - name: QUAY_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: quay-push-secret
+            key: .dockerconfigjson
       - name: MY_GITHUB_ORG
         value: redhat-appstudio-appdata
       - name: EC_PIPELINES_REPO_URL


### PR DESCRIPTION
The tkn-bundle tests need to push a bundle to quay. This change export the token from a secret.

https://issues.redhat.com/browse/EC-624



