### PR TITLE
Add the new source-build-oci-ta Task

### DIFF
--- a/task/source-build-oci-ta/0.1/README.md
+++ b/task/source-build-oci-ta/0.1/README.md
@@ -1,4 +1,4 @@
-# source-build task
+# source-build-oci-ta task
 
 Source image build.
 
@@ -7,6 +7,8 @@ Source image build.
 |---|---|---|---|
 |BINARY_IMAGE|Binary image name from which to generate the source image name.||true|
 |BASE_IMAGES|Base images used to build the binary image. Each image per line in the same order of FROM instructions specified in a multistage Dockerfile. Default to an empty string, which means to skip handling a base image.|""|false|
+|SOURCE_ARTIFACT|The trusted artifact URI containing the application source code.||true|
+|CACHI2_ARTIFACT|The trusted artifact URI containing the prefetched dependencies.|""|false|
 
 ## Results
 |name|description|
@@ -15,7 +17,3 @@ Source image build.
 |SOURCE_IMAGE_URL|The source image url.|
 |SOURCE_IMAGE_DIGEST|The source image digest.|
 
-## Workspaces
-|name|description|optional|
-|---|---|---|
-|workspace|The workspace where source code is included.|false|

--- a/task/source-build-oci-ta/0.1/README.md
+++ b/task/source-build-oci-ta/0.1/README.md
@@ -1,0 +1,21 @@
+# source-build task
+
+Source image build.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|BINARY_IMAGE|Binary image name from which to generate the source image name.||true|
+|BASE_IMAGES|Base images used to build the binary image. Each image per line in the same order of FROM instructions specified in a multistage Dockerfile. Default to an empty string, which means to skip handling a base image.|""|false|
+
+## Results
+|name|description|
+|---|---|
+|BUILD_RESULT|Build result.|
+|SOURCE_IMAGE_URL|The source image url.|
+|SOURCE_IMAGE_DIGEST|The source image digest.|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|workspace|The workspace where source code is included.|false|

--- a/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: source-build
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio"
+spec:
+  description: Source image build.
+  params:
+    - name: BINARY_IMAGE
+      description: Binary image name from which to generate the source image name.
+      type: string
+    - name: BASE_IMAGES
+      description: >-
+        Base images used to build the binary image. Each image per line in the same order of FROM
+        instructions specified in a multistage Dockerfile. Default to an empty string, which means
+        to skip handling a base image.
+      type: string
+      default: ""
+  results:
+    - name: BUILD_RESULT
+      description: Build result.
+    - name: SOURCE_IMAGE_URL
+      description: The source image url.
+    - name: SOURCE_IMAGE_DIGEST
+      description: The source image digest.
+  workspaces:
+    - name: workspace
+      description: The workspace where source code is included.
+  volumes:
+    - name: source-build-work-place
+      emptyDir: {}
+  steps:
+    - name: build
+      image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils@sha256:cd87bbe51f1c22ff7578f5c9caf19db4f9ee7aefd0307288383b9bd478cdf856
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 512Mi
+          cpu: 250m
+      workingDir: "/var/source-build"
+      securityContext:
+        runAsUser: 0
+        capabilities:
+          add:
+            - SETFCAP
+      volumeMounts:
+        - name: source-build-work-place
+          mountPath: /var/source-build
+      env:
+        - name: BINARY_IMAGE
+          value: "$(params.BINARY_IMAGE)"
+        - name: SOURCE_DIR
+          value: "$(workspaces.workspace.path)/source"
+        - name: BASE_IMAGES
+          value: "$(params.BASE_IMAGES)"
+        - name: RESULT_FILE
+          value: "$(results.BUILD_RESULT.path)"
+        - name: CACHI2_ARTIFACTS_DIR
+          value: "$(workspaces.workspace.path)/cachi2"
+        - name: RESULT_SOURCE_IMAGE_URL
+          value: "$(results.SOURCE_IMAGE_URL.path)"
+        - name: RESULT_SOURCE_IMAGE_DIGEST
+          value: "$(results.SOURCE_IMAGE_DIGEST.path)"
+        - name: WS_BUILD_RESULT_FILE
+          value: "$(workspaces.workspace.path)/source_build_result.json"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        app_dir=/opt/source_build
+        registry_allowlist="
+        registry.access.redhat.com
+        registry.redhat.io
+        "
+
+        ## This is needed for the builds performed by the rpm-ostree task
+        ## otherwise, we can see this error:
+        ## "fatal: detected dubious ownership in repository at '/workspace/workspace/source'"
+        ##
+        git config --global --add safe.directory $SOURCE_DIR
+
+        ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \
+          --output-binary-image "$BINARY_IMAGE" \
+          --workspace /var/source-build \
+          --source-dir "$SOURCE_DIR" \
+          --base-images "$BASE_IMAGES" \
+          --write-result-to "$RESULT_FILE" \
+          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
+          --registry-allowlist="$registry_allowlist"
+
+        cat "$RESULT_FILE" | jq -r ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
+        cat "$RESULT_FILE" | jq -r ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"
+
+        cp "$RESULT_FILE" "$WS_BUILD_RESULT_FILE"

