### PR TITLE
buildah*: add BUILD_ARGS param

### DIFF
--- a/hack/generate-readme.sh
+++ b/hack/generate-readme.sh
@@ -9,7 +9,16 @@ echo "# $(yq '.metadata.name' $TASK) task"
 echo
 yq '.spec.description' $TASK
 echo
-PARAMS=$(yq '.spec.params.[] | ("|" + .name + "|" + (.description // "" | sub("\n", " ")) + "|" + (.default // (.default != "*" | "")) + "|" + (.default != "*") + "|")' $TASK)
+PARAMS=$(yq '
+    .spec.params.[] |
+    with(select(.default | type == "!!seq"); .default = (.default | tojson(0))) |
+    (
+        "|" + .name +
+        "|" + (.description // "" | sub("\n", " ")) +
+        "|" + (.default // (.default != "*" | "")) +
+        "|" + (.default != "*") + "|"
+    )' $TASK
+)
 if [ -n "$PARAMS" ]; then
   echo "## Parameters"
   echo "|name|description|default value|required|"

--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -31,8 +31,15 @@
 - op: add
   path: /spec/params/-
   value:
+    name: build-args
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    type: array
+    default: []
+- op: add
+  path: /spec/params/-
+  value:
     name: build-args-file
-    description: Path to a file with build arguments which will be passed to podman during build
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     type: string
     default: ""
 - op: add
@@ -58,6 +65,9 @@
       value: "$(params.image-expires-after)"
     - name: COMMIT_SHA
       value: "$(tasks.clone-repository.results.commit)"
+    - name: BUILD_ARGS
+      value:
+        - $(params.build-args[*])
     - name: BUILD_ARGS_FILE
       value: "$(params.build-args-file)"
 # Remove tasks

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -2,7 +2,8 @@
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args-file| Path to a file with build arguments which will be passed to podman during build| | build-container:0.1:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.1:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.1:BUILD_ARGS_FILE|
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
@@ -16,11 +17,17 @@
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
 ## Available params from tasks
+### apply-tags:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### buildah:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |BUILDER_IMAGE| Deprecated. Has no effect. Will be removed in the future.| | |
-|BUILD_ARGS_FILE| Path to a file with build arguments which will be passed to podman during build| | '$(params.build-args-file)'|
+|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
+|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |COMMIT_SHA| The image is built from this commit.| | '$(tasks.clone-repository.results.commit)'|
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
@@ -137,7 +144,7 @@
 |---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of the base images used for build| build-source-image:0.1:BASE_IMAGES ; deprecated-base-image-check:0.4:BASE_IMAGES_DIGESTS|
 |IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.1:image-digest ; clamav-scan:0.1:image-digest ; sbom-json-check:0.1:IMAGE_DIGEST|
-|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; clamav-scan:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL|
+|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; clamav-scan:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL ; apply-tags:0.1:IMAGE|
 |JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
 |SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
 ### clair-scan:0.1 task results

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -16,8 +16,15 @@
 - op: add
   path: /spec/params/-
   value:
+    name: build-args
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    type: array
+    default: []
+- op: add
+  path: /spec/params/-
+  value:
     name: build-args-file
-    description: Path to a file with build arguments which will be passed to podman during build
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     type: string
     default: ""
 - op: add
@@ -37,6 +44,9 @@
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+  - name: BUILD_ARGS
+    value:
+      - $(params.build-args[*])
   - name: BUILD_ARGS_FILE
     value: "$(params.build-args-file)"
 - op: add

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -15,11 +15,17 @@
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
 ## Available params from tasks
+### apply-tags:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### buildah:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |BUILDER_IMAGE| Deprecated. Has no effect. Will be removed in the future.| | |
-|BUILD_ARGS_FILE| Path to a file with build arguments which will be passed to podman during build| | |
+|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| |
+|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | |
 |COMMIT_SHA| The image is built from this commit.| | '$(tasks.clone-repository.results.commit)'|
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
@@ -113,7 +119,7 @@
 |---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of the base images used for build| deprecated-base-image-check:0.4:BASE_IMAGES_DIGESTS|
 |IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; sbom-json-check:0.1:IMAGE_DIGEST ; inspect-image:0.1:IMAGE_DIGEST ; fbc-validate:0.1:IMAGE_DIGEST|
-|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; sbom-json-check:0.1:IMAGE_URL ; inspect-image:0.1:IMAGE_URL ; fbc-validate:0.1:IMAGE_URL|
+|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; sbom-json-check:0.1:IMAGE_URL ; apply-tags:0.1:IMAGE ; inspect-image:0.1:IMAGE_URL ; fbc-validate:0.1:IMAGE_URL|
 |JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
 |SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
 ### deprecated-image-check:0.4 task results

--- a/pipelines/java-builder/README.md
+++ b/pipelines/java-builder/README.md
@@ -15,6 +15,11 @@
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
 ## Available params from tasks
+### apply-tags:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -156,7 +161,7 @@
 |---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of the base images used for build| build-source-image:0.1:BASE_IMAGES ; deprecated-base-image-check:0.4:BASE_IMAGES_DIGESTS|
 |IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.1:image-digest ; clamav-scan:0.1:image-digest ; sbom-json-check:0.1:IMAGE_DIGEST|
-|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; clamav-scan:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL|
+|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; clamav-scan:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL ; apply-tags:0.1:IMAGE|
 |JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
 |SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
 ### sast-snyk-check:0.1 task results

--- a/pipelines/nodejs-builder/README.md
+++ b/pipelines/nodejs-builder/README.md
@@ -15,6 +15,11 @@
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
 ## Available params from tasks
+### apply-tags:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -156,7 +161,7 @@
 |---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of the base images used for build| build-source-image:0.1:BASE_IMAGES ; deprecated-base-image-check:0.4:BASE_IMAGES_DIGESTS|
 |IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.1:image-digest ; clamav-scan:0.1:image-digest ; sbom-json-check:0.1:IMAGE_DIGEST|
-|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; clamav-scan:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL|
+|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; clamav-scan:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL ; apply-tags:0.1:IMAGE|
 ### sast-snyk-check:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -15,6 +15,11 @@
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
 ## Available params from tasks
+### apply-tags:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -126,7 +131,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_DIGEST| Digest of the image just built| clair-scan:0.1:image-digest ; sbom-json-check:0.1:IMAGE_DIGEST|
-|IMAGE_URL| Image repository where the built image was pushed with tag only| clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL|
+|IMAGE_URL| Image repository where the built image was pushed with tag only| clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL ; apply-tags:0.1:IMAGE|
 
 ## Workspaces
 |name|description|optional|used in tasks

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -24,7 +24,8 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
-|BUILD_ARGS_FILE|Path to a file with build arguments which will be passed to podman during build|""|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
+|BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
 
 ## Results
 |name|description|

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -75,8 +75,12 @@ spec:
     description: Name of secret which contains the entitlement certificates
     type: string
     default: "etc-pki-entitlement"
+  - name: BUILD_ARGS
+    description: Array of --build-arg values ("arg=value" strings)
+    type: array
+    default: []
   - name: BUILD_ARGS_FILE
-    description: Path to a file with build arguments which will be passed to podman during build
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
     type: string
     default: ""
 
@@ -143,6 +147,8 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
+    args:
+      - $(params.BUILD_ARGS[*])
     script: |
       SOURCE_CODE_DIR=source
       if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
@@ -201,6 +207,10 @@ spec:
         BUILDAH_ARGS+=("--build-arg-file=${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}")
       fi
 
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
       if [ -d "/var/workdir/cachi2" ]; then
         cp -r "/var/workdir/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -246,8 +256,8 @@ spec:
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah build \
         $VOLUME_MOUNTS \
-        ${BUILDAH_ARGS[@]} \
-        ${LABELS[@]} \
+        "${BUILDAH_ARGS[@]}" \
+        "${LABELS[@]}" \
         --tls-verify=$TLSVERIFY --no-cache \
         --ulimit nofile=4096:4096 \
         -f "$dockerfile_path" -t $IMAGE $SOURCE_CODE_DIR/$CONTEXT

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -78,9 +78,12 @@ spec:
     description: Name of secret which contains the entitlement certificates
     name: ENTITLEMENT_SECRET
     type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
   - default: ""
-    description: Path to a file with build arguments which will be passed to podman
-      during build
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: BUILD_ARGS_FILE
     type: string
   - description: The platform to build on
@@ -135,7 +138,9 @@ spec:
     - name: BUILDER_IMAGE
       value: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
   steps:
-  - computeResources:
+  - args:
+    - $(params.BUILD_ARGS[*])
+    computeResources:
       limits:
         memory: 4Gi
       requests:
@@ -243,6 +248,10 @@ spec:
         BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
       fi
 
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
       if [ -d "$(workspaces.source.path)/cachi2" ]; then
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -288,8 +297,8 @@ spec:
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
         $VOLUME_MOUNTS \
-        ${BUILDAH_ARGS[@]} \
-        ${LABELS[@]} \
+        "${BUILDAH_ARGS[@]}" \
+        "${LABELS[@]}" \
         --tls-verify=$TLSVERIFY --no-cache \
         --ulimit nofile=4096:4096 \
         -f "$dockerfile_path" -t $IMAGE .

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -28,8 +28,12 @@ spec:
     description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
     name: TLSVERIFY
     type: string
+  - name: BUILD_ARGS
+    description: Array of --build-arg values ("arg=value" strings)
+    type: array
+    default: []
   - name: BUILD_ARGS_FILE
-    description: Path to a file with build arguments which will be passed to podman during build
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
     type: string
     default: ""
   results:
@@ -58,6 +62,8 @@ spec:
   steps:
   - name: build
     image: registry.access.redhat.com/ubi9/buildah@sha256:3b11aae36f6c762e01731952ee6fb8e89c41660ce410e4c30d0bfc6496bca93c
+    args:
+      - $(params.BUILD_ARGS[*])
     script: |
       # Check if the Dockerfile exists
       SOURCE_CODE_DIR=source
@@ -75,9 +81,13 @@ spec:
         BUILDAH_ARGS+=("--build-arg-file=${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}")
       fi
 
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
       # Build the image
       buildah build \
-        ${BUILDAH_ARGS[@]} \
+        "${BUILDAH_ARGS[@]}" \
         --tls-verify=$TLSVERIFY \
         --ulimit nofile=4096:4096 \
         -f "$dockerfile_path" -t $IMAGE $SOURCE_CODE_DIR/$CONTEXT

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -9,7 +9,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |name|description|default value|required|
 |---|---|---|---|
 |IMAGE|Reference of the image buildah will produce.||true|
-|BUILDER_IMAGE|The location of the buildah builder image.|registry.access.redhat.com/ubi9/buildah:9.0.0-19@sha256:c8b1d312815452964885680fc5bc8d99b3bfe9b6961228c71a09c72ca8e915eb|false|
+|BUILDER_IMAGE|Deprecated. Has no effect. Will be removed in the future.|""|false|
 |DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
 |CONTEXT|Path to the directory to use as context.|.|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
@@ -17,10 +17,14 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
 |YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
-|ENTITLEMENT_SECRET|Name of the entitlement secret in the namespace. If present, it enables subscription in the build|etc-pki-entitlement|false|
+|TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
+|ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
+|BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -71,8 +71,12 @@ spec:
     description: Name of secret which contains the entitlement certificates
     type: string
     default: "etc-pki-entitlement"
+  - name: BUILD_ARGS
+    description: Array of --build-arg values ("arg=value" strings)
+    type: array
+    default: []
   - name: BUILD_ARGS_FILE
-    description: Path to a file with build arguments which will be passed to podman during build
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
     type: string
     default: ""
 
@@ -133,6 +137,8 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
+    args:
+      - $(params.BUILD_ARGS[*])
     script: |
       if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
         echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
@@ -195,6 +201,10 @@ spec:
         BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
       fi
 
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
       if [ -d "$(workspaces.source.path)/cachi2" ]; then
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -240,8 +250,8 @@ spec:
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
         $VOLUME_MOUNTS \
-        ${BUILDAH_ARGS[@]} \
-        ${LABELS[@]} \
+        "${BUILDAH_ARGS[@]}" \
+        "${LABELS[@]}" \
         --tls-verify=$TLSVERIFY --no-cache \
         --ulimit nofile=4096:4096 \
         -f "$dockerfile_path" -t $IMAGE .


### PR DESCRIPTION
[STONEBLD-2462](https://issues.redhat.com//browse/STONEBLD-2462)

Add a BUILD_ARGS array parameter to allow users to pass build args
directly, not just via BUILD_ARGS_FILE.

This provides greater flexibility. Those who just need static build args
can commit a file into their repo and use BUILD_ARGS_FILE. Those who
need dynamic values can create a custom task and incorporate its return
value into the BUILD_ARGS array.

---

Also:
* generate-readme: handle array param defaults
* buildah: re-generate README