### PR TITLE
Add the new sast-snyk-check-oci-ta Task

### DIFF
--- a/task/sast-snyk-check-oci-ta/0.1/README.md
+++ b/task/sast-snyk-check-oci-ta/0.1/README.md
@@ -1,0 +1,35 @@
+# sast-snyk-check task
+
+## Description:
+
+The sast-snyk-check task uses Snyk Code tool to perform Static Application Security Testing (SAST) for Snyk, a popular cloud-native application security platform.
+
+Snyk's SAST tool uses a combination of static analysis and machine learning techniques to scan an application's source code for potential security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks.
+
+> NOTE: This task is executed only if the user provides a Snyk token stored in a secret in their namespace. The name of the secret then needs to be supplied in the `snyk-secret` pipeline parameter.
+
+## Params:
+
+| name        | description                               |
+|-------------|-------------------------------------------|
+| SNYK_SECRET | Name of secret which contains Snyk token. |
+| ARGS        | Append arguments.                         |
+
+## How to obtain a snyk-token and enable snyk task on the pipeline:
+
+Follow the steps given [here](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/testing_applications/enable_snyk_check_for_a_product/)
+
+## Results:
+
+| name                  | description              |
+|-----------------------|--------------------------|
+| TEST_OUTPUT     | Tekton task test output. |
+
+## Source repository for image:
+
+https://github.com/konflux-ci/konflux-test
+
+## Additional links:
+
+* https://snyk.io/product/snyk-code/
+* https://snyk.io/

--- a/task/sast-snyk-check-oci-ta/0.1/README.md
+++ b/task/sast-snyk-check-oci-ta/0.1/README.md
@@ -1,35 +1,22 @@
-# sast-snyk-check task
+# sast-snyk-check-oci-ta task
 
-## Description:
+Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application Security Testing (SAST) tool.
 
