### PR TITLE
Add the new prefetch-dependencies-oci-ta Task

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.1/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.1/README.md
@@ -1,0 +1,19 @@
+# prefetch-dependencies task
+
+Task that uses Cachi2 to prefetch build dependencies.
+See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|input|Configures project packages that will have their dependencies prefetched.||true|
+|dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
+|log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|source|Workspace with the source code, cachi2 artifacts will be stored on the workspace as well|false|
+|git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|

--- a/task/prefetch-dependencies-oci-ta/0.1/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.1/README.md
@@ -1,19 +1,29 @@
-# prefetch-dependencies task
+# prefetch-dependencies-oci-ta task
 
-Task that uses Cachi2 to prefetch build dependencies.
-See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+application source code are stored as a trusted artifact in the provided OCI repository.
+For additional info on Cachi2, see docs at
+https://github.com/containerbuildsystem/cachi2#basic-usage.
 
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
 |input|Configures project packages that will have their dependencies prefetched.||true|
+|source-artifact|The trusted artifact URI containing the application source code.||true|
+|oci-storage|The OCI repository where the trusted artifacts with the modified cloned repository and the prefetched depedencies will be stored.||true|
+|oci-artifact-expires-after|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
 |dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
 |log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 
+## Results
+|name|description|
+|---|---|
+|source-artifact|The trusted artifact URI containing the modified application source.|
+|cachi2-artifact|The trusted artifact URI containing the fetched dependencies.|
+
 ## Workspaces
 |name|description|optional|
 |---|---|---|
-|source|Workspace with the source code, cachi2 artifacts will be stored on the workspace as well|false|
 |git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -6,14 +7,30 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "image-build, hacbs"
-  name: prefetch-dependencies
+  name: prefetch-dependencies-oci-ta
 spec:
   description: |-
-    Task that uses Cachi2 to prefetch build dependencies.
-    See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+    Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+    application source code are stored as a trusted artifact in the provided OCI repository.
+    For additional info on Cachi2, see docs at
+    https://github.com/containerbuildsystem/cachi2#basic-usage.
   params:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
+  - description: The trusted artifact URI containing the application source code.
+    name: source-artifact
+    type: string
+  - description: >-
+      The OCI repository where the trusted artifacts with the modified cloned repository and
+      the prefetched depedencies will be stored.
+    name: oci-storage
+    type: string
+  - description: >-
+      Expiration date for the trusted artifacts created in the OCI repository. An empty string means
+      the artifacts do not expire.
+    name: oci-artifact-expires-after
+    type: string
+    default: ""
   - description: >
       Enable in-development package managers. WARNING: the behavior may change at any time without
       notice. Use at your own risk.
@@ -30,11 +47,23 @@ spec:
     type: string
     description: The name of the key in the ConfigMap that contains the CA bundle data.
     default: ca-bundle.crt
+  results:
+    - description: The trusted artifact URI containing the modified application source.
+      name: source-artifact
+      type: string
+    - description: The trusted artifact URI containing the fetched dependencies.
+      name: cachi2-artifact
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
   steps:
+  - image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:4e39fb97f4444c2946944482df47b39c5bbc195c54c6560b0647635f553ab23d
+    name: use-trusted-artifact
+    args:
+      - use
+      - $(params.source-artifact)=/var/workdir/source
   - image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
     name: prefetch-dependencies
     env:
     - name: INPUT