--- a/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: source-build
+  name: source-build-oci-ta
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
@@ -21,6 +21,14 @@ spec:
         to skip handling a base image.
       type: string
       default: ""
+    - name: SOURCE_ARTIFACT
+      description: The trusted artifact URI containing the application source code.
+      type: string
+    - name: CACHI2_ARTIFACT
+      description: The trusted artifact URI containing the prefetched dependencies.
+      type: string
+      default: ""
+
   results:
     - name: BUILD_RESULT
       description: Build result.
@@ -28,18 +36,22 @@ spec:
       description: The source image url.
     - name: SOURCE_IMAGE_DIGEST
       description: The source image digest.
-  workspaces:
-    - name: workspace
-      description: The workspace where source code is included.
   volumes:
     - name: source-build-work-place
       emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - name: source-build-work-place
+        mountPath: /var/source-build
   steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:4e39fb97f4444c2946944482df47b39c5bbc195c54c6560b0647635f553ab23d
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/source-build/source
+        - $(params.CACHI2_ARTIFACT)=/var/source-build/cachi2
     - name: build
       image: quay.io/redhat-appstudio/build-definitions-source-image-build-utils@sha256:cd87bbe51f1c22ff7578f5c9caf19db4f9ee7aefd0307288383b9bd478cdf856
-      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-      # the cluster will set imagePullPolicy to IfNotPresent
-      # also per direction from Ralph Bean, we want to use image digest based tags to use a cue to automation like dependabot or renovatebot to periodially submit pull requests that update the digest as new images are released.
       computeResources:
         limits:
           memory: 2Gi
@@ -52,26 +64,23 @@ spec:
         capabilities:
           add:
             - SETFCAP
-      volumeMounts:
-        - name: source-build-work-place
-          mountPath: /var/source-build
       env:
         - name: BINARY_IMAGE
           value: "$(params.BINARY_IMAGE)"
         - name: SOURCE_DIR
-          value: "$(workspaces.workspace.path)/source"
+          value: "/var/source-build/source"
         - name: BASE_IMAGES
           value: "$(params.BASE_IMAGES)"
         - name: RESULT_FILE
           value: "$(results.BUILD_RESULT.path)"
         - name: CACHI2_ARTIFACTS_DIR
-          value: "$(workspaces.workspace.path)/cachi2"
+          value: "/var/source-build/cachi2"
         - name: RESULT_SOURCE_IMAGE_URL
           value: "$(results.SOURCE_IMAGE_URL.path)"
         - name: RESULT_SOURCE_IMAGE_DIGEST
           value: "$(results.SOURCE_IMAGE_DIGEST.path)"
         - name: WS_BUILD_RESULT_FILE
-          value: "$(workspaces.workspace.path)/source_build_result.json"
+          value: "/var/source-build/source_build_result.json"
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -84,7 +93,7 @@ spec:
 
         ## This is needed for the builds performed by the rpm-ostree task
         ## otherwise, we can see this error:
-        ## "fatal: detected dubious ownership in repository at '/workspace/workspace/source'"
+        ## "fatal: detected dubious ownership in repository at '/var/source-build/source'"
         ##
         git config --global --add safe.directory $SOURCE_DIR
 