-The sast-snyk-check task uses Snyk Code tool to perform Static Application Security Testing (SAST) for Snyk, a popular cloud-native application security platform.
+Follow the steps given [here](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/testing_applications/enable_snyk_check_for_a_product/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
 
-Snyk's SAST tool uses a combination of static analysis and machine learning techniques to scan an application's source code for potential security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks.
+The snyk binary used in this Task comes from a container image defined in https://github.com/konflux-ci/konflux-test
 
-> NOTE: This task is executed only if the user provides a Snyk token stored in a secret in their namespace. The name of the secret then needs to be supplied in the `snyk-secret` pipeline parameter.
+See https://snyk.io/product/snyk-code/ and https://snyk.io/ for more information about the snyk tool.
 
-## Params:
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|SOURCE_ARTIFACT|The trusted artifact URI containing the application source code.||true|
+|SNYK_SECRET|Name of secret which contains Snyk token.|snyk-secret|false|
+|ARGS|Append arguments.|--all-projects --exclude=test*,vendor,deps|false|
 
-| name        | description                               |
-|-------------|-------------------------------------------|
-| SNYK_SECRET | Name of secret which contains Snyk token. |
-| ARGS        | Append arguments.                         |
+## Results
+|name|description|
+|---|---|
+|TEST_OUTPUT|Tekton task test output.|
 
-## How to obtain a snyk-token and enable snyk task on the pipeline:
-
-Follow the steps given [here](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/testing_applications/enable_snyk_check_for_a_product/)
-
-## Results:
-
-| name                  | description              |
-|-----------------------|--------------------------|
-| TEST_OUTPUT     | Tekton task test output. |
-
-## Source repository for image:
-
-https://github.com/konflux-ci/konflux-test
-
-## Additional links:
-
-* https://snyk.io/product/snyk-code/
-* https://snyk.io/

--- a/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
@@ -1,0 +1,89 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio, hacbs"
+  name: sast-snyk-check
+spec:
+  description: >-
+    Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application Security Testing (SAST) tool.
+  results:
+    - description: Tekton task test output.
+      name: TEST_OUTPUT
+  params:
+    - name: SNYK_SECRET
+      description: Name of secret which contains Snyk token.
+      default: snyk-secret
+    - name: ARGS
+      type: string
+      description: Append arguments.
+      default: "--all-projects --exclude=test*,vendor,deps"
+  volumes:
+    - name: snyk-secret
+      secret:
+        secretName: $(params.SNYK_SECRET)
+        optional: true
+  steps:
+    - name: sast-snyk-check
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.0@sha256:54d49b37c9a2e280d42961a57e4f7a16c171d6b065559f1329b548db85300bea
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      volumeMounts:
+        - name: snyk-secret
+          mountPath: "/etc/secrets"
+          readOnly: true
+      env:
+        - name: SNYK_SECRET
+          value: $(params.SNYK_SECRET)
+        - name: ARGS
+          value: $(params.ARGS)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        SNYK_TOKEN_PATH="/etc/secrets/snyk_token"
+
+        if [ -f "${SNYK_TOKEN_PATH}" ] && [ -s "${SNYK_TOKEN_PATH}" ]; then
+          # SNYK token is provided
+          SNYK_TOKEN="$(cat ${SNYK_TOKEN_PATH})"
+          export SNYK_TOKEN
+        else
+          to_enable_snyk='[here](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/testing_applications/enable_snyk_check_for_a_product/)'
+          note="Task $(context.task.name) skipped: If you wish to use the Snyk code SAST task, please create a secret name snyk-secret with the key "snyk_token" containing the Snyk token by following the steps given ${to_enable_snyk}"
+          TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        SNYK_EXIT_CODE=0
+        SOURCE_CODE_DIR=$(workspaces.workspace.path)/source
+        snyk code test $ARGS $SOURCE_CODE_DIR --sarif-file-output=sast_snyk_check_out.json 1>&2>> stdout.txt || SNYK_EXIT_CODE=$?
+        test_not_skipped=0
+        SKIP_MSG="We found 0 supported files"
+        grep -q "$SKIP_MSG" stdout.txt || test_not_skipped=$?
+
+        if [[ "$SNYK_EXIT_CODE" -eq 0 ]] || [[ "$SNYK_EXIT_CODE" -eq 1 ]]; then
+          cat sast_snyk_check_out.json
+          TEST_OUTPUT=
+          parse_test_output $(context.task.name) sarif sast_snyk_check_out.json  || true
+
+        # When the test is skipped, the "SNYK_EXIT_CODE" is 3 and it can also be 3 in some other situation
+        elif [[ "$test_not_skipped" -eq 0 ]]; then
+          note="Task $(context.task.name) success: Snyk code test found zero supported files."
+          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        else
+          echo "sast-snyk-check test failed because of the following issues:"
+          cat stdout.txt
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        fi
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
+  workspaces:
+  - name: workspace

--- a/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -6,14 +7,32 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "appstudio, hacbs"
-  name: sast-snyk-check
+  name: sast-snyk-check-oci-ta
 spec:
   description: >-
-    Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application Security Testing (SAST) tool.
+    Scans source code for security vulnerabilities, including common issues such as SQL injection,
+    cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application
+    Security Testing (SAST) tool.
+
+
+    Follow the steps given
+    [here](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/testing_applications/enable_snyk_check_for_a_product/)
+    to obtain a snyk-token and to enable the snyk task in a Pipeline.
+
+
+    The snyk binary used in this Task comes from a container image defined in
+    https://github.com/konflux-ci/konflux-test
+
+
+    See https://snyk.io/product/snyk-code/ and https://snyk.io/ for more information about the snyk
+    tool.
   results:
     - description: Tekton task test output.
       name: TEST_OUTPUT
   params:
+    - name: SOURCE_ARTIFACT
+      type: string
+      description: The trusted artifact URI containing the application source code.
     - name: SNYK_SECRET
       description: Name of secret which contains Snyk token.
       default: snyk-secret
@@ -26,13 +45,21 @@ spec:
       secret:
         secretName: $(params.SNYK_SECRET)
         optional: true
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
   steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:4e39fb97f4444c2946944482df47b39c5bbc195c54c6560b0647635f553ab23d
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: sast-snyk-check
       image: quay.io/redhat-appstudio/konflux-test:v1.4.0@sha256:54d49b37c9a2e280d42961a57e4f7a16c171d6b065559f1329b548db85300bea
-      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-      # the cluster will set imagePullPolicy to IfNotPresent
-      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
-      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      workingDir: /var/workdir/source
       volumeMounts:
         - name: snyk-secret
           mountPath: "/etc/secrets"
@@ -63,7 +90,7 @@ spec:
         fi
 
         SNYK_EXIT_CODE=0
-        SOURCE_CODE_DIR=$(workspaces.workspace.path)/source
+        SOURCE_CODE_DIR=/var/workdir/source
         snyk code test $ARGS $SOURCE_CODE_DIR --sarif-file-output=sast_snyk_check_out.json 1>&2>> stdout.txt || SNYK_EXIT_CODE=$?
         test_not_skipped=0
         SKIP_MSG="We found 0 supported files"
@@ -85,5 +112,3 @@ spec:
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
-  workspaces:
-  - name: workspace

--- a/task/sast-snyk-check-oci-ta/OWNERS
+++ b/task/sast-snyk-check-oci-ta/OWNERS
@@ -1,0 +1,1 @@
+Stonesoup Test Team


### PR DESCRIPTION
This pull request introduces a new Tekton Task, `sast-snyk-check-oci-ta`. This is a variation of the `0.1/sast-snyk-check` Task. The main different is that instead of expecting the application source code to come from a workspace, this Task consumes the source code as a Trusted Artifact from an OCI registry.

The Task is not currently used in any of the default Pipelines. This will happen later on.

I tested this Task on a kind cluster like this:

```
# First created a secret with the Snyk token and linked it to my account, then:
🐚 oc -n default apply -f task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml

🐚 tkn -n default task start sast-snyk-check-oci-ta --showlog \
    --param SOURCE_ARTIFACT=oci:quay.io/lucarval/ec-551@sha256:450d6a50de35262296c79860dcc3369a25eec205a39ac4d6921c13763412f103 \
    --use-param-defaults
TaskRun started: sast-snyk-check-oci-ta-run-fsb7w
Waiting for logs to be available...
[use-trusted-artifact] Using token for quay.io
[use-trusted-artifact] Restored artifact quay.io/lucarval/ec-551@sha256:450d6a50de35262296c79860dcc3369a25eec205a39ac4d6921c13763412f103 to /var/workdir/source
[use-trusted-artifact] 

[sast-snyk-check] {
[sast-snyk-check]   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
[sast-snyk-check]   "version": "2.1.0",
[sast-snyk-check]   "runs": [
[sast-snyk-check]     {
[sast-snyk-check]       "tool": {
[sast-snyk-check]         "driver": {
[sast-snyk-check]           "name": "SnykCode",
[sast-snyk-check]           "semanticVersion": "1.0.0",
[sast-snyk-check]           "version": "1.0.0",
[sast-snyk-check]           "rules": []
[sast-snyk-check]         }
[sast-snyk-check]       },
[sast-snyk-check]       "results": [],
[sast-snyk-check]       "properties": {
[sast-snyk-check]         "coverage": [
[sast-snyk-check]           {
[sast-snyk-check]             "isSupported": true,
[sast-snyk-check]             "lang": "Go",
[sast-snyk-check]             "files": 173,
[sast-snyk-check]             "type": "SUPPORTED"
[sast-snyk-check]           }
[sast-snyk-check]         ]
[sast-snyk-check]       }
[sast-snyk-check]     }
[sast-snyk-check]   ]
[sast-snyk-check] }
[sast-snyk-check] {"result":"SUCCESS","timestamp":"1715719388","note":"For details, check Tekton task log.","namespace":"default","successes":0,"failures":0,"warnings":0}
```

Resolves [EC-553](https://issues.redhat.com/browse/EC-553)