@@ -72,7 +101,7 @@ spec:
           cp "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" "${HOME}/.gitconfig"
         # Compatibility with kubernetes.io/basic-auth secrets
         elif [ -f "${WORKSPACE_GIT_AUTH_PATH}/username" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/password" ]; then
-          HOSTNAME=$(cd "$(workspaces.source.path)/source" && git remote get-url origin | awk -F/ '{print $3}')
+          HOSTNAME=$(cd /var/workdir/source && git remote get-url origin | awk -F/ '{print $3}')
           echo "https://$(cat ${WORKSPACE_GIT_AUTH_PATH}/username):$(cat ${WORKSPACE_GIT_AUTH_PATH}/password)@$HOSTNAME" > "${HOME}/.git-credentials"
           echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${HOME}/.gitconfig"
         else
@@ -92,20 +121,29 @@ spec:
 
       cachi2 --log-level="$LOG_LEVEL" fetch-deps \
       $dev_pacman_flag \
-      --source=$(workspaces.source.path)/source \
-      --output=$(workspaces.source.path)/cachi2/output \
+      --source=/var/workdir/source \
+      --output=/var/workdir/cachi2/output \
       "${INPUT}"
 
-      cachi2 --log-level="$LOG_LEVEL" generate-env $(workspaces.source.path)/cachi2/output \
+      cachi2 --log-level="$LOG_LEVEL" generate-env /var/workdir/cachi2/output \
       --format env \
       --for-output-dir=/cachi2/output \
-      --output $(workspaces.source.path)/cachi2/cachi2.env
+      --output /var/workdir/cachi2/cachi2.env
 
-      cachi2 --log-level="$LOG_LEVEL" inject-files $(workspaces.source.path)/cachi2/output \
+      cachi2 --log-level="$LOG_LEVEL" inject-files /var/workdir/cachi2/output \
       --for-output-dir=/cachi2/output
+  - image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:4e39fb97f4444c2946944482df47b39c5bbc195c54c6560b0647635f553ab23d
+    name: create-trusted-artifact
+    env:
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.oci-artifact-expires-after)
+    args:
+      - create
+      - --store
+      - $(params.oci-storage)
+      - $(results.source-artifact.path)=/var/workdir/source
+      - $(results.cachi2-artifact.path)=/var/workdir/cachi2
   workspaces:
-  - name: source
-    description: Workspace with the source code, cachi2 artifacts will be stored on the workspace as well
   - name: git-basic-auth
     description: |
       A Workspace containing a .gitconfig and .git-credentials file or username and password.
@@ -114,6 +152,8 @@ spec:
       to bind a Secret to this Workspace over other volume types.
     optional: true
   volumes:
+    - name: workdir
+      emptyDir: {}
     - name: trusted-ca
       configMap:
         name: $(params.caTrustConfigMapName)

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -1,0 +1,123 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "image-build, hacbs"
+  name: prefetch-dependencies
+spec:
+  description: |-
+    Task that uses Cachi2 to prefetch build dependencies.
+    See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+  params:
+  - description: Configures project packages that will have their dependencies prefetched.
+    name: input
+  - description: >
+      Enable in-development package managers. WARNING: the behavior may change at any time without
+      notice. Use at your own risk.
+    name: dev-package-managers
+    default: "false"
+  - description: Set cachi2 log level (debug, info, warning, error)
+    name: log-level
+    default: "info"
+  - name: caTrustConfigMapName
+    type: string
+    description: The name of the ConfigMap to read CA bundle data from.
+    default: trusted-ca
+  - name: caTrustConfigMapKey
+    type: string
+    description: The name of the key in the ConfigMap that contains the CA bundle data.
+    default: ca-bundle.crt
+  steps:
+  - image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+    name: prefetch-dependencies
+    env:
+    - name: INPUT
+      value: $(params.input)
+    - name: DEV_PACKAGE_MANAGERS
+      value: $(params.dev-package-managers)
+    - name: LOG_LEVEL
+      value: $(params.log-level)
+    - name: WORKSPACE_GIT_AUTH_BOUND
+      value: $(workspaces.git-basic-auth.bound)
+    - name: WORKSPACE_GIT_AUTH_PATH
+      value: $(workspaces.git-basic-auth.path)
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+    script: |
+      if [ -z "${INPUT}" ]
+      then
+        # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
+        echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
+        exit 0
+      fi
+
+      if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
+        dev_pacman_flag=--dev-package-managers
+      else
+        dev_pacman_flag=""
+      fi
+
+      # Copied from https://github.com/redhat-appstudio/build-definitions/blob/main/task/git-clone/0.1/git-clone.yaml
+      if [ "${WORKSPACE_GIT_AUTH_BOUND}" = "true" ] ; then
+        if [ -f "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" ]; then
+          cp "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" "${HOME}/.git-credentials"
+          cp "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" "${HOME}/.gitconfig"
+        # Compatibility with kubernetes.io/basic-auth secrets
+        elif [ -f "${WORKSPACE_GIT_AUTH_PATH}/username" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/password" ]; then
+          HOSTNAME=$(cd "$(workspaces.source.path)/source" && git remote get-url origin | awk -F/ '{print $3}')
+          echo "https://$(cat ${WORKSPACE_GIT_AUTH_PATH}/username):$(cat ${WORKSPACE_GIT_AUTH_PATH}/password)@$HOSTNAME" > "${HOME}/.git-credentials"
+          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${HOME}/.gitconfig"
+        else
+          echo "Unknown git-basic-auth workspace format"
+          exit 1
+        fi
+        chmod 400 "${HOME}/.git-credentials"
+        chmod 400 "${HOME}/.gitconfig"
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cachi2 --log-level="$LOG_LEVEL" fetch-deps \
+      $dev_pacman_flag \
+      --source=$(workspaces.source.path)/source \
+      --output=$(workspaces.source.path)/cachi2/output \
+      "${INPUT}"
+
+      cachi2 --log-level="$LOG_LEVEL" generate-env $(workspaces.source.path)/cachi2/output \
+      --format env \
+      --for-output-dir=/cachi2/output \
+      --output $(workspaces.source.path)/cachi2/cachi2.env
+
+      cachi2 --log-level="$LOG_LEVEL" inject-files $(workspaces.source.path)/cachi2/output \
+      --for-output-dir=/cachi2/output
+  workspaces:
+  - name: source
+    description: Workspace with the source code, cachi2 artifacts will be stored on the workspace as well
+  - name: git-basic-auth
+    description: |
+      A Workspace containing a .gitconfig and .git-credentials file or username and password.
+      These will be copied to the user's home before any cachi2 commands are run. Any
+      other files in this Workspace are ignored. It is strongly recommended
+      to bind a Secret to this Workspace over other volume types.
+    optional: true
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true

--- a/task/prefetch-dependencies-oci-ta/OWNERS
+++ b/task/prefetch-dependencies-oci-ta/OWNERS
@@ -1,0 +1,1 @@
+Stonesoup Build Team


### PR DESCRIPTION
This pull request introduces a new Tekton Task, `prefetch-dependencies-oci-task`. This is a variation of the `0.1/prefetch-dependencies` Task. The main difference is that instead of using a workspace, this Task stores the modified application source and the fetched dependencies as Trusted Artifacts in an OCI registry.

The Task is not currently used in any of the default Pipelines. This will happen later on.

I tested this Task on a kind cluster by first taking the Trusted Artifact generated by `git-clone-oci-ta` (https://github.com/redhat-appstudio/build-definitions/pull/1005), then starting the `prefetch-dependencies-oci-ta` Task like this:

```
$ tkn -n default task start prefetch-dependencies-oci-ta --showlog     --param input=gomod     --param source-artifact=oci:quay.io/lucarval/ec-551@sha256:ba749adb9923fb1085c621fc757699c52acd2d40153e07402851aad5ea9d4f1b     --param oci-storage=quay.io/lucarval/ec-551:prefetch     --param image-expires-after=2h     --use-param-defaults     --skip-optional-workspace
TaskRun started: prefetch-dependencies-oci-ta-run-ssxdj
Waiting for logs to be available...
[use-trusted-artifact] Using token for quay.io
[use-trusted-artifact] Restored artifact quay.io/lucarval/ec-551@sha256:ba749adb9923fb1085c621fc757699c52acd2d40153e07402851aad5ea9d4f1b to /var/workdir/source
[use-trusted-artifact] 

[prefetch-dependencies] 2024-05-13 17:25:11,478 INFO Fetching the gomod dependencies at subpath .
[prefetch-dependencies] 2024-05-13 17:25:11,478 INFO Fetching the gomod dependencies at the "." directory
[prefetch-dependencies] 2024-05-13 17:25:11,516 INFO go.mod reported versions: '1.21.4'[go], '-'[toolchain]
[prefetch-dependencies] 2024-05-13 17:25:11,516 INFO Using Go release: go1.21.0
[prefetch-dependencies] 2024-05-13 17:25:11,517 INFO Downloading the gomod dependencies
	[prefetch-dependencies] 2024-05-13 17:26:26,763 INFO Retrieving the list of packages
[prefetch-dependencies] 2024-05-13 17:26:29,943 INFO All dependencies fetched successfully \o/

[create-trusted-artifact] gzip: warning: GZIP environment variable is deprecated; use an alias or script
[create-trusted-artifact] Prepared artifact from /var/workdir/source (sha256:450d6a50de35262296c79860dcc3369a25eec205a39ac4d6921c13763412f103)
[create-trusted-artifact] gzip: warning: GZIP environment variable is deprecated; use an alias or script
[create-trusted-artifact] Prepared artifact from /var/workdir/cachi2 (sha256:8a7e5b231ecf32a1b64297ef205725a6b72438590a466e7914cd1ea59edac747)
[create-trusted-artifact] Using token for quay.io
[create-trusted-artifact] Uploading 8a7e5b231ecf cachi2-artifact
[create-trusted-artifact] Uploading 450d6a50de35 source-artifact
[create-trusted-artifact] Uploaded  450d6a50de35 source-artifact
[create-trusted-artifact] Uploaded  8a7e5b231ecf cachi2-artifact
[create-trusted-artifact] Pushed [registry] quay.io/lucarval/ec-551:prefetch
[create-trusted-artifact] Digest: sha256:3e7c1507607a7a11f67806451eb441d2cfaa1b82c0c8a93527755925272fc158
[create-trusted-artifact] Artifacts created
[create-trusted-artifact] 

$ tkn -n default tr describe --last
Name:              prefetch-dependencies-oci-ta-run-ssxdj
Namespace:         default
Task Ref:          prefetch-dependencies-oci-ta
Service Account:   default
Timeout:           1h0m0s
Labels:
 app.kubernetes.io/managed-by=tekton-pipelines
 app.kubernetes.io/version=0.1
 tekton.dev/task=prefetch-dependencies-oci-ta
Annotations:
 chains.tekton.dev/signed=true
 pipeline.tekton.dev/release=34d8c0f
 tekton.dev/pipelines.minVersion=0.12.1
 tekton.dev/tags=image-build, hacbs

🌡️  Status

STARTED         DURATION    STATUS
7 minutes ago   5m0s        Succeeded

⚓ Params

 NAME                    VALUE
 ∙ image-expires-after   2h
 ∙ input                 gomod
 ∙ oci-storage           quay.io/lucarval/ec-551:prefetch
 ∙ source-artifact       oci:quay.io/lucarval/ec-551@sha256:ba749adb9923fb1085c621fc757699c52acd2d40153e07402851aad5ea9d4f1b

📝 Results

 NAME                VALUE
 ∙ cachi2-artifact   oci:quay.io/lucarval/ec-551@sha256:8a7e5b231ecf32a1b64297ef205725a6b72438590a466e7914cd1ea59edac747
 ∙ source-artifact   oci:quay.io/lucarval/ec-551@sha256:450d6a50de35262296c79860dcc3369a25eec205a39ac4d6921c13763412f103

🦶 Steps

 NAME                        STATUS
 ∙ use-trusted-artifact      Completed
 ∙ prefetch-dependencies     Completed
 ∙ create-trusted-artifact   Completed

$ oras blob fetch quay.io/lucarval/ec-551@sha256:450d6a50de35262296c79860dcc3369a25eec205a39ac4d6921c13763412f103 --output - | tar -zxvf -

$ oras blob fetch quay.io/lucarval/ec-551@sha256:8a7e5b231ecf32a1b64297ef205725a6b72438590a466e7914cd1ea59edac747 --output - | tar -zxvf -
```

Both artifacts contained the expected data.