--- a/task/source-build-oci-ta/OWNERS
+++ b/task/source-build-oci-ta/OWNERS
@@ -1,0 +1,1 @@
+Stonesoup Build Team


### PR DESCRIPTION
This pull request introduces a new Tekton Task, `source-build-oci-ta`. This is a variation of the `0.1/source-build` Task. The main difference is that instead of expecting the application source code and the prefetched dependencies to come from a workspace, this Task consumes those as Trusted Artifacts from an OCI registry.

The Task is not currently used in any of the default Pipelines. This will happen later on.

I tested this Task on a kind cluster like this:

```
$ oc apply -f task/source-build-oci-ta/0.1/source-build-oci-ta.yaml

$ tkn -n default task start source-build-oci-ta --showlog \
    --param BINARY_IMAGE=quay.io/lucarval/ec-551:buildah \
    --param BASE_IMAGES='docker.io/library/golang:1.21@sha256:b58705289f65009af963d7704eee0473270a3a61a4c5b6e1379d9434cf9cb9cf 
registry.access.redhat.com/ubi9/ubi-minimal:<none>@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3
registry.access.redhat.com/ubi9/ubi-minimal:<none>@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3' \
    --param SOURCE_ARTIFACT=oci:quay.io/lucarval/ec-551@sha256:450d6a50de35262296c79860dcc3369a25eec205a39ac4d6921c13763412f103 \
    --param CACHI2_ARTIFACT=oci:quay.io/lucarval/ec-551@sha256:8a7e5b231ecf32a1b64297ef205725a6b72438590a466e7914cd1ea59edac747 \
    --use-param-defaults
TaskRun started: source-build-oci-ta-run-6jx44

$ tkn -n default tr describe --last
Name:              source-build-oci-ta-run-6jx44
Namespace:         default
Task Ref:          source-build-oci-ta
Service Account:   default
Timeout:           1h0m0s
Labels:
 app.kubernetes.io/managed-by=tekton-pipelines
 app.kubernetes.io/version=0.1
 tekton.dev/task=source-build-oci-ta
Annotations:
 chains.tekton.dev/signed=true
 pipeline.tekton.dev/release=34d8c0f
 tekton.dev/pipelines.minVersion=0.12.1
 tekton.dev/tags=appstudio

🌡️  Status

STARTED          DURATION    STATUS
22 minutes ago   18m23s      Succeeded

⚓ Params

 NAME            VALUE
 ∙ BASE_IMAGES   docker.io/library/golang:1.21@sha256:b58705289f65009af963d7704eee0473270a3a61a4c5b6e1379d9434cf9cb9cf
registry.access.redhat.com/ubi9/ubi-minimal:<none>@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3
registry.access.redhat.com/ubi9/ubi-minimal:<none>@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3
 ∙ BINARY_IMAGE      quay.io/lucarval/ec-551:buildah
 ∙ CACHI2_ARTIFACT   oci:quay.io/lucarval/ec-551@sha256:8a7e5b231ecf32a1b64297ef205725a6b72438590a466e7914cd1ea59edac747
 ∙ SOURCE_ARTIFACT   oci:quay.io/lucarval/ec-551@sha256:450d6a50de35262296c79860dcc3369a25eec205a39ac4d6921c13763412f103

📝 Results

 NAME                    VALUE
 ∙ BUILD_RESULT          {"status": "success", "dependencies_included": true, "base_image_source_included": true, "image_url": "quay.io/lucarval/ec-551:sha256-75edcbf0120af29154a720b95128eed3b815ae96b77099e98eb4436ae1579df4.src", "image_digest": "sha256:2983a70cff298e4564987e73cd102e86aebfb48dcf33dd44d92ada6f43ce8a65"}
 ∙ SOURCE_IMAGE_DIGEST   sha256:2983a70cff298e4564987e73cd102e86aebfb48dcf33dd44d92ada6f43ce8a65
 ∙ SOURCE_IMAGE_URL      quay.io/lucarval/ec-551:sha256-75edcbf0120af29154a720b95128eed3b815ae96b77099e98eb4436ae1579df4.src

🦶 Steps

 NAME                     STATUS
 ∙ use-trusted-artifact   Completed
 ∙ build                  Completed